### PR TITLE
Fix for #75

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -213,7 +213,6 @@ export class Actor4e extends Actor {
 		}
 		
 		data.details.tier = Math.clamped(Math.floor(( data.details.level - 1 ) /10 + 1),1,3);
-		this.update({[`data.details.tier`]: data.details.tier });
 
 		//Weight & Encumbrance
 		data.encumbrance = this._computeEncumbrance(actorData);


### PR DESCRIPTION
prepareData was calling the actors db update method for Tier, which triggered an infinite update loop - there is clearly an internal hook on the DB update method that re-creates the actor objects and reruns prepareData when it detects the underlying DB state has changed.