### PR TITLE
Pass the event into initative to allow for fast forwarding.

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -990,6 +990,7 @@ export class Actor4e extends Actor {
 		const initRoll = await  d20Roll(mergeObject(options, {
 			parts: parts,
 			data: data,
+			event,
 			title: `Init Roll`,
 			speaker: ChatMessage.getSpeaker({actor: this}),
 			flavor: isReroll? `${this.name} re-rolls Initiative!` : `${this.name} rolls for Initiative!`,


### PR DESCRIPTION
Without this you can't fast forward initative rolls, which is not fun when you have a lot of monsters to roll initative for.