### PR TITLE
Make ActiveEffectConfig getData async to match v11 base version

### DIFF
--- a/module/effects/effects-config.js
+++ b/module/effects/effects-config.js
@@ -14,8 +14,8 @@ export default class ActiveEffectConfig4e extends ActiveEffectConfig {
 	}
 
 	/** @override */
-	getData(options) {
-		let data = super.getData(options);
+	async getData(options) {
+		let data = await super.getData(options);
 		
 		data.config = CONFIG.DND4EBETA;
 		data.powerParent = (this.object.parent.type === "power");


### PR DESCRIPTION
This should fix the empty dropdown in this issue:

https://github.com/EndlesNights/dnd4eBeta/issues/289

As well as any other strange issues with the edit Active Effect dialog.