### PR TITLE
[Helper] FastForward Keys

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1234,7 +1234,8 @@ ${parseInt(data.data.movement.shift.value)} ${game.i18n.localize("DND4EBETA.Move
 		const item = this.actor.items.get(itemId);
 		
 		if ( item.data.type === "power") {
-			return this.actor.usePower(item, {configureDialog: !event.shiftKey, fastForward: event.shiftKey});
+			const fastForward = Helper.isUsingFastForwardKey(event);
+			return this.actor.usePower(item, {configureDialog: !fastForward, fastForward: fastForward});
 		}
 		// Otherwise roll the Item directly
 		return item.roll();

--- a/module/dice.js
+++ b/module/dice.js
@@ -436,7 +436,7 @@ function mergeInputArgumentsIntoRollConfig(rollConfig, parts, event, rollMode, t
 
 	// Determine whether the roll can be fast-forward, make explicit comparison here as it might be set as false, so no falsey checks
 	if ( fastForward === null || fastForward === undefined) {
-		rollConfig.fastForward = event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey);
+		rollConfig.fastForward = Helper.isUsingFastForwardKey(event);
 		if(rollConfig.options?.fastForward){
 			rollConfig.fastForward = rollConfig.options.fastForward;
 		}

--- a/module/helper.js
+++ b/module/helper.js
@@ -1023,6 +1023,16 @@ export class Helper {
 			}
 		}
 	}
+
+	/**
+	 * Determine if a fastForward key was held during the given click event.
+	 *
+	 * @param {Event} event A click event
+	 * @returns {boolean} if the click was done while holding down a fastForward key
+	 */
+	static isUsingFastForwardKey(event) {
+		return event && (event.shiftKey || event.altKey || event.ctrlKey || event.metaKey)
+	}
 }
 
 export async function handleApplyEffectToToken(data){


### PR DESCRIPTION
Moves the check for `fastForward` keys into a `helper.js` function. Uses this new Helper function when
* Rolling an item from the character sheet with  `_onItemRoll()`
* Rolling a check or damage with `mergeInputArgumentsIntoRollConfig()`

This change will provide a consistent experience when fastForwarding. Before this PR, fastForwarding items from the character sheet could only be done with the Shift Key while all other rolls could use Shift, Ctrl, Alt, or the Meta key.

Future changes to fastFoward keys can now be managed in one place.