### PR TITLE
Recharge condition box appears if the power use type is "recharge"

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -559,6 +559,7 @@
 "DND4EBETA.PowerBaseDamage": "Base Damage",
 "DND4EBETA.PowerDaily": "Daily",
 "DND4EBETA.PowerRecharge": "Recharge",
+"DND4EBETA.PowerRechargeCondition": "Recharge On",
 "DND4EBETA.PowerDetails": "Power Details",
 "DND4EBETA.PowerEnc": "Encounter",
 "DND4EBETA.PowerPrepared": "Prepared",

--- a/module/item/sheet.js
+++ b/module/item/sheet.js
@@ -66,7 +66,9 @@ export default class ItemSheet4e extends ItemSheet {
 			itemData.data.isRange = true;
 			if(itemData.data.rangeType === "closeBurst" || itemData.data.rangeType === "closeBlast" || itemData.data.rangeType === "rangeBurst" || data.data.rangeType === "rangeBlast" || data.data.rangeType === "wall" ) 
 			itemData.data.isArea = true;
+			itemData.data.isRecharge = itemData.data.useType === "recharge";
 		}
+
 
 		// Weapon Properties
 		if(itemData.type === "weapon"){

--- a/templates/items/parts/item-power-template.html
+++ b/templates/items/parts/item-power-template.html
@@ -52,6 +52,14 @@
 			{{/select}}
 		</select>
 	</div>
+	{{#if data.isRecharge}}
+	<div class="form-group">
+		<label>{{ localize "DND4EBETA.PowerRechargeCondition" }}</label>
+		<div class="form-fields">
+			<input type="text" name="data.rechargeRoll" value="{{data.rechargeRoll}}"/>
+		</div>
+	</div>
+	{{/if}}
 
 	{{!-- Action Type --}}
 	<div class="form-group select">


### PR DESCRIPTION
Adds a text box for the rechargeRoll template property letting you specify the condition for a power to recharge.  

Note should be text not a number as while dice roll range is the most common other conditions exist "when first bloodied" is quite common