### PR TITLE
Changes to chat card generation for NPC powers

### DIFF
--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -7,10 +7,18 @@
 	</header>
 
 	<div class="card-content" style="display: block;">
+	{{#if (eq actor.type "NPC")}}
+		{{#if item.system.autoGenChatPowerCard}}
+			{{#if item.system.chatFlavor}}<p class="chat-flavour">{{item.system.chatFlavor}}</p>{{/if}}
+		{{else}}
+			{{{system.description.value}}}
+		{{/if}}
+	{{else}}
 		{{#if item.system.chatFlavor}}<p class="chat-flavour">{{/if}}{{{system.description.value}}}{{#if item.system.chatFlavor}}</p>{{/if}}
 		{{#if data.materials.value}}
 		<p><strong>{{ localize "DND4EBETA.RequiredMaterials" }}.</strong> {{data.materials.value}}</p>
 		{{/if}}
+	{{/if}}
 	</div>
 	<div class="item-summary">
 		<div class="item-details">


### PR DESCRIPTION
Added logic to bypass the use of description as flavour text _if_ the power came from an NPC _and_ has auto-generate turned on. (Also incidentally bypasses the out put of "required materials", which could be changed, but shouldn't be an issue for 4e powers anyway?)

My reasoning is that NPC powers almost never have flavour text, so relying on the "Chat Message Flavour" field to override the description text doesn't make as much sense as it does for character powers. This is largely based on the behaviour of Wigs' importer, which places the full power writeup in the description. When setting up powers I have found it useful to keep that for reference, but I use auto-generated power cards as a rule, which would cause lots of duplicate info unless you also add chat flavour. With character powers that's fine, but for NPC powers you need to either delete the description, or put some kind of placeholder in the flavour field.

This change seemed to me like a good way to handle it, allowing for the description field to be used arbitrarily without messing up auto-generated cards for flavour-textless powers. However, I know this is a subjective thing, and other contributors might disagree. Please feel free to discuss! I don't mean to force my preference if most people don't like it.