### PR TITLE
Fixed description text output error

### DIFF
--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -14,7 +14,11 @@
 			{{{system.description.value}}}
 		{{/if}}
 	{{else}}
-		{{#if item.system.chatFlavor}}<p class="chat-flavour">{{/if}}{{{system.description.value}}}{{#if item.system.chatFlavor}}</p>{{/if}}
+		{{#if item.system.chatFlavor}}
+			<p class="chat-flavour">{{{item.system.chatFlavor}}}</p>
+		{{else}}
+			{{{system.description.value}}}
+		{{/if}}
 		{{#if data.materials.value}}
 		<p><strong>{{ localize "DND4EBETA.RequiredMaterials" }}.</strong> {{data.materials.value}}</p>
 		{{/if}}


### PR DESCRIPTION
Fixed a bug reported in Discord where the full description text was being output in the chat card regardless of whether the chat flavour field existed. I tested this with a lot of combinations and it SEEMS to be correct now. Behaviour should now be as expected:

* **For PC powers:**
  * _Auto-generate off:_ description only
  * _Auto-generate on + no chat flavour:_ description with markup as per user input, followed by auto details
  * _Auto-generate on + chat flavour:_ chat flavour marked up as "flavour", followed by auto details
* **For NPC powers:**
  * _Auto-generate off:_ description only
  * _Auto-generate on:_ auto details, preceded by flavour field if present.