### PR TITLE
[Bugfix] Any Includes Weapon

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -137,7 +137,7 @@ export class Helper {
 	 */
 	static lacksRequiredWeaponEquipped(itemData, weaponUse) {
 		// a power needs a weapon equipped to roll attack if a weapon type has been specified that is not None or Implement And weaponUse is not none.
-		const powerNeedsAWeapon = itemData.weaponType && itemData.weaponType !== "none" && itemData.weaponType !== "implement" && itemData.weaponUse !== "none"
+		const powerNeedsAWeapon = itemData.weaponType && !["none", "implement", "any"].includes(itemData.weaponType) && itemData.weaponUse !== "none"
 		return !weaponUse && powerNeedsAWeapon
 	}
 


### PR DESCRIPTION
##Issue
When `weaponType` in `Item4e` is set to `"any"` for a power, a character is allowed to use an Implement for the power. However, when the character attempts to use the power without any weapon or implement equipped, an error is thrown. This is despite an actual Implement not being required for Implement powers.

## Fix
This PR adds `"any"` to the list of `weaponType`s that do not require a weapon. It also changes the boolean logic to an `Array.inclueds()` instead of three separate `!==` checks. 