### PR TITLE
[v10] enrichHTML

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -821,7 +821,7 @@ ${parseInt(data.system.movement.shift.value)} ${game.i18n.localize("DND4EBETA.Mo
    * Handle rolling of an item from the Actor sheet, obtaining the Item instance and dispatching to it's roll method
    * @private
    */
-	_onItemSummary(event) {
+	async _onItemSummary(event) {
 		event.preventDefault();
 		const li = $(event.currentTarget).parents(".item")
 	    const itemId = li.data("item-id")
@@ -831,7 +831,7 @@ ${parseInt(data.system.movement.shift.value)} ${game.i18n.localize("DND4EBETA.Mo
 			return
 		}
 		const item = this.actor.items.get(itemId)
-		const chatData = item.getChatData({secrets: this.actor.isOwner});
+		const chatData = await item.getChatData({secrets: this.actor.isOwner});
 
 
 		// Toggle summary

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -86,7 +86,7 @@ export default class ActorSheet4e extends ActorSheet {
   /* -------------------------------------------- */
 
 	/** @override */
-	getData() {
+	async getData() {
 
 		let isOwner = this.actor.isOwner;
 
@@ -153,6 +153,13 @@ export default class ActorSheet4e extends ActorSheet {
 			if (res && res.max === 0) delete res.max;
 			return arr.concat([res]);
 			}, []);
+
+		data.biographyHTML = await TextEditor.enrichHTML(data.system.biography, {
+			secrets: isOwner,
+			async: true,
+			relativeTo: this.actor
+		});
+
 		return data;
 	}
 	

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -399,10 +399,10 @@ export default class Item4e extends Item {
 			Helper.executeMacro(this)
 			if (this.system.macro.launchOrder === "sub") return;
 		}
-		const cardData = (() => {
+		const cardData = (async () => {
 			if ((this.type === "power" || this.type === "consumable") && this.system.autoGenChatPowerCard) {
 				let weaponUse = Helper.getWeaponUse(this.system, this.actor);
-				let cardString = Helper._preparePowerCardData(this.getChatData(), CONFIG, this.actor);
+				let cardString = Helper._preparePowerCardData(await this.getChatData(), CONFIG, this.actor);
 				return Helper.commonReplace(cardString, this.actor, this, weaponUse? weaponUse.system : null, 1);
 			} else {
 				return null;
@@ -414,7 +414,7 @@ export default class Item4e extends Item {
 			actor: this.actor,
 			tokenId: token ? token.uuid : null,
 			item: this,
-			system: this.getChatData(),
+			system: await this.getChatData(),
 			labels: this.labels,
 			hasAttack: this.hasAttack,
 			isHealing: this.isHealing,
@@ -632,14 +632,14 @@ export default class Item4e extends Item {
 	 * @param {Object} htmlOptions    Options used by the TextEditor.enrichHTML function
 	 * @return {Object}               An object of chat data to render
 	 */
-	getChatData(htmlOptions={}) {
+	async getChatData(htmlOptions={}) {
 		const data = duplicate(this.system);
 		const labels = this.labels;
 
 		
 		// Rich text description
-		htmlOptions.async=false; //TextEditor.enrichHTML is becoming asynchronous. In the short term you may pass async=true or async=false as an option to nominate your preferred behavior.
-		data.description.value = TextEditor.enrichHTML(data.description.value || ``, htmlOptions);
+		htmlOptions.async = true; //TextEditor.enrichHTML is becoming asynchronous. In the short term you may pass async=true or async=false as an option to nominate your preferred behavior.
+		data.description.value = await TextEditor.enrichHTML(data.description.value || ``, htmlOptions);
 
 		// Item type specific properties
 		const props = [];

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -399,7 +399,7 @@ export default class Item4e extends Item {
 			Helper.executeMacro(this)
 			if (this.system.macro.launchOrder === "sub") return;
 		}
-		const cardData = (async () => {
+		const cardData = await ( async () => {
 			if ((this.type === "power" || this.type === "consumable") && this.system.autoGenChatPowerCard) {
 				let weaponUse = Helper.getWeaponUse(this.system, this.actor);
 				let cardString = Helper._preparePowerCardData(await this.getChatData(), CONFIG, this.actor);

--- a/module/item/sheet.js
+++ b/module/item/sheet.js
@@ -104,6 +104,20 @@ export default class ItemSheet4e extends ItemSheet {
 		// Re-define the template data references (backwards compatible)
 		data.item = itemData;
 		data.system = itemData.system;
+
+		const description = data.system.description;
+		data.descriptionHTML = await TextEditor.enrichHTML(description.value || description, {
+			secrets: data.item.isOwner,
+			async: true,
+			relativeTo: this.item
+		});
+
+		data.effectDetailHTML = await TextEditor.enrichHTML(data.system.effect.detail, {
+			secrets: data.item.isOwner,
+			async: true,
+			relativeTo: this.item
+		});
+
 		return data;
 	}
 

--- a/templates/actors/parts/actor-biography.html
+++ b/templates/actors/parts/actor-biography.html
@@ -1,1 +1,1 @@
-{{editor system.biography target="system.biography" button=true owner=owner editable=editable rollData=rollData}}
+{{editor biographyHTML target="system.biography" button=true owner=owner editable=editable rollData=rollData}}

--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -7,7 +7,7 @@
 	</header>
 
 	<div class="card-content" style="display: block;">
-		{{{data.description.value}}}
+		{{{system.description.value}}}
 		{{#if data.materials.value}}
 		<p><strong>{{ localize "DND4EBETA.RequiredMaterials" }}.</strong> {{data.materials.value}}</p>
 		{{/if}}

--- a/templates/item-sheet.html
+++ b/templates/item-sheet.html
@@ -25,7 +25,7 @@
 
         {{!-- Description Tab --}}
         <div class="tab" data-group="primary" data-tab="description">
-            {{editor system.description target="system.description" button=true owner=owner editable=editable}}
+            {{editor descriptionHTML target="system.description" button=true owner=owner editable=editable}}
         </div>
 
         {{!-- Attributes Tab --}}

--- a/templates/items/classFeats.html
+++ b/templates/items/classFeats.html
@@ -38,7 +38,7 @@
 
 		{{!-- Description Tab --}}
 		<div class="tab flexrow active" data-group="primary" data-tab="description">
-			{{editor system.description.value target="system.description.value" button=true owner=owner editable=editable}}
+			{{editor descriptionHTML target="system.description.value" button=true owner=owner editable=editable}}
 		</div>
 
 		{{!-- Details Tab --}}

--- a/templates/items/consumable.html
+++ b/templates/items/consumable.html
@@ -269,7 +269,7 @@
 				<input type="checkbox" name="system.effectHTML" data-dtype="Boolean" {{checked system.effectHTML}}/>
 			</div>
 			{{#if system.effectHTML}}
-			{{editor system.effect.detail target="system.effect.detail" button=true owner=owner editable=editable}}
+			{{editor effectDetailHTML target="system.effect.detail" button=true owner=owner editable=editable}}
 			{{else}}
 			<div class="form-group">
 				<input type="text" name="system.effect.detail" value="{{system.effect.detail}}" placeholder="{{ localize "DND4EBETA.PowerTextFieldsPlaceholder"}}"/>

--- a/templates/items/parts/item-description.html
+++ b/templates/items/parts/item-description.html
@@ -24,5 +24,5 @@
             {{/each}}
         </ol>
     </div>
-    {{editor system.description.value target="system.description.value" button=true owner=owner editable=editable rollData=rollData}}
+    {{editor descriptionHTML target="system.description.value" button=true owner=owner editable=editable rollData=rollData}}
 </div>

--- a/templates/items/parts/item-power-template.html
+++ b/templates/items/parts/item-power-template.html
@@ -390,7 +390,7 @@
 		<span class="checkbox">{{ localize "DND4EBETA.EffectHTMLInput" }}<input type="checkbox" name="system.effectHTML" data-dtype="Boolean" {{checked system.effectHTML}}/></span>
 	</div>
 	{{#if system.effectHTML}}
-		{{editor system.effect.detail target="system.effect.detail" button=true owner=owner editable=editable}}
+		{{editor effectDetailHTML target="system.effect.detail" button=true owner=owner editable=editable}}
 	{{else}}
 		<div class="form-group">
 			<input type="text" name="system.effect.detail" value="{{system.effect.detail}}" placeholder="{{ localize "DND4EBETA.PowerTextFieldsPlaceholder"}}"/>


### PR DESCRIPTION
This PR adds three fixes for v10 all related to the FoundryVTT `TextEditor.enrichHTML()` static method.

## Fix 1: Async TextEditor.enrichHTML
I changed the call to `TextEditor.enrichHTML()` within `Item4e.getChatData()` to use `async = true`. If a modder used the new `CONFIG.TextEditor.enrichers` feature for v10, their changes would not appear in html produced by `Item4e.getChatData()` but it would in all other areas giving an inconsistent experience.

## Fix 2:  Editors must enrich their own HTML
Starting in v10, editors must have their HTML enriched. See the FoundryVTT warning
```js
      foundry.utils.logCompatibilityWarning("The content option for the editor handlebars helper has been deprecated. "
        + "Please pass the content in as the first option to the helper and ensure it has already been enriched by "
        + "TextEditor.enrichHTML if necessary", {since: 10, until: 12});
```
This fix uses `TextEditor.enrichHTML()` with `async = true` on all editor content before submitting it to the editor, adding the enriched html as a separate property used in the template.
```html
{{editor enrichedExampleHTML content=path.to.content}}
```

## Fix 3: Invalid path to item description
Within `templates/chat/item-card.html`, the description of the item was still referenced using the old path. I have updated it to the new path
```html
{{{system.description.value}}}
```