### PR TITLE
fix: Bonus effect checker to check implement type

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -194,7 +194,7 @@ export class Helper {
 							suitableKeywords.push("meleeWeapon");
 							break;
 						case "ranged":
-							suitableKeywords.push("usesWeapon");
+							suitableKeywords.push("weapon");
 							suitableKeywords.push("rangedWeapon");
 							break;
 						case "meleeRanged":

--- a/module/helper.js
+++ b/module/helper.js
@@ -174,8 +174,7 @@ export class Helper {
 					this._addKeywords(suitableKeywords, weaponInnerData.weaponGroup)
 					this._addKeywords(suitableKeywords, weaponInnerData.properties)
 					this._addKeywords(suitableKeywords, weaponInnerData.damageType)
-					/* Unnecessary with the later tool logic? Just commenting out for now cus I'm afraid I'm going to break required tool detection.—Fox
-					this._addKeywords(suitableKeywords, weaponInnerData.implement)*/
+					this._addKeywords(suitableKeywords, weaponInnerData.implement) // implement group for implement powers.  Bad naming of property, sorry -Drac
 				}
 
 				if (powerInnerData.powersource) {


### PR DESCRIPTION
My bad property naming made the implement property on an item confusing, it should be implementGroup.

Long term we can probably rename the property, as I doubt it gets used outside of this method.  But that needs a bit of thought, so this is the quick fix to make all the implement attack / damage feats work again.  