### PR TITLE
Fix actor sheet effects tab for v11 ActiveEffects transfer

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -406,6 +406,7 @@
 "DND4EBETA.EffectToggle": "Toggle Effect",
 "DND4EBETA.EffectEdit": "Edit Effect",
 "DND4EBETA.EffectDelete": "Delete Effect",
+"DND4EBETA.EffectFromItem": "Transferred from Item",
 "DND4EBETA.EffectWhenEquipped": "Only Apply Effect when Equipped",
 "DND4EBETA.EffectUnavailable": "Unavailable Effect",
 "DND4EBETA.Elemental": "Elemental",

--- a/lang/en.json
+++ b/lang/en.json
@@ -406,6 +406,7 @@
 "DND4EBETA.EffectToggle": "Toggle Effect",
 "DND4EBETA.EffectEdit": "Edit Effect",
 "DND4EBETA.EffectDelete": "Delete Effect",
+"DND4EBETA.EffectFromItem": "Transferred from Item",
 "DND4EBETA.EffectWhenEquipped": "Only Apply Effect when Equipped",
 "DND4EBETA.EffectUnavailable": "Unavailable Effect",
 "DND4EBETA.Elemental": "Elemental",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -179,7 +179,7 @@ export default class ActorSheet4e extends ActorSheet {
 		
 		// Prepare active effects
 		// data.effects = prepareActiveEffectCategories(this.actor.effects);
-		data.effects = ActiveEffect4e.prepareActiveEffectCategories(actor.effects);
+		data.effects = ActiveEffect4e.prepareActiveEffectCategories(actor.getActiveEffects());
 
 		// Resources
 		actorData.resources = ["primary", "secondary", "tertiary"].reduce((obj, r) => {

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -179,7 +179,7 @@ export default class ActorSheet4e extends ActorSheet {
 		
 		// Prepare active effects
 		// data.effects = prepareActiveEffectCategories(this.actor.effects);
-		data.effects = ActiveEffect4e.prepareActiveEffectCategories(actor.getActiveEffects());
+		data.effects = ActiveEffect4e.prepareActiveEffectCategories(actor.appliedEffects);
 
 		// Resources
 		actorData.resources = ["primary", "secondary", "tertiary"].reduce((obj, r) => {

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -179,7 +179,7 @@ export default class ActorSheet4e extends ActorSheet {
 		
 		// Prepare active effects
 		// data.effects = prepareActiveEffectCategories(this.actor.effects);
-		data.effects = ActiveEffect4e.prepareActiveEffectCategories(actor.appliedEffects);
+		data.effects = ActiveEffect4e.prepareActiveEffectCategories(actor.getActiveEffects());
 
 		// Resources
 		actorData.resources = ["primary", "secondary", "tertiary"].reduce((obj, r) => {

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -72,13 +72,6 @@ export class Actor4e extends Actor {
 	}
 
 
-	/** Get all ActiveEffects stored in the actor or transferred from items */
-	getActiveEffects() {
-		const effects = this.effects.filter(e => true); // Effects stored in actor
-		const transferred = this.items.map(item => item.effects.filter(e => e.transfer)).flat(); // Stored in items
-		return effects.concat(transferred);
-	}
-
 	/* --------------------------------------------- */
 
 	/** @override */

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -585,7 +585,7 @@ export class Actor4e extends Actor {
 			flags:{dnd4e:{effectData:{durationType:"startOfUserTurn"}}}
 		};
 
-		this.update({"system.details.secondwindEffect": secondwindEffect});
+		this.system.details.secondwindEffect = secondwindEffect;
 	}
 
 	/* -------------------------------------------- */

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -72,6 +72,13 @@ export class Actor4e extends Actor {
 	}
 
 
+	/** Get all ActiveEffects stored in the actor or transferred from items */
+	getActiveEffects() {
+		const effects = this.effects.filter(e => true); // Effects stored in actor
+		const transferred = this.items.map(item => item.effects.filter(e => e.transfer)).flat(); // Stored in items
+		return effects.concat(transferred);
+	}
+
 	/* --------------------------------------------- */
 
 	/** @override */

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -71,6 +71,12 @@ export class Actor4e extends Actor {
 		this._displayScrollingDamage(options.dhp);
 	}
 
+	/** Get all ActiveEffects stored in the actor or transferred from items */
+	getActiveEffects() {
+		const effects = this.effects.contents; // Effects stored in actor
+		const transferred = this.items.map(item => item.effects.filter(e => e.transfer)).flat(); // Stored in items
+		return effects.concat(transferred);
+	}
 
 	/* --------------------------------------------- */
 

--- a/module/effects/effects.js
+++ b/module/effects/effects.js
@@ -173,7 +173,8 @@
 		event.preventDefault();
 		const a = event.currentTarget;
 		const li = a.closest("li");
-		const effect = li.dataset.effectId ? owner.effects.get(li.dataset.effectId) : null;
+		const effects = ["Player Character", "NPC"].includes(owner.type) ? owner.getActiveEffects() : owner.effects.contents;
+		const effect = li.dataset.effectId ? effects.find(e => e._id === li.dataset.effectId) : null;
 		switch ( a.dataset.action ) {
 			case "create":
 				const isActor = owner instanceof Actor;

--- a/module/helper.js
+++ b/module/helper.js
@@ -1284,3 +1284,7 @@ Handlebars.registerHelper("isActor", function(obj) {
 Handlebars.registerHelper("isActive", function(effect){
 	return !effect.disabled && !effect.isSuppressed;
 });
+
+Handlebars.registerHelper("getSourceName", function(effect){
+	return effect.sourceName === "Unknown" ? effect.parent.name : effect.sourceName;
+});

--- a/module/helper.js
+++ b/module/helper.js
@@ -1276,3 +1276,11 @@ Handlebars.registerHelper('contains', function(lunch, lunchbox, meal) {
 		return "Contains helper spat up. Did you give it the right parameter types?";
 	}
 });
+
+Handlebars.registerHelper("isActor", function(obj) {
+	return obj.isCharacter || obj.isNPC;
+});
+
+Handlebars.registerHelper("isActive", function(effect){
+	return !effect.disabled && !effect.isSuppressed;
+});

--- a/templates/actors/parts/active-effects.html
+++ b/templates/actors/parts/active-effects.html
@@ -34,7 +34,7 @@
 				<img class="item-image" src="{{effect.icon}}"/>
 				<h4>{{effect.name}}</h4>
 			</div>
-			<div class="effect-source">{{effect.sourceName}}</div>
+			<div class="effect-source">{{getSourceName effect}}</div>
 			{{#if effect._getIsSave}}
 				<a class="effect-duration effect-save rollable">{{effect.duration.label}}</a>
 			{{else}}

--- a/templates/actors/parts/active-effects.html
+++ b/templates/actors/parts/active-effects.html
@@ -30,15 +30,15 @@
 	<ol class="item-list">
 	{{#each section.effects as |effect|}}
 		<li class="item effect flexrow" data-effect-id="{{effect.id}}">
-			<div class="item-name effect-name flexrow">
+			<div class="item-name effect-name flexrow" data-tooltip="{{effect.name}}">
 				<img class="item-image" src="{{effect.icon}}"/>
 				<h4>{{effect.name}}</h4>
 			</div>
-			<div class="effect-source">{{getSourceName effect}}</div>
+			<div class="effect-source" data-tooltip="{{getSourceName effect}}">{{getSourceName effect}}</div>
 			{{#if effect._getIsSave}}
-				<a class="effect-duration effect-save rollable">{{effect.duration.label}}</a>
+				<a class="effect-duration effect-save rollable" data-tooltip="{{effect.duration.label}}">{{effect.duration.label}}</a>
 			{{else}}
-				<div class="effect-duration">{{effect.duration.label}}</div>
+				<div class="effect-duration" data-tooltip="{{effect.duration.label}}">{{effect.duration.label}}</div>
 			{{/if}}
 			<div class="item-controls effect-controls flexrow">
 				<a class="effect-control" data-action="toggle" data-tooltip="{{localize 'DND4EBETA.EffectToggle'}}">

--- a/templates/actors/parts/active-effects.html
+++ b/templates/actors/parts/active-effects.html
@@ -49,9 +49,9 @@
 				</a>
 				{{#if (isActor ../../this)}}
 					{{#if effect.transfer}}
-						<p>
+						<a class="effect-control" data-action="none" data-tooltip="{{localize 'DND4EBETA.EffectFromItem'}}">
 							<i class=""></i>
-						</p>
+						</a>
 					{{else}}
 						<a class="effect-control" data-action="delete" data-tooltip="{{localize 'DND4EBETA.EffectDelete'}}">
 							<i class="fas fa-trash"></i>

--- a/templates/actors/parts/active-effects.html
+++ b/templates/actors/parts/active-effects.html
@@ -42,14 +42,26 @@
 			{{/if}}
 			<div class="item-controls effect-controls flexrow">
 				<a class="effect-control" data-action="toggle" data-tooltip="{{localize 'DND4EBETA.EffectToggle'}}">
-					<i class="fas fa-circle-notch"></i>
+					<i class="{{#if (isActive this)}}fas fa-power-off{{else}}fas fa-circle-notch{{/if}}"></i>
 				</a>
 				<a class="effect-control" data-action="edit" data-tooltip="{{localize 'DND4EBETA.EffectEdit'}}">
 					<i class="fas fa-edit"></i>
 				</a>
-				<a class="effect-control" data-action="delete" data-tooltip="{{localize 'DND4EBETA.EffectDelete'}}">
-					<i class="fas fa-trash"></i>
-				</a>
+				{{#if (isActor ../../this)}}
+					{{#if effect.transfer}}
+						<p>
+							<i class=""></i>
+						</p>
+					{{else}}
+						<a class="effect-control" data-action="delete" data-tooltip="{{localize 'DND4EBETA.EffectDelete'}}">
+							<i class="fas fa-trash"></i>
+						</a>
+					{{/if}}
+				{{else}}
+					<a class="effect-control" data-action="delete" data-tooltip="{{localize 'DND4EBETA.EffectDelete'}}">
+						<i class="fas fa-trash"></i>
+					</a>
+				{{/if}}
 			</div>
 		</li>
 	{{/each}}


### PR DESCRIPTION
I realised that the new v11 ActiveEffect transfer method (legacyTransferral = false) no longer "transfers" effects. Item effects don't get copied to the actor anymore, which breaks the char sheet effects tab. See also here: [https://github.com/foundryvtt/foundryvtt/issues/8978](https://github.com/foundryvtt/foundryvtt/issues/8978)
The Actor4e.getActiveEffects() method returns all effects stored in the actor or transferred from items.