### PR TITLE
Fixed socket namespace

### DIFF
--- a/module/item/sheet.js
+++ b/module/item/sheet.js
@@ -128,7 +128,7 @@ export default class ItemSheet4e extends ItemSheet {
 	}
 
 	shareItem() {
-		game.socket.emit("system.dnd4eBeta", {
+		game.socket.emit("system.dnd4e", {
 			itemId: this.item._id
 		});
 	}
@@ -726,7 +726,7 @@ function executeMacro(item)
 }
 
 Hooks.once('ready', async function () {
-	game.socket.on("system.dnd4eBeta", (msg) => {
+	game.socket.on("system.dnd4e", (msg) => {
 		ItemSheet4e._handleShareItem(msg);
 	});
 })


### PR DESCRIPTION
The socket listener / sender had not been updated to the new namespace so messages for sharing items with players were not being sent and the "show players" button did nothing.  