### PR TITLE
Weapons that have never been implements have no implement groupings, …

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -254,9 +254,11 @@ export class Helper {
 	}
 
 	static _addKeywords(suitableKeywords, keywordsActive) {
-		for (const [key, value] of Object.entries(keywordsActive)) {
-			if (value === true) {
-				suitableKeywords.push(key)
+		if (keywordsActive) {
+			for (const [key, value] of Object.entries(keywordsActive)) {
+				if (value === true) {
+					suitableKeywords.push(key)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
…causing a null pointer exception in _addKeywords.

Added the null check in the helper in case any other keyword methods are added later