### PR TITLE
Fixed NPE when opening damage options

### DIFF
--- a/templates/chat/roll-dialog.html
+++ b/templates/chat/roll-dialog.html
@@ -149,24 +149,25 @@ function toggleMultibonus() {
 function showTab(n) {
 	let x = document.getElementsByClassName("multitarget-tab");
 	let numTargets = x.length;
+	if (document.getElementById("multibonus-toggle")) {
+		if (numTargets <= 1) {
+			multiTargetToggleString = "Universal Attack Bonuses"
+			document.getElementById("multibonus-toggle").disabled = true;
+		}
 
-	if (numTargets <= 1) {
-		multiTargetToggleString = "Universal Attack Bonuses"
-		document.getElementById("multibonus-toggle").disabled = true;
-	}
+		document.getElementById("multibonus-toggle").innerHTML = multiTargetToggleString;
 
-	document.getElementById("multibonus-toggle").innerHTML = multiTargetToggleString;
-
-	x[n].style.display = "block";
-	if (n <= 0){
-		document.getElementById("prevBtn").disabled = true;
-	} else {
-		document.getElementById("prevBtn").disabled = false;
-	}
-	if (n >= x.length - 1 || multiTargetToggle == 0){
-		document.getElementById("nextBtn").disabled = true;
-	} else {
-		document.getElementById("nextBtn").disabled = false;
+		x[n].style.display = "block";
+		if (n <= 0){
+			document.getElementById("prevBtn").disabled = true;
+		} else {
+			document.getElementById("prevBtn").disabled = false;
+		}
+		if (n >= x.length - 1 || multiTargetToggle == 0){
+			document.getElementById("nextBtn").disabled = true;
+		} else {
+			document.getElementById("nextBtn").disabled = false;
+		}
 	}
 }
 


### PR DESCRIPTION
Surrounded Multibonus-toggle logic in an if such that it doesn't run on non-attack roll dialogs.

Note: I have not being able to test this fix as upgrading to foundry v9 and then downgrading to v8 has completely broken my foundry isntall :(

Test instructions:
When clicking a button to roll damage before: receive a NPE exception in the console from the openTab method.  
When clicking after merge: No NPE's rolls and buttons still work.  Option and arrow still appear and work on the attack dialog.  
