### PR TITLE
Added Hooks for Token Action HUD

### DIFF
--- a/module/dnd4eBeta.js
+++ b/module/dnd4eBeta.js
@@ -16,7 +16,6 @@ import { _getInitiativeFormula } from "./combat.js";
 
 import ActorSheet4e from "./actor/actor-sheet.js";
 import ActorSheet4eNPC from "./actor/npc-sheet.js";
-import {SaveThrowDialog} from "./apps/save-throw.js";
 import { preloadHandlebarsTemplates } from "./templates.js";
 
 // Import Entities
@@ -30,6 +29,7 @@ import * as macros from "./macros.js";
 import * as migrations from "./migration.js";
 import {MultiAttackRoll} from "./roll/multi-attack-roll.js";
 import {RollWithOriginalExpression} from "./roll/roll-with-expression.js";
+import {TokenBarHooks} from "./hooks.js";
 
 /* -------------------------------------------- */
 /*  Foundry VTT Initialization                  */
@@ -99,7 +99,9 @@ Hooks.once("init", async function() {
 	preloadHandlebarsTemplates();
 
 	// setup methods that allow for easy integration with token hud
-	game.dnd4eBeta.quickSave = (actor) => new SaveThrowDialog(actor)._updateObject(null, {save : 0, dc: 10})
+	game.dnd4eBeta.tokenBarHooks = TokenBarHooks
+	//legacy, remove after some time when its reasonable for people to have updated token bar
+	game.dnd4eBeta.quickSave = (actor) => game.dnd4eBeta.tokenBarHooks.quickSave(actor, null)
 });
 
 Hooks.once("setup", function() {

--- a/module/hooks.js
+++ b/module/hooks.js
@@ -1,0 +1,32 @@
+import {SaveThrowDialog} from "./apps/save-throw.js";
+
+/**
+ * These methods are all called by https://github.com/Drental/fvtt-tokenactionhud, their method signature should not be changed without a code change there.
+ */
+export const TokenBarHooks = {}
+
+TokenBarHooks.generatePowerGroups = (actor) => actor.sheet._generatePowerGroups()
+
+TokenBarHooks.updatePowerAvailable = (actor, power) =>  actor.sheet._checkPowerAvailable(power.data)
+
+TokenBarHooks.isPowerAvailable = (actor, power) => {
+    actor.sheet._checkPowerAvailable(power.data)
+    return !power.data.data.notAvailable
+}
+
+TokenBarHooks.quickSave = (actor, event) => new SaveThrowDialog(actor)._updateObject(event, {save : 0, dc: 10})
+
+TokenBarHooks.saveDialog = (actor, event) =>  actor.sheet._onSavingThrow(event)
+
+TokenBarHooks.healDialog = (actor, event) =>  actor.sheet._onHealMenuDialog(event)
+
+TokenBarHooks.rechargePower = (actor, power, event) => actor.sheet._onItemRecharge(event)
+
+TokenBarHooks.rollPower = (actor, power, event) => actor.usePower(power)
+
+TokenBarHooks.rollSkill = (actor, checkId, event) => actor.rollSkill(checkId, { event: event });
+
+TokenBarHooks.rollAbility = (actor, checkId, event) => actor.rollAbility(checkId, { event: event });
+
+TokenBarHooks.rollItem = (actor, item, event) => item.roll()
+


### PR DESCRIPTION
When adding equipment to token action HUD integration I was reminded that in order to get it working I had to poke some quite internal and knarly methods in 4E.

Basically things that we would change, that would then break token hud, and we would have no idea why or even that we had broken it.

So I refactored them all into the hooks.js object, which gives Token HUD a single place for when it needs to call any method on one of our objects.  Especially as a lot of them the logic is actually in the sheet.  This means they will at least show up in a usages search in VSCode/Webstorm etc... so we know if we change them to also update the calling method.

Method signatures were made to be as standardised as possible with all relevant information, so hopefully if we ever change an implementation there is no need to change api.