### PR TITLE
[Bugfix] Targeting when attack.def = ''

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -203,7 +203,7 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 		}
 		if (isAttackRoll && targets.length > rollExpressionIdx) {
 			let targName = targets[rollExpressionIdx].data.name;
-			let targDefVal = targets[rollExpressionIdx].document._actor.data.data.defences[options.attackedDef].value;
+			let targDefVal = targets[rollExpressionIdx].document._actor.data.data.defences[options.attackedDef]?.value;
 			targetData.targNameArray.push(targName);
 			targetData.targDefValArray.push(targDefVal);
 			targetData.targets.push(targets[rollExpressionIdx]);

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -802,7 +802,9 @@ export default class Item4e extends Item {
 		let title = `${this.name} - ${game.i18n.localize("DND4EBETA.AttackRoll")}`;
 		let flavor = title;
 
-		flavor += ` ${game.i18n.localize("DND4EBETA.VS")} <b>${itemData.attack.def.toUpperCase() }</b>`;
+		if(itemData.attack.def) {
+			flavor += ` ${game.i18n.localize("DND4EBETA.VS")} <b>${itemData.attack.def.toUpperCase() }</b>`;
+		}
 
 		if(game.user.targets.size) {
 			options.attackedDef = itemData.attack.def; 

--- a/module/roll/multi-attack-roll.js
+++ b/module/roll/multi-attack-roll.js
@@ -72,7 +72,7 @@ export class MultiAttackRoll extends Roll {
 
             let hitState = "";
 
-            if(game.settings.get("dnd4e", "automationCombat")){
+	     if(game.settings.get("dnd4e", "automationCombat") && targDefVal !== undefined) {
                 if (critState === " critical"){
                     hitState = game.i18n.localize("DND4EBETA.AttackRollHitCrit");
                     targDataArray.targetHit.push(targDataArray.targets[i]);

--- a/module/roll/multi-attack-roll.js
+++ b/module/roll/multi-attack-roll.js
@@ -72,7 +72,7 @@ export class MultiAttackRoll extends Roll {
 
             let hitState = "";
 
-	     if(game.settings.get("dnd4e", "automationCombat") && targDefVal !== undefined) {
+	    if(game.settings.get("dnd4e", "automationCombat") && targDefVal !== undefined) {
                 if (critState === " critical"){
                     hitState = game.i18n.localize("DND4EBETA.AttackRollHitCrit");
                     targDataArray.targetHit.push(targDataArray.targets[i]);


### PR DESCRIPTION
## Issue
When creating a power, It is possible to select the defense for the attack as no defense.
![no_def_example](https://user-images.githubusercontent.com/20159776/185827839-a8eee652-80d6-4c63-be3e-1f94c2e00e6a.png)

This functions without issue when nothing is targeted. However, when at least one token is targeted an exception is thrown, leaving the Attack button in the Power Chat Card in the disabled state. A new Power Chat Card needs to be generated and all tokens untargeted before trying again. The error is
```
dice.js:206 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'value')
[Detected 1 package: system:dnd4e]
    at performD20RollAndCreateMessage (dice.js:206)
    at Object.callback (dice.js:90)
    at Dialog.submit (foundry.js:44156)
    at Dialog._onClickButton (foundry.js:44119)
    at HTMLButtonElement.dispatch (jquery.min.js:2)
    at HTMLButtonElement.v.handle (jquery.min.js:2)
```

## Fix
The solution offered in this PR
* Conditionally skips adding the `DND4EBETA.VS` text if the attack isn't against any defense.
* Sets `targDefVal` to `undefined` when the targeted creature does not have that defense, using optional chaining.
* Skips calculating `hitState` if `targDefVal` === `undefined`.

Example: Attacking four targeted tokens when `Item4e.data.data.attack.def = ''`.
![no_def_example_2](https://user-images.githubusercontent.com/20159776/185828930-e3eafbd2-9893-4a67-8991-55eacc8a0e0d.png)

I have tested that the `hitState` is still calculated when the value of a target's defense is equal to `0` for a valid defense. It would only not display the `hitState` if a creature somehow had `undefined` for a valid defense.
