### PR TITLE
Rolls allowed without weapon if weaponUse is set to None even if weaponType is not None

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -493,6 +493,7 @@
 "DND4EBETA.JackOfAllTrades": "Jack of all Trades",
 "DND4EBETA.Keywords": "Keywords",
 "DND4EBETA.Ki": "Ki",
+"DND4EBETA.LackRequiredWeapon": "You may not use this power as you do not have the proper weapon equipped.",
 "DND4EBETA.LairAct": "Uses Lair Action",
 "DND4EBETA.Languages": "Languages",
 "DND4EBETA.LaunchOrderBoth": "Both Pre & Post Item",

--- a/module/helper.js
+++ b/module/helper.js
@@ -388,7 +388,7 @@ export class Helper {
 				}
 				
 				// Handle Weapon Type Damage
-				if(diceType.includes("weapon")){
+				if(diceType.includes("weapon") && weaponData){
 					let parts = weaponData.damageDice.parts;
 						for(let i = 0; i< parts.length; i++) {
 							if(!parts[i][0] || !parts[i][1]) continue;

--- a/module/helper.js
+++ b/module/helper.js
@@ -22,6 +22,13 @@ export class Helper {
 		return o;
 	}
 
+	/**
+	 * Find A suitable weapon to use with the power.
+	 * Either the specified weapon, or a weapon that matches the itemData.weaponType category if itemData.weaponUse is set to default
+	 * @param itemData The Power being used
+	 * @param actor The actor that owns the power
+	 * @returns {null|*} The weapon details or null if either no suitable weapon is found or itemData.weaponUse is set to none.
+	 */
 	static getWeaponUse(itemData, actor) {
 		if(itemData.weaponUse === "none" || (itemData.weaponType === "none" && actor.itemTypes.weapon.length == 0)) return null;
 		let weaponUse = itemData.weaponUse? actor.items.get(itemData.weaponUse) : null;
@@ -82,6 +89,18 @@ export class Helper {
 			}, {});
 		}
 		return weaponUse;
+	}
+
+	/**
+	 * Returns true if we should error out because the power needs a weapon equipped and the character doesn't have one
+	 * @param itemData The data object of the Power being used
+	 * @param weaponUse The details of the weapon being used for the power from Helper.getWeaponUse
+	 * @returns {boolean} True if the character lacks a suitable weapon to use the power
+	 */
+	static lacksRequiredWeaponEquipped(itemData, weaponUse) {
+		// a power needs a weapon equipped to roll attack if a weapon type has been specified that is not None or Implement And weaponUse is not none.
+		const powerNeedsAWeapon = itemData.weaponType && itemData.weaponType !== "none" && itemData.weaponType !== "implement" && itemData.weaponUse !== "none"
+		return !weaponUse && powerNeedsAWeapon
 	}
 	
 	static commonReplace (formula, actorData, powerData, weaponData=null, depth = 1, stringOnly = false) {

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -742,15 +742,17 @@ export default class Item4e extends Item {
 	 */
 	async rollAttack(options={}) {
 		const itemData = this.data.data;
-		const actorData = this.actor.data.data;	
+		const actorData = this.actor.data.data;
+		// itemData.weaponUse = 2nd dropdown - default/none/weapon
+		// itemData.weaponType = first dropdown: melee/ranged/implement/none etc...
+		// find details on the weapon being used, if any.   This is null if no weapon is being used.
 		const weaponUse = Helper.getWeaponUse(itemData, this.actor);
 
-		if(!weaponUse && !(itemData.weaponType === "none" || itemData.weaponType === "implement" || itemData.weaponType === undefined)) {
-			ui.notifications.error("You may not use this power as you do not have the proper weapon equipped.");
+		if(Helper.lacksRequiredWeaponEquipped(itemData, weaponUse)) {
+			ui.notifications.error(game.i18n.localize("DND4EBETA.LackRequiredWeapon"));
 			return null;
 		}
 
-		const flags = this.actor.data.flags.dnd4eBeta || {};
 		if(!this.hasAttack ) {
 			ui.notifications.error("You may not place an Attack Roll with this Item.");
 			return null;
@@ -875,8 +877,8 @@ export default class Item4e extends Item {
 		const actorData = this.actor.data.data;
 		const weaponUse = Helper.getWeaponUse(itemData, this.actor);
 
-		if(!weaponUse && !(itemData.weaponType === "none" || itemData.weaponType === "implement" || itemData.weaponType === undefined)) {
-			ui.notifications.error("You may not use this power as you do not have the proper weapon equipped.");
+		if(Helper.lacksRequiredWeaponEquipped(itemData, weaponUse)) {
+			ui.notifications.error(game.i18n.localize("DND4EBETA.LackRequiredWeapon"));
 			return null;
 		}
 
@@ -1033,8 +1035,8 @@ export default class Item4e extends Item {
 		const actorData = this.actor.data.data;
 		const weaponUse = Helper.getWeaponUse(itemData, this.actor);
 
-		if(!weaponUse && !(itemData.weaponType === "none" || itemData.weaponType === "implement" || itemData.weaponType === undefined)) {
-			ui.notifications.error("You may not use this power as you do not have the proper weapon equipped.");
+		if(Helper.lacksRequiredWeaponEquipped(itemData, weaponUse)) {
+			ui.notifications.error(game.i18n.localize("DND4EBETA.LackRequiredWeapon"));
 			return null;
 		}
 


### PR DESCRIPTION
Change for #110 

This is a change to allow Weapon attack rolls (with weapon type set) even if the character does not have a weapon equipped if weaponUse has been set to None, which I think was the original intention of the code block.  

As the logic to trigger the error is used in 3 places (attack, damage, healing) I refactored it into a method in Helpers. 

The only actual change to the logic is that I have changed 
`!weaponUse && !(itemData.weaponType === "none" || itemData.weaponType === "implement" || itemData.weaponType === undefined`

to be

`itemData.weaponUse !== "none" && !weaponUse && !(itemData.weaponType === "none" || itemData.weaponType === "implement" || itemData.weaponType === undefined`

by putting the leading `itemData.weaponUse !== "none"` we bail from the check if the weaponUse dialog has been explicitly set to None.  

The other change on the method was to make it easier to read - I flipped to using `x != a && y != b` instead of `!(x == a || y == b)` as I find that is easier to tell what it is trying to do.  

(also removed the flags variable from roll calculation as it was not used anywhere)