### PR TITLE
Chat card tweaks to facilitate styling

### DIFF
--- a/styles/dnd4eBeta.css
+++ b/styles/dnd4eBeta.css
@@ -2201,8 +2201,7 @@ font-size: 12px;
 .dnd4eBeta.chat-card .card-header img {
 	flex: 0 0 36px;
 	margin-right: 5px;
-	
-		display: flex;
+	display: flex;
 	flex-direction: row;
 	flex-wrap: wrap;
 	justify-content: flex-start;
@@ -2216,6 +2215,7 @@ font-size: 12px;
 	font-weight: 700;
 	color: #e0e0e0;
 	border-bottom: 0px;
+	padding-left: 3px;
 }
 .dnd4eBeta.chat-card .card-header h3:hover {
 	color: #111;

--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -1,9 +1,9 @@
 <!-- note here actor == the actor instance (thus must us .id), item == item.data instance (thus should use ._id) -->
-<div class="dnd4eBeta chat-card item-card" data-actor-id="{{actor.id}}" data-item-id="{{item._id}}"
+<div class="dnd4eBeta chat-card item-card {{item.type}}-card {{actor.type}} {{#if isPower}}use-{{item.system.useType}}{{/if}}" data-actor-id="{{actor.id}}" data-item-id="{{item._id}}"
 	 {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}} {{#if isSpell}}data-spell-level="{{item.data.level}}"{{/if}}>
 	<header class="card-header flexrow">
 		<img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
-		<h3 class="item-name ability-usage--" style="padding-left: 3px;">{{item.name}}</h3>
+		<h3 class="item-name ability-usage--">{{item.name}}</h3>
 	</header>
 
 	<div class="card-content" style="display: block;">
@@ -18,8 +18,6 @@
 		</div>
 	</div>
 	<div class="card-buttons">
-
-
 
 		{{#if hasAttack}}
 		<button data-action="attack" title="{{ localize "DND4EBETA.QuickRoll" }}">
@@ -65,12 +63,11 @@
 		{{/if}}
 	</div>
 
+	{{#unless isPower}}
 	<footer class="card-footer">
-		{{#if isPower}}
-		{{else}}
 			{{#each data.properties}}
 			<span>{{this}}</span>
 			{{/each}}
-		{{/if}}
 	</footer>
+	{{/unless}}
 </div>

--- a/templates/chat/ritual-card.html
+++ b/templates/chat/ritual-card.html
@@ -1,8 +1,8 @@
 <!-- note here actor == the actor instance (thus must us .id), item == item.data instance (thus should use ._id) -->
-<div class="dnd4eBeta chat-card item-card" data-actor-id="{{actor.id}}" data-item-id="{{item._id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
+<div class="dnd4eBeta chat-card item-card ritual {{actor.type}}" data-actor-id="{{actor.id}}" data-item-id="{{item._id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
     <header class="card-header flexrow">
         <img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
-        <h3 class="item-name ability-usage--" style="padding-left: 3px;">{{item.name}}</h3>
+        <h3 class="item-name ability-usage--">{{item.name}}</h3>
     </header>
 
     <div class="card-content">{{{system.description.value}}}</div>

--- a/templates/chat/tool-card.html
+++ b/templates/chat/tool-card.html
@@ -1,8 +1,8 @@
 <!-- note here actor == the actor instance (thus must us .id), item == item.data instance (thus should use ._id) -->
-<div class="dnd4eBeta chat-card item-card" data-actor-id="{{actor.id}}" data-item-id="{{item._id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
+<div class="dnd4eBeta chat-card item-card tool {{actor.type}}" data-actor-id="{{actor.id}}" data-item-id="{{item._id}}" {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}}>
     <header class="card-header flexrow">
         <img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
-        <h3 class="item-name ability-usage--" style="padding-left: 3px;">{{item.name}}</h3>
+        <h3 class="item-name ability-usage--">{{item.name}}</h3>
     </header>
 
     <div class="card-content">{{{system.description.value}}}</div>


### PR DESCRIPTION
A self-interested update that tweaks chat cards to facilitate add-on styling. (Yes, I just wanted to make it easier to work with in my styling module!) Under default styling, no differences will be visible unless you inspect the HTML markup.
- Added classes to the outer div wrapper of chat cards to indicate the item (object) type, actor type, and (if power) usage type.
- Moved the left-side padding on chat card h3 titles to CSS rather than inline styling.
- Changed the "isPower" if/else loop in the generic item card footer to an equivalent "unless" loop, just for tidiness.