### PR TITLE
Figured out why Item macros kept getting massive numbers of indents.

### DIFF
--- a/templates/items/backpack.html
+++ b/templates/items/backpack.html
@@ -77,6 +77,7 @@
 		</div>
 
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/classFeats.html
+++ b/templates/items/classFeats.html
@@ -101,6 +101,7 @@
 			{{> "systems/dnd4e/templates/actors/parts/active-effects.html"}}
 		</div>
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/consumable.html
+++ b/templates/items/consumable.html
@@ -278,6 +278,7 @@
 			{{> "systems/dnd4e/templates/actors/parts/active-effects.html"}}
 		</div>
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/destinyFeats.html
+++ b/templates/items/destinyFeats.html
@@ -50,6 +50,7 @@
 		</div>
 		
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/equipment.html
+++ b/templates/items/equipment.html
@@ -251,6 +251,7 @@
 			{{> "systems/dnd4e/templates/actors/parts/active-effects.html"}}
 		</div>
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/feat.html
+++ b/templates/items/feat.html
@@ -50,6 +50,7 @@
 		</div>
 		
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/loot.html
+++ b/templates/items/loot.html
@@ -42,6 +42,7 @@
 			{{> "systems/dnd4e/templates/actors/parts/active-effects.html"}}
 		</div>
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/pathFeats.html
+++ b/templates/items/pathFeats.html
@@ -48,8 +48,9 @@
 		<div class="tab effects flexcol" data-group="primary" data-tab="effects">
 			{{> "systems/dnd4e/templates/actors/parts/active-effects.html"}}
 		</div>
-		
+
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/power.html
+++ b/templates/items/power.html
@@ -42,6 +42,7 @@
 		{{> "systems/dnd4e/templates/items/parts/item-power-template.html"}}
 
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/raceFeats.html
+++ b/templates/items/raceFeats.html
@@ -47,6 +47,7 @@
 		</div>
 		
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/ritual.html
+++ b/templates/items/ritual.html
@@ -126,6 +126,7 @@
 		</div>
 
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/tool.html
+++ b/templates/items/tool.html
@@ -80,6 +80,7 @@
 		</div>
 		
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>

--- a/templates/items/weapon.html
+++ b/templates/items/weapon.html
@@ -447,6 +447,7 @@
 		</div>
 
 		{{!-- Macros Tab --}}
-		{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
+<!-- DO NOT INDENT ME:  All of my indentation will be transferred to the macro text every time it is opened, causing each line of the macro to get steadily more tabs in front of it and march across the screen -->
+{{> "systems/dnd4e/templates/items/parts/item-macro.html"}}
 	</section>
 </form>


### PR DESCRIPTION
It was picking up the indentation of the link used to insert the Macro Tab into the html.

The first line didn't pick it up, because the first line was immiedately following the opening <TextArea> tag.  However, I am guessing because of some interaction between how things inserted by the templater behave, all subsequent lines, which are subsequent lines in the html (as textarea uses its value as the contents) picked up the indentation of the template invoker.

Have de-indentented and left a comment on all the places that reference the macro template.