### PR TITLE
Removed the default miss formula

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -557,6 +557,7 @@
 "DND4EBETA.Melee": "Melee",
 "DND4EBETA.Miss": "Miss",
 "DND4EBETA.MissDetailsText": "Miss Details",
+"DND4EBETA.MissFormulaPlaceholder": "Half damage can easily be applied form the damage menu, no need for a separate formula",
 "DND4EBETA.Modifier": "Modifier",
 "DND4EBETA.ModifierAttack": "Attack Modifier",
 "DND4EBETA.ModifierDamage": "Damage Modifier",

--- a/template.json
+++ b/template.json
@@ -745,8 +745,8 @@
 				"healFormula": ""
 			},
 			"miss": {
-				"detail": "Half Damage.",
-				"formula": "@damageFormula/2"
+				"detail": "",
+				"formula": ""
 			},
 			"effect": {
 				"detail": ""

--- a/templates/items/parts/item-power-template.html
+++ b/templates/items/parts/item-power-template.html
@@ -324,7 +324,7 @@
 
 	<div class="form-group stacked">
 		<label>Miss Damage {{ localize "DND4EBETA.Formula" }}</label>
-		<input type="text" name="data.miss.formula" value="{{data.miss.formula}}"/>
+		<input type="text" name="data.miss.formula" value="{{data.miss.formula}}" placeholder="{{ localize "DND4EBETA.MissFormulaPlaceholder" }}"/>
 	</div>
 
 	<div class="form-group stacked weapon-properties">


### PR DESCRIPTION
Also miss effect description, since it meant that by default all powers had half damage miss effect that you had to remember to remove.

Added a placeholder to the miss formula to let the user know it's not needed for half-damage (the most common)