### PR TITLE
V11 first round of updates.

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -203,7 +203,7 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 		}
 		if (isAttackRoll && targets.length > rollExpressionIdx) {
 			let targName = targets[rollExpressionIdx].name;
-			let targDefVal = targets[rollExpressionIdx].document._actor.system.defences[options.attackedDef]?.value;
+			let targDefVal = targets[rollExpressionIdx].document.actor.system.defences[options.attackedDef]?.value;
 			targetData.targNameArray.push(targName);
 			targetData.targDefValArray.push(targDefVal);
 			targetData.targets.push(targets[rollExpressionIdx]);

--- a/module/effects/effects.js
+++ b/module/effects/effects.js
@@ -32,13 +32,6 @@
 		return super.apply(actor, change);
 	}
 
-
-  /** @inheritdoc */
-  _onUpdate(data, options, userId) {
-	super._onUpdate(data, options, userId);
-	if ( "disabled" in data ) this._displayScrollingStatus(!data.disabled);
-  }
-
 	/** @inheritdoc */
 	async _preCreate(data, options, user) {
 		await super._preCreate(data, options, user);
@@ -102,7 +95,7 @@
 		switch ( a.dataset.action ) {
 			case "create":
 				return owner.createEmbeddedDocuments("ActiveEffect", [{
-					label: game.i18n.localize("DND4EBETA.EffectNew"),
+					name: game.i18n.localize("DND4EBETA.EffectNew"),
 					icon: "icons/svg/aura.svg",
 					origin: owner.uuid,
 					"duration.rounds": li.dataset.effectType === "temporary" ? 1 : undefined,
@@ -131,33 +124,6 @@
 		
 		return super.isTemporary;
 	}
-	
-	// /**
-	//  * @override
-	//  * Summarize the active effect duration
-	//  * @type {{type: string, duration: number|null, remaining: number|null, label: string}}
-	//  */
-	// get duration() {
-	// 	// console.log(this)
-	// 	if(this.flags?.dnd4e?.effectData?.durationType){
-	// 		const d = this.duration;
-	// 		const duration = this._getCombatTime(d.rounds, d.turns);
-	// 		return {
-	// 			type: "turns",
-	// 			duration: duration,
-	// 			remaining: duration,
-	// 			label: this._getDurationLabel(d.rounds, d.turns)
-	// 		}
-	// 	}
-	// 	if(super.duration){
-	// 		return super.duration
-	// 	}
-	// 	return {};
-	// }
-
-	// set duration(duration){
-	// 	return duration;
-	// }
 
 	/* -------------------------------------------- */
 
@@ -220,7 +186,6 @@
 
 		// Iterate over active effects, classifying them into categories
 		for ( let e of effects ) {
-			e._getSourceName(); // Trigger a lookup for the source name
 			if ( e.isSuppressed ) categories.suppressed.effects.push(e);
 			else if ( e.disabled ) categories.inactive.effects.push(e);
 			else if ( e.isTemporary ) categories.temporary.effects.push(e);

--- a/module/helper.js
+++ b/module/helper.js
@@ -725,12 +725,12 @@ export class Helper {
 						if (!resultObject[change.key]) {
 							resultObject[change.key] = changeValueReplaced
 							if (debug) {
-								console.log(`${debug} Effect: ${effect.label}.  Computed Value: ${change.value} was the first match to ${change.key} `)
+								console.log(`${debug} Effect: ${effect.name}.  Computed Value: ${change.value} was the first match to ${change.key} `)
 							}
 						}
 						else {
 							if (debug) {
-								console.log(`${debug} Effect: ${effect.label}. Computed Value: ${change.value} was an additional match to ${change.key} adding to previous`)
+								console.log(`${debug} Effect: ${effect.name}. Computed Value: ${change.value} was an additional match to ${change.key} adding to previous`)
 							}
 							if(this._isNumber(resultObject[change.key]) && this._isNumber(changeValueReplaced)){
 								resultObject[change.key] = Number(resultObject[change.key]) + Number(changeValueReplaced)

--- a/templates/actors/parts/active-effects.html
+++ b/templates/actors/parts/active-effects.html
@@ -32,7 +32,7 @@
 		<li class="item effect flexrow" data-effect-id="{{effect.id}}">
 			<div class="item-name effect-name flexrow">
 				<img class="item-image" src="{{effect.icon}}"/>
-				<h4>{{effect.label}}</h4>
+				<h4>{{effect.name}}</h4>
 			</div>
 			<div class="effect-source">{{effect.sourceName}}</div>
 			{{#if effect._getIsSave}}

--- a/templates/sheets/active-effect-config.html
+++ b/templates/sheets/active-effect-config.html
@@ -3,7 +3,7 @@
     <!-- Effect Header -->
     <header class="sheet-header">
         <img class="effect-icon" src="{{ data.icon }}" data-edit="icon">
-        <h1 class="effect-title">{{ data.label }}</h1>
+        <h1 class="effect-title">{{ data.name }}</h1>
     </header>
 
     <!-- Effect Configuration Tabs -->
@@ -17,9 +17,9 @@
     <section class="tab" data-tab="details">
 
         <div class="form-group">
-            <label>{{ localize "EFFECT.Label" }}</label>
+            <label>{{ localize "EFFECT.Name" }}</label>
             <div class="form-fields">
-                <input type="text" name="label" value="{{ data.label }}"/>
+                <input type="text" name="label" value="{{ data.name }}"/>
             </div>
         </div>
 


### PR DESCRIPTION
Things I did: 

`dice.js` moved to the exposed actor variable.  Targetting now works fine again.  Fixes #283 

`effects.js` removed the _onUpdate method which was calling an API that has now been made private.  The base classes _onUpdate method seems to perform all of this logic for us now.  

on line 223 removed `e._getSourceName(); // Trigger a lookup for the source name` which is now deprecated.  I couldn't see where and why that as being done, and it seems to work fine without it?

Various `effect.label` -> `effect.name` to make deprecation warnings go away.    fixes everything I could find in #282 

I tried to look at the libwrapper issue with circleShape, - issue #281  but got nowhere sorry.  
