### PR TITLE
Markup updates to chat cards and roll dialogue

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -744,9 +744,11 @@ export class Helper {
 	}
 
 	static _preparePowerCardData(chatData, CONFIG, actorData=null) {
-		let powerSource = (chatData.powersource && chatData.powersource !== "") ? ` ♦ ${CONFIG.DND4EBETA.powerSource[`${chatData.powersource}`]}` : "";
-		let powerDetail = `<span><b>${CONFIG.DND4EBETA.powerUseType[`${chatData.useType}`]}${powerSource}`;
+		let powerSource = (chatData.powersource && chatData.powersource !== "") ? `${CONFIG.DND4EBETA.powerSource[`${chatData.powersource}`]}` : "";
+		let powerDetail = `<span class="basics"><span class="usage">${CONFIG.DND4EBETA.powerUseType[`${chatData.useType}`]}</span>`;
 		let tag = [];
+		
+		if(chatData.powersource) tag.push(powerSource);
 
 		if(['melee', 'meleeRanged', 'ranged'].includes(chatData.weaponType) ) {
 			tag.push(`Weapon`);
@@ -758,8 +760,6 @@ export class Helper {
 		if (chatData.powersource && chatData.secondPowersource && chatData.secondPowersource != chatData.powersource){
 			tag.push(`${CONFIG.DND4EBETA.powerSource[`${chatData.secondPowersource}`]}`)
 		}
-
-
 		
 		if(chatData.weaponDamageType) {
 			for ( let [damage, d] of Object.entries(chatData.weaponDamageType)) {
@@ -778,41 +778,42 @@ export class Helper {
 			}
 		}
 		tag.sort();
-		powerDetail += tag.length > 0 ? `, ${tag.join(', ')}</b></span>` : `</b></span>`;
+		if(tag.length > 0) powerDetail += ` ♦ <span class="keywords">${tag.join(', ')}</span>`;
 		
-		powerDetail += `<br><span><b>${CONFIG.DND4EBETA.abilityActivationTypes[chatData.actionType]} •`;
+		powerDetail += `</span><br /><span><span class="action">${CONFIG.DND4EBETA.abilityActivationTypes[chatData.actionType]}</span> `;
 
 		if(chatData.rangeType === "weapon") {
-			powerDetail += ` ${CONFIG.DND4EBETA.weaponType[chatData.weaponType]}`;
-			chatData.rangePower ? powerDetail += `</b> ${chatData.rangePower}</span>` : powerDetail += `</b></span>`;
+			powerDetail += ` <span class="range-type weapon">${CONFIG.DND4EBETA.weaponType[chatData.weaponType]}</span>`;
+			if(chatData.rangePower) powerDetail += ` <span class="range-value">${chatData.rangePower}</span>`;
 		}
 		else if (chatData.rangeType === "melee") {
-			powerDetail += ` ${game.i18n.localize("DND4EBETA.Melee")}</b> ${chatData.rangePower}</span>`;
+			powerDetail += ` <span class="range-type melee">${game.i18n.localize("DND4EBETA.Melee")}</span><span class="range-size"> ${chatData.rangePower}</span>`;
 		}
 		else if (chatData.rangeType === "reach") {
-			powerDetail += ` ${game.i18n.localize("DND4EBETA.rangeReach")}</b> ${chatData.rangePower}</span>`;
+			powerDetail += ` <span class="range-type reach">${game.i18n.localize("DND4EBETA.rangeReach")}</span> <span class="range-size">${chatData.rangePower}</span>`;
 		}
 		else if (chatData.rangeType === "range") {
-			powerDetail += ` ${game.i18n.localize("DND4EBETA.rangeRanged")}</b> ${chatData.rangePower}</span>`;
+			powerDetail += ` <span class="range-type ranged">${game.i18n.localize("DND4EBETA.rangeRanged")}</span> <span class="range-size">${chatData.rangePower}</span>`;
 		}
 		else if (['closeBurst', 'closeBlast'].includes(chatData.rangeType)) {
-			powerDetail += ` ${CONFIG.DND4EBETA.rangeType[chatData.rangeType]} ${this._areaValue(chatData, actorData)}</b></span>`;
+			powerDetail += ` <span class="range-type close">${CONFIG.DND4EBETA.rangeType[chatData.rangeType]}</span><span class="range-size">${this._areaValue(chatData, actorData)}</span>`;
 		}
 		else if (['rangeBurst', 'rangeBlast', 'wall'].includes(chatData.rangeType)) {
-			powerDetail += ` ${CONFIG.DND4EBETA.rangeType[chatData.rangeType]} ${this._areaValue(chatData, actorData)}</b> ${game.i18n.localize("DND4EBETA.RangeWithin")} <b>${chatData.rangePower}</b></span>`;
+			powerDetail += ` <span class="range-type area">${CONFIG.DND4EBETA.rangeType[chatData.rangeType]}</span> <span class="range-size">${this._areaValue(chatData, actorData)}</span> <span class="label-within">${game.i18n.localize("DND4EBETA.RangeWithin")}</span> <span class="range-within">${chatData.rangePower}</span>`;
 		}
 		else if (chatData.rangeType === "personal") {
-			powerDetail += ` ${CONFIG.DND4EBETA.rangeType[chatData.rangeType]}</b></span>`;
+			powerDetail += ` <span class="range-type personal">${CONFIG.DND4EBETA.rangeType[chatData.rangeType]}</span>`;
 		}
 		else if (chatData.rangeType === "special") {
-			powerDetail += ` ${CONFIG.DND4EBETA.rangeType[chatData.rangeType]}</b></span>`;
+			powerDetail += ` <span class="range-type special">${CONFIG.DND4EBETA.rangeType[chatData.rangeType]}</span>`;
 		}
 		else if (chatData.rangeType === "touch") {
-			powerDetail += ` ${game.i18n.localize("DND4EBETA.Melee")} ${CONFIG.DND4EBETA.rangeType[chatData.rangeType]}</b></span>`;
+			powerDetail += ` <span class="range-type melee">${game.i18n.localize("DND4EBETA.Melee")}</span> <span class="range-size touch">${CONFIG.DND4EBETA.rangeType[chatData.rangeType]}</span>`;
 		}
 		else {
-			powerDetail += `</b></span>`;
+			powerDetail += `</span>`;
 		}
+		powerDetail += `</span>`;
 
 		if(chatData.requirement) {
 			powerDetail += `<p span><b>${game.i18n.localize("DND4EBETA.Requirements")}:</b> ${chatData.requirement}</span></p>`;

--- a/styles/dnd4eBeta.css
+++ b/styles/dnd4eBeta.css
@@ -2318,13 +2318,26 @@ font-size: 12px;
 	color: #4b4a44;
 }
 
-.dnd4eBeta .item-details span,
+.dnd4eBeta .item-details span{
+	margin: 1px;
+	color: #000;
+}
+.dnd4eBeta .item-details>span,
 .dnd4eBeta .item-details p,
 .dnd4eBeta .item-description p {
 	padding-left: 3px;
 	padding-right: 3px;
 	margin: 1px;
 	color: #000;
+}
+.dnd4eBeta .item-details .action+.range-type{
+	padding-left:1em;
+}
+.dnd4eBeta .item-details .usage,
+.dnd4eBeta .item-details .keywords,
+.dnd4eBeta .item-details .action,
+.dnd4eBeta .item-details .range-type{
+	font-weight:bold;
 }
 
 .dnd4eBeta .item-description p ,

--- a/styles/dnd4eBeta.css
+++ b/styles/dnd4eBeta.css
@@ -2352,7 +2352,6 @@ span.flavor-text.critical,
 span.flavor-text.fumble {
 	font-weight: bold;
 }
-
 .dice-roll .dice-total.success {
 	color: inherit;
 	background: #c7d0c0;
@@ -2368,6 +2367,17 @@ span.flavor-text.fumble {
 }
 .dice-roll .dice-total.fumble {
 	color: red;
+}
+.dice-roll .hit-prediction::before{
+	content:"\1F894";
+	display:inline-block;
+	margin-right:5px;
+}
+.dice-roll .hit-prediction.critical{
+	color:green;
+}
+.dice-roll .hit-prediction.fumble{
+	color:red;
 }
 /* ----------------------------------------- */
 /* Trait Selector

--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -1,5 +1,5 @@
 <!-- note here actor == the actor instance (thus must us .id), item == item.data instance (thus should use ._id) -->
-<div class="dnd4eBeta chat-card item-card {{item.type}}-card {{actor.type}} {{#if isPower}}use-{{item.system.useType}}{{/if}}" data-actor-id="{{actor.id}}" data-item-id="{{item._id}}"
+<div class="dnd4eBeta chat-card item-card {{item.type}}-card {{actor.type}} {{#if isPower}}use-{{item.system.useType}}{{#if item.system.autoGenChatPowerCard}} autogen{{/if}}{{/if}}" data-actor-id="{{actor.id}}" data-item-id="{{item._id}}"
 	 {{#if tokenId}}data-token-id="{{tokenId}}"{{/if}} {{#if isSpell}}data-spell-level="{{item.data.level}}"{{/if}}>
 	<header class="card-header flexrow">
 		<img src="{{item.img}}" title="{{item.name}}" width="36" height="36"/>
@@ -7,7 +7,7 @@
 	</header>
 
 	<div class="card-content" style="display: block;">
-		{{{system.description.value}}}
+		{{#if item.system.chatFlavor}}<p class="chat-flavour">{{/if}}{{{system.description.value}}}{{#if item.system.chatFlavor}}</p>{{/if}}
 		{{#if data.materials.value}}
 		<p><strong>{{ localize "DND4EBETA.RequiredMaterials" }}.</strong> {{data.materials.value}}</p>
 		{{/if}}

--- a/templates/chat/roll-template-multiattack.html
+++ b/templates/chat/roll-template-multiattack.html
@@ -3,7 +3,13 @@
         <div class="dice-result">
             <span class="flavor-text target"><b>Target</b>: {{roll.target}}</span>
             <div class="dice-flavor">{{roll.flavor}}</div>
-            <span class="flavor-text hit-prediction{{roll.critstate}}">{{roll.hitstate}}</span>
+            <span class="flavor-text hit-prediction{{roll.critstate}}{{!--
+				--}}{{#if (eq roll.hitstate 'Probable Hit!')}}{{!--
+						--}} probable-hit{{!--
+					--}}{{else if (eq roll.hitstate 'Probable Miss!')}}{{!--
+						--}} probable-miss{{!--
+					--}}{{/if}}{{!--
+				--}}">{{roll.hitstate}}</span>
             <div class="dice-formula">{{{roll.formula}}}</div>
             <div class="dice-tooltip dice-formula">{{{roll.expression}}}</div>
             {{{roll.tooltip}}}

--- a/templates/chat/roll-template-multiattack.html
+++ b/templates/chat/roll-template-multiattack.html
@@ -1,9 +1,9 @@
 <div class="dice-roll">
     {{#each multirollData as |roll|}}
         <div class="dice-result">
-            <span class="flavor-text"><b>Target</b>: {{roll.target}}</span>
+            <span class="flavor-text target"><b>Target</b>: {{roll.target}}</span>
             <div class="dice-flavor">{{roll.flavor}}</div>
-            <span class="flavor-text{{roll.critstate}}">{{roll.hitstate}}</span>
+            <span class="flavor-text hit-prediction{{roll.critstate}}">{{roll.hitstate}}</span>
             <div class="dice-formula">{{{roll.formula}}}</div>
             <div class="dice-tooltip dice-formula">{{{roll.expression}}}</div>
             {{{roll.tooltip}}}

--- a/templates/chat/roll-template-single.html
+++ b/templates/chat/roll-template-single.html
@@ -5,14 +5,14 @@
     <div class="dice-result">
         
         {{#if attackRoll}}
-        <span class="flavor-text"><b>Target</b>: {{attackRoll.target}}</span>
-        <span class="flavor-text{{roll.critstate}}">{{attackRoll.hitstate}}</span>
+        <span class="flavor-text target"><b>Target</b>: {{attackRoll.target}}</span>
+        <span class="flavor-text hit-prediction{{attackRoll.critstate}}">{{attackRoll.hitstate}}</span>
         {{/if}}
 
         <div class="dice-formula">{{{formula}}}</div>
         <div class="dice-tooltip dice-formula">{{{expression}}}</div>
         {{{tooltip}}}
-        <h4 class="dice-total">{{total}}</h4>
+        <h4 class="dice-total{{attackRoll.critstate}}">{{total}}</h4>
     </div>
 </div>
 <div class="chatDamageButtons">

--- a/templates/chat/roll-template-single.html
+++ b/templates/chat/roll-template-single.html
@@ -4,9 +4,15 @@
     {{/if}}
     <div class="dice-result">
         
-        {{#if attackRoll}}
-        <span class="flavor-text target"><b>Target</b>: {{attackRoll.target}}</span>
-        <span class="flavor-text hit-prediction{{attackRoll.critstate}}">{{attackRoll.hitstate}}</span>
+			{{#if attackRoll}}
+			<span class="flavor-text target"><b>Target</b>: {{attackRoll.target}}</span>
+			<span class="flavor-text hit-prediction{{attackRoll.critstate}}{{!--
+				--}}{{#if (eq attackRoll.hitstate 'Probable Hit!')}}{{!--
+					--}} probable-hit{{!--
+				--}}{{else if (eq attackRoll.hitstate 'Probable Miss!')}}{{!--
+					--}} probable-miss{{!--
+				--}}{{/if}}{{!--
+			--}}">{{attackRoll.hitstate}}</span>
         {{/if}}
 
         <div class="dice-formula">{{{formula}}}</div>


### PR DESCRIPTION
Based on discussion on the DND4e Discord, I've updated the roll HTML markup to better separate the target from the probable hit/miss text in chat roll dialogue, highlight crits, and provide CSS classes to aid in styling these elements further.

Similarly, I've updated "preparePowerCardData" to provide CSS context for different parts of the power card markup. It's mostly not noticeable with the default styling—the only visible difference is the bullet separating action type and range being replaced with a wide space—but this markup should make it much easier to target and style specific parts of the power card to taste.

Finally, I've updated the main CSS file to suit the new markup—mostly changing some hard-coded markup elements to CSS styles instead, so they can be manipulated easily.