### PR TITLE
[Bugfix] Attacking Multiple Tokens with FastForward

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -124,13 +124,13 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 	manageBonusInParts(parts, form, data)
 
 	let allRollsParts = []
+	const numberOfTargets = Math.max(1, game.user.targets.size);
 	if (isAttackRoll && form !== null) {
 		// populate the common attack bonuses into data
 		Object.keys(CONFIG.DND4EBETA.commonAttackBonuses).forEach(function(key,index) {
 			data[key] = CONFIG.DND4EBETA.commonAttackBonuses[key].value
 		});
 		const individualAttack = (Object.entries(form)[6][1].value === "true");
-		const numberOfTargets = Math.max(1, game.user.targets.size)
 		for (let targetIndex = 0; targetIndex < numberOfTargets; targetIndex++ ) {
 			const targetBonuses = []
 			for ( let [k, v] of Object.entries(form) ) {
@@ -157,7 +157,7 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 		}
 	}
 	else {
-		allRollsParts.push(parts)
+		allRollsParts = Array(numberOfTargets).fill(parts);
 	}
 
 	// if the form updated the roll flavor


### PR DESCRIPTION
## Issue

Attacking when multiple tokens are targeted works as expected, rolling an attack for each target when not using the `fastForward` feature. However, when the `fastForward` feature is used, only a single attack is made against just one of the tokens targeted.

## Fix

In `module/dice.js` change the behavior in `performD20RollAndCreateMessage()` when `form === null` to setting `allRollsParts` equal to an Array with `parts` repeated a number of times equal to the number of targets (or 1 if no targets). This fixes the issue so that an Attack will be made against each targeted token.

Note that this does allow `allRollsParts` to get unnecessarily large when targeting multiple tokens while making a non-Attack d20Roll, but line 230 filters down to the one needed roll for these non-Attack rolls.
```js
        if (!isAttackRoll || game.user.targets.size < 1) {
		roll = roll.rollArray[0];
	}
```