### PR TITLE
Fix that PHB damage calc was checking diagonal movement setting

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1062,7 +1062,7 @@ export class Actor4e extends Actor {
 		if(game.settings.get("dnd4e", "damageCalcRules") === "errata"){
 			this.calcDamageErrata(damage, multiplier,surges);
 		}
-		else if(game.settings.get("dnd4e", "diagonalMovement") === "phb"){
+		else {
 			this.calcDamagePHB(damage, multiplier, surges);
 		}
 	}


### PR DESCRIPTION
Just made it an else to guarentee that some damage would happen even if there is no option (should never happen, but felt a fall through was a safer case)