### PR TITLE
Update to effect variables

### DIFF
--- a/module/apps/heal-menu-dialog.js
+++ b/module/apps/heal-menu-dialog.js
@@ -31,7 +31,7 @@ export class HealMenuDialog extends FormApplication {
 
 		console.log(JSON.stringify(formData))
 
-		let roll = await Helper.roll(formData.bonus, "DND4EBETA.InvalidHealingBonus")
+		let roll = await Helper.rollWithErrorHandling(formData.bonus, { errorMessageKey: "DND4EBETA.InvalidHealingBonus"})
 
 		let surgeValueText = "0"
 		let surgeValue = 0

--- a/module/apps/second-wind.js
+++ b/module/apps/second-wind.js
@@ -24,7 +24,7 @@ export class SecondWindDialog extends DocumentSheet {
 	}
 	async _updateObject(event, formData) {
 		
-		let r = await Helper.roll(formData.bonus, "DND4EBETA.InvalidHealingBonus")
+		let r = await Helper.rollWithErrorHandling(formData.bonus, { errorMessageKey: "DND4EBETA.InvalidHealingBonus"})
 
 		const updateData = {};
 		if(this.object.data.data.attributes.hp.value <= 0) {

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -796,7 +796,7 @@ export default class Item4e extends Item {
 			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponUse.data.data.consume, "weapon used by the power")
 		}
 
-		Helper.applyEffects([parts], rollData, actorData, this.data, weaponUse?.data, "attack")
+		await Helper.applyEffects([parts], rollData, actorData, this.data, weaponUse?.data, "attack")
 
 		// Compose roll options
 		const rollConfig = {
@@ -849,7 +849,7 @@ export default class Item4e extends Item {
 	 *
 	 * @return {Promise<Roll>}   A Promise which resolves to the created Roll instance
 	 */
-	rollDamage({event, spellLevel=null, versatile=false}={}) {
+	async rollDamage({event, spellLevel=null, versatile=false}={}) {
 		const itemData = this.data.data;
 		const actorData = this.actor.data;
 		const actorInnerData = this.actor.data.data;
@@ -1059,7 +1059,7 @@ export default class Item4e extends Item {
 		partsCritExpressionReplacement.unshift({target : partsCrit[0], value: critDamageFormulaExpression})
 		partsMissExpressionReplacement.unshift({target : partsMiss[0], value: missDamageFormulaExpression})
 
-		Helper.applyEffects([parts, partsCrit, partsMiss], rollData, actorData, this.data, weaponUse?.data, "damage")
+		await Helper.applyEffects([parts, partsCrit, partsMiss], rollData, actorData, this.data, weaponUse?.data, "damage")
 
 		return damageRoll({
 			event,


### PR DESCRIPTION
custom variables and attack/damage effects can now use @variables - the standard set that are used in attacks / damages.

By quirk this also allows for attack/damage effects to use custom variables.

attack/damage effects have to evaluate a non numerical expression to compute if its larger or not, but custom variables can just use the appended string method that @EndlesNights factored in.

Moved the custom variable substitution to last and did a pre check to see if there were any @variables left to improve performance - there is no need to iterate the effects on a character if there are no variables left to substitute.