### PR TITLE
Fix chat card posting and effect transfer

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -1066,7 +1066,8 @@ export class Helper {
 
 	static async applyEffectsToTokens(effectMap, tokenTarget, condition, parent){
 		const combat = game.combat;
-		for(let e of effectMap){
+		for(let effect of effectMap){
+			let e = effect.toObject(); // This is to avoid editing the source effect
 			if(e.flags.dnd4e.effectData.powerEffectTypes === condition){
 				for(let t of tokenTarget){
 					// console.log(e)
@@ -1081,13 +1082,13 @@ export class Helper {
 					flags.dnd4e.effectData.startTurnInit =  combat?.turns[combat?.turn]?.initiative || 0;
 
 					const userTokenId = this.getTokenIdForLinkedActor(parent);
-					const userInit = this.getInitiativeByToken(this.getTokenIdForLinkedActor(parent));
+					const userInit = this.getInitiativeByToken(userTokenId);
 					const targetInit = t ? this.getInitiativeByToken(t.id) : userInit;
 					const currentInit = this.getCurrentTurnInitiative();
 
 					if(flags.dnd4e.effectData.durationType === "endOfTargetTurn" || flags.dnd4e.effectData.durationType === "startOfTargetTurn"){
 						duration.rounds = combat? currentInit > targetInit ? combat.round : combat.round + 1 : 0;
-						flags.dnd4e.effectData.durationTurnInit = t ? this.getInitiativeByToken(t._id) : userInit;						
+						flags.dnd4e.effectData.durationTurnInit = t ? targetInit : userInit;						
 					}
 					else if(flags.dnd4e.effectData.durationType === "endOfUserTurn" || flags.dnd4e.effectData.durationType === "startOfUserTurn" ){
 						duration.rounds = combat? currentInit > userInit ? combat.round : combat.round + 1 : 0;

--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -25,6 +25,8 @@
 			{{#if item.system.chatFlavor}}
 				{{#if item.system.autoGenChatPowerCard}}
 					<p class="chat-flavour">{{{item.system.chatFlavor}}}</p>
+				{{else}}
+				    {{{system.description.value}}}
 				{{/if}}
 			{{else}}
 				{{{system.description.value}}}


### PR DESCRIPTION
Fix chat card if chatFlavor contains text and autoGenChatPowerCard is false. Under these conditions, the card is currently empty.