### PR TITLE
[Bugfix] enrichHTML effect

### DIFF
--- a/module/item/sheet.js
+++ b/module/item/sheet.js
@@ -112,7 +112,7 @@ export default class ItemSheet4e extends ItemSheet {
 			relativeTo: this.item
 		});
 
-		data.effectDetailHTML = await TextEditor.enrichHTML(data.system.effect.detail, {
+		data.effectDetailHTML = await TextEditor.enrichHTML(data.system.effect?.detail, {
 			secrets: data.item.isOwner,
 			async: true,
 			relativeTo: this.item


### PR DESCRIPTION
# Issue
A bug was introduced in my PR #233 . It assumed that the `effect` property would always exist for all ItemSheet4e. However, this is not always the case.

# Fix 
Use optional chaining: `data.system.effect?.detail` .