### PR TITLE
Add item name to item roll data

### DIFF
--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -1650,6 +1650,7 @@ export default class Item4e extends Item {
 		if ( !this.actor ) return null;
 		const rollData = this.actor.getRollData();
 		rollData.item = duplicate(this.system);
+		rollData.item.name = this.name;
 
 		// Include an ability score modifier if one exists
 		const abl = this.abilityMod;


### PR DESCRIPTION
Automated Animations needs the item name to work with its automatic selection menu, but this doesn't return it (since the item's name is not part of its `system` data). This adds it so that will work.