### PR TITLE
Formula term highlight rollback + minor fixes.

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -586,7 +586,7 @@ export class Helper {
 				}
 				// Handle Dice Type Damage
 				else{
-					let diceValue = diceType.match(/\d+/g).join('');
+					let diceValue = diceType.match(/\d+/g)?.join('');
 					dice += `${quantity} * ${diceValue}`;
 				}
 				dice = this.commonReplace(dice, actorData, powerInnerData, weaponInnerData, depth-1)

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -1094,6 +1094,22 @@ export default class Item4e extends Item {
 			options.formulaInnerData.actorBonusDamage = actorBonus.damage
 		}
 
+
+		// Originally these were a separate part, but then they were not part of the primary damage type
+		// which they should be.  So now appending them to the main expression.
+		const effectDamageParts = []
+		await Helper.applyEffects([effectDamageParts], rollData, actorData, this.data, weaponUse?.data, "damage")
+		effectDamageParts.forEach(part => {
+			const value = rollData[part.substring(1)]
+			damageFormula += `+ ${value}`
+			missDamageFormula += `+ ${value}`
+			critDamageFormula += `+ ${value}`
+			damageFormulaExpression  += `+ ${part}`
+			missDamageFormulaExpression += `+ ${part}`
+			critDamageFormulaExpression += `+ ${part}`
+			options.formulaInnerData[part.substring(1)] = value
+		})
+
 		// Ammunition Damage from power
 		if ( this._ammo ) {
 			parts.push("@ammo");
@@ -1147,7 +1163,7 @@ export default class Item4e extends Item {
 		partsCritExpressionReplacement.unshift({target : partsCrit[0], value: critDamageFormulaExpression})
 		partsMissExpressionReplacement.unshift({target : partsMiss[0], value: missDamageFormulaExpression})
 
-		await Helper.applyEffects([parts, partsCrit, partsMiss], rollData, actorData, this.data, weaponUse?.data, "damage")
+
 
 		return damageRoll({
 			event,

--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -165,7 +165,7 @@ export class RollWithOriginalExpression extends Roll {
 
    getChatData(isPrivate = false) {
        if (!isPrivate && game.settings.get("dnd4e", "showRollExpression")) {
-           return this.surroundFormulaWithExpressionSpanTags(this.options.originalFormula ? this.options.originalFormula : this._formula, this.options.expressionArr)
+           return this.surroundFormulaWithExpressionSpanTags(this._formula, this.options.expressionArr)
        }
        else {
            return {


### PR DESCRIPTION
attempts to fix Foundry's occasional editing of formula made things look gash with variables in the output, so I've reverted that.

It works most of the time, but occasionally Foundry will change the formula by adding or removing a space.  Note for Me for future: It was Rise, Criticals with the greataxe.  The axe critical bonus formula "(@enhance)d6 + @wepDice(@tier)"  for some reason when foundry parses it, it spits back out "(@enhance)d6 +@wepDice(@tier)" (though with the numbers obviously)

Given its much more edgecasey I am leaving it (and all that happens is the highlighting won't get individual terms).   have 2 solutions in the pipe: 1. let the highlighter fail in a more granular way, 2 enforce spacing around operators, but that could be perilous.

 Other changes:
 Moved the effect bonuses for damage to be part of the main expression so they get the damage type of the primary damage type, as they were breaking resistance calculations otherwise.  Note this is still a problem (and always has been) with bonus damage.  I think there is a bug or 2 in the damage type / resistances calculator, but that is for another time.

 Minor change to replacer to handle nulls:  If you had selected "None" as weapon but damage type as "base weapon damage" and still had @wepDamage in the formla (a possible combination given defaults (invalid, but possible)) the helper with crash with an NPE.  This way you get an output (that looks awful, so you go and fix it)