### PR TITLE
[Bugfix] Resetting Resources

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -145,14 +145,15 @@ export default class ActorSheet4e extends ActorSheet {
 		data.effects = ActiveEffect4e.prepareActiveEffectCategories(actor.effects);
 
 		// Resources
-		actorData.resources = ["primary", "secondary", "tertiary"].reduce((arr, r) => {
+		actorData.resources = ["primary", "secondary", "tertiary"].reduce((obj, r) => {
 			const res = actorData.resources[r] || {};
 			res.name = r;
 			res.placeholder = game.i18n.localize("DND4EBETA.Resource"+r.titleCase());
 			if (res && res.value === 0) delete res.value;
 			if (res && res.max === 0) delete res.max;
-			return arr.concat([res]);
-			}, []);
+			obj[r] = res
+			return obj;
+		}, {});
 
 		data.biographyHTML = await TextEditor.enrichHTML(data.system.biography, {
 			secrets: isOwner,


### PR DESCRIPTION
## Issue
After setting a Resource within the Actor sheet, if the user closes and opens the Actor sheet, the `system.resources` will be reset losing the information the user recorded.

After editing a resource, the `system.resources` will be an Array
```json
[
    {
        "value": 1,
        "max": 2,
        "sr": true,
        "lr": false,
        "label": "EXAMPLE NAME",
        "name": "primary",
        "placeholder": "Resource 1"
    },
    {
        "value": 3,
        "max": 4,
        "sr": false,
        "lr": true,
        "label": "OTHER EXAMPLE",
        "name": "secondary",
        "placeholder": "Resource 2"
    },
    {
        "value": 5,
        "max": 6,
        "sr": true,
        "lr": true,
        "label": "NAME",
        "name": "tertiary",
        "placeholder": "Resource 3"
    }
]
```

After closing and opening the character sheet, the `system.resources` will be an Array without user defined input
```json
[
    {
        "name": "primary",
        "placeholder": "Resource 1"
    },
    {
        "name": "secondary",
        "placeholder": "Resource 2"
    },
    {
        "name": "tertiary",
        "placeholder": "Resource 3"
    }
]
```
After logging out and logging back in, the `system.resources` will be an Object
```json
{
    "primary": {
        "value": null,
        "max": null,
        "sr": false,
        "lr": false,
        "label": ""
    },
    "secondary": {
        "value": null,
        "max": null,
        "sr": false,
        "lr": false,
        "label": ""
    },
    "tertiary": {
        "value": null,
        "max": null,
        "sr": false,
        "lr": false,
        "label": ""
    }
}
```

## Fix
Chage `ActorSheet4e.getData()` to reduce `resources` to an Object instead of an Array.