### PR TITLE
Minor Fixes:

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@
 
 ## Version 0.3.0
 - Update to Foundry v10
-- Minnor fixes to css
+- Minor fixes to css
 
 ## Version 0.2.85
-- Pass the event into initative to allow for fast forwarding [merge](https://github.com/EndlesNights/dnd4eBeta/pull/232) from [TheGiddyLimit](https://github.com/TheGiddyLimit)
+- Pass the event into initiative to allow for fast forwarding [merge](https://github.com/EndlesNights/dnd4eBeta/pull/232) from [draconas1](https://github.com/draconas1)
 - FastForward Keys moved to helper function [merge](https://github.com/EndlesNights/dnd4eBeta/pull/231) from [kyleady](https://github.com/kyleady)
 - Bugfix with Attacking Multiple Tokens with FastForward [merge](https://github.com/EndlesNights/dnd4eBeta/pull/230) from [kyleady](https://github.com/kyleady)
-- Bugfix when attack with defecne that targeted null defence type [merge](https://github.com/EndlesNights/dnd4eBeta/pull/229) from [kyleady](https://github.com/kyleady)
+- Bugfix when attack with defence that targeted null defence type [merge](https://github.com/EndlesNights/dnd4eBeta/pull/229) from [kyleady](https://github.com/kyleady)
 - Added limited view for NPCs [merge](https://github.com/EndlesNights/dnd4eBeta/pull/228) from [mncimino1993](https://github.com/mncimino1993)
 
 ## Version 0.2.84
@@ -31,11 +31,11 @@
 ## Version 0.2.82
 - fixed small issue with object sorting on sheets. Powers, items, and feats should now be able to be manually resorted objects within the confines of the current sorting filters by dragging and dropping the items once more.
 - fixed issue with power text filter, where the input element id was having interference from the feat filter input element because they shared the same id.
-- fixed css for pwer text filter, where the css intended for another element was not specific enough and was causing the text to be unreadable shade of white.
+- fixed css for power text filter, where the css intended for another element was not specific enough and was causing the text to be unreadable shade of white.
 
 ## Version 0.2.81
 - fixed fastforward for damage rolls
-- can now fastword power use, will autmaticly roll attack, damage, and healing rolls, as well as place measure templates.
+- can now fastforward power use, will automatically roll attack, damage, and healing rolls, as well as place measure templates.
 
 ## Version 0.2.80
 - hotfix, forgot to remove a testcase.

--- a/module/apps/ability-use-dialog.js
+++ b/module/apps/ability-use-dialog.js
@@ -38,7 +38,7 @@ export default class AbilityUseDialog extends Dialog {
     // Prepare dialog form data
     const system = {
       item: item.system,
-      title: game.i18n.format("DND4EBETA.AbilityUseHint", item.system),
+      title: game.i18n.format("DND4EBETA.AbilityUseHint", item),
       note: this._getAbilityUseNote(item, uses, recharge),
       hasLimitedUses: itemData.preparedMaxUses || recharges,
       canUse: recharges ? recharge.charged : (quantity > 0 && !uses.value) || uses.value > 0,

--- a/module/apps/heal-menu-dialog.js
+++ b/module/apps/heal-menu-dialog.js
@@ -19,8 +19,9 @@ export class HealMenuDialog extends FormApplication {
 	/** @override */
 	getData(options) {
 		const hpMax = this.object.system.attributes.hp.value === this.object.system.attributes.hp.max
+		const surgeValue = this.object.system.details.surgeValue
 		const constHasSurges = this.object.system.details.surges.value > 0
-		return {hpMax, constHasSurges}
+		return {hpMax, constHasSurges, surgeValue}
 	}
 
 	/* -------------------------------------------- */

--- a/module/effects/effects.js
+++ b/module/effects/effects.js
@@ -47,7 +47,7 @@
 		if ( this.parent instanceof Actor ) {
 			const updates = {duration: {startTime: game.time.worldTime}, transfer: false, equippedRec: false};
 			const combat = game.combat;
-			if (combat?.turn) {//if combat has started
+			if (combat?.turn != null && combat.turns && combat.turns[combat.turn]) {//if combat has started - combat.turn for the first character = 0 (so cannot use truthy value).  If there are no combatents combat.turns = []
 				updates.flags = {dnd4e: { effectData: { startTurnInit: combat.turns[combat.turn].initiative ?? 0}}};
 			}
 			this.updateSource(updates);

--- a/module/helper.js
+++ b/module/helper.js
@@ -9,14 +9,8 @@ export class Helper {
 			command : item.system.macro.command, //cmd,
 			author : game.user.id
 		})
-		// below vars are not part of the Macro data object so need to be set manually
-		// CODE SMELL
-		// data.item has historically been item.data
-		// data.actor has historically been the actor
-		// changing that would break existing macros that rely on item data.  I would like to make data.item = the item.
-		// can still get to the item using .document
 		macro.item = item
-		macro.actor = item.actor //needs to be actor and not data to get at actors items collection - e.g. other items
+		macro.actor = item.actor
 		macro.launch = item.system.macro.launchOrder;
 		return macro.execute();
 	}

--- a/module/hooks.js
+++ b/module/hooks.js
@@ -9,10 +9,10 @@ export const TokenBarHooks = {
 
 TokenBarHooks.generatePowerGroups = (actor) => actor.sheet._generatePowerGroups()
 
-TokenBarHooks.updatePowerAvailable = (actor, power) =>  actor.sheet._checkPowerAvailable(power.data)
+TokenBarHooks.updatePowerAvailable = (actor, power) =>  actor.sheet._checkPowerAvailable(power)
 
 TokenBarHooks.isPowerAvailable = (actor, power) => {
-    actor.sheet._checkPowerAvailable(power.data)
+    actor.sheet._checkPowerAvailable(power)
     return !power.system.notAvailable
 }
 

--- a/templates/apps/heal-menu-dialog.html
+++ b/templates/apps/heal-menu-dialog.html
@@ -6,7 +6,7 @@
   <p>{{localize "DND4EBETA.HealingMenuSpendHealingSurgeDesc"}}</p>
   <div class="form-group">
     <input type="checkbox" id="gain-healing-surge-value" name="gain-healing-surge-value" checked>
-    <label for="gain-healing-surge-value">{{localize "DND4EBETA.HealingMenuGainSurgeValue"}}</label>
+    <label for="gain-healing-surge-value">{{localize "DND4EBETA.HealingMenuGainSurgeValue"}}</label>({{surgeValue}})
   </div>
   <p>{{localize "DND4EBETA.HealingMenuGainSurgeValueDesc"}}</p>
   <div class="form-group">

--- a/templates/chat/ritual-card.html
+++ b/templates/chat/ritual-card.html
@@ -5,16 +5,16 @@
         <h3 class="item-name ability-usage--" style="padding-left: 3px;">{{item.name}}</h3>
     </header>
 
-    <div class="card-content">{{{data.description.value}}}</div>
+    <div class="card-content">{{{system.description.value}}}</div>
 
-    {{#if data.attribute}}
+    {{#if system.attribute}}
     <div class="card-buttons">
-        <button data-action="ritualCheck" data-ability="{{data.ability.value}}">{{ abilityCheck }} Check to {{item.name}}</button>
+        <button data-action="ritualCheck" data-ability="{{system.ability.value}}">{{ abilityCheck }} Check to {{item.name}}</button>
     </div>
     {{/if}}
 
     <footer class="card-footer">
-        {{#each data.properties}}
+        {{#each system.properties}}
         <span>{{this}}</span>
         {{/each}}
     </footer>

--- a/templates/chat/tool-card.html
+++ b/templates/chat/tool-card.html
@@ -5,14 +5,14 @@
         <h3 class="item-name ability-usage--" style="padding-left: 3px;">{{item.name}}</h3>
     </header>
 
-    <div class="card-content">{{{data.description.value}}}</div>
+    <div class="card-content">{{{system.description.value}}}</div>
 
     <div class="card-buttons">
-        <button data-action="toolCheck" data-ability="{{data.ability.value}}">{{ localize "DND4EBETA.Use" }} {{item.name}}</button>
+        <button data-action="toolCheck" data-ability="{{system.ability.value}}">{{ localize "DND4EBETA.Use" }} {{item.name}}</button>
     </div>
 
     <footer class="card-footer">
-        {{#each data.properties}}
+        {{#each system.properties}}
         <span>{{this}}</span>
         {{/each}}
     </footer>

--- a/templates/chat/tool-roll-dialog.html
+++ b/templates/chat/tool-roll-dialog.html
@@ -7,7 +7,7 @@
     <div class="form-group">
         <label>{{ localize "DND4EBETA.AbilityModifier" }}</label>
         <select name="ability">
-        {{#select data.item.ability}}
+        {{#select system.item.ability}}
         {{#each config.abilities as |ability a|}}
         <option value="{{a}}">{{ability}}</option>
         {{/each}}


### PR DESCRIPTION
Consumable name and type are part of main item document not system collection, fixes "undefined undefined" when using consumables

Effects would not set for the first combatent because combat.turn = 0 === false when put in a truthy comparison check.  I actually managed to find this in a bizarre edgecase where the next line failed because combat.turn had been set, but there was no combatent in that part of the array so got an undefined.  Have not been able to replicate it, but made the check more paranoid.

Heal dialog menu now displays surge value.  (mostly useful for me because my players need to deal with mournland healing which halves the value)

changelog updated to fix spelling and fix mis-attributed changeset.