### PR TITLE
Effect application from chat card

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -1135,6 +1135,15 @@ export class Helper {
 		}
 	}
 
+	static async applyEffectsToTargets(effects, actor){
+		if (game.user.targets.size){
+			await this.applyEffectsToTokens(effects, game.user.targets, "all", actor);
+			const parentDisposition = actor.token?.disposition || actor.prototypeToken.disposition || null;
+			await this.applyEffectsToTokens(effects, this.filterActorSetByDisposition([game.user.targets], parentDisposition), "allies", actor);
+			await this.applyEffectsToTokens(effects, this.filterActorSetByDisposition([game.user.targets], parentDisposition, false), "enemies", actor);
+		}
+	}
+
 	/**
 	 * Determine if a fastForward key was held during the given click event.
 	 *
@@ -1287,4 +1296,9 @@ Handlebars.registerHelper("isActive", function(effect){
 
 Handlebars.registerHelper("getSourceName", function(effect){
 	return effect.sourceName === "Unknown" ? effect.parent.name : effect.sourceName;
+});
+
+Handlebars.registerHelper("needsEffectButton", function(power){
+	const effects = power.item.effects.contents.filter(e => ["all", "allies", "enemies"].includes(e.flags.dnd4e.effectData.powerEffectTypes));
+	return effects.length > 0;
 });

--- a/module/item/entity.js
+++ b/module/item/entity.js
@@ -573,13 +573,7 @@ export default class Item4e extends Item {
 			html = html.replace("ability-usage--", `ability-usage--${templateData.system.useType}`);
 
 			Helper.applyEffectsToTokens(this.effects, [this.parent.token], "self", this.parent);
-
-			if(game.user.targets.size){
-				Helper.applyEffectsToTokens(this.effects, game.user.targets, "all", this.parent);
-				const parentDisposition = this.parent.token?.disposition || this.parent.prototypeToken.disposition || null;
-				Helper.applyEffectsToTokens(this.effects, Helper.filterActorSetByDisposition([game.user.targets], parentDisposition), "allies", this.parent);
-				Helper.applyEffectsToTokens(this.effects, Helper.filterActorSetByDisposition([game.user.targets], parentDisposition, false), "enemies", this.parent);
-			}
+			Helper.applyEffectsToTargets(this.effects, this.parent);
 		}
 		else if (["weapon", "equipment", "backpack", "tool", "loot"].includes(templateData.item.type)) {
 			html = html.replace("ability-usage--", `ability-usage--item`);
@@ -1815,6 +1809,9 @@ export default class Item4e extends Item {
 		else if ( action === "healing" ) await item.rollHealing({event, spellLevel});
 		else if ( action === "versatile" ) await item.rollDamage({event, spellLevel, versatile: true});
 		else if ( action === "formula" ) await item.rollFormula({event, spellLevel});
+		
+		// Effects
+		else if ( action === "effect" ) Helper.applyEffectsToTargets(item.effects, actor);
 
 		// Saving Throws for card targets
 		else if ( action === "save" ) {

--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -60,6 +60,12 @@
 			{{/if}}
 			<!-- {{#if hasEffect}}<button data-action="effect">{{ localize "DND4EBETA.Effect" }}</button>{{/if}} -->
 
+			{{#if (needsEffectButton this)}}
+			<button data-action="effect" data-tooltip="{{ localize 'DND4EBETA.EffectApply' }}">
+				{{ localize "DND4EBETA.Effect" }}
+			</button>
+			{{/if}}
+
 			{{#if isVersatile}}
 			<button data-action="versatile">{{ localize "DND4EBETA.Versatile" }}</button>
 			{{/if}}


### PR DESCRIPTION
We often had the situation where someone activates a power without having targets selected, either because it's an area power and they want the measuring template button, or they forgot. In those cases, one needs to use the power again *after* selecting targets.

I have added an effect button to the power chat card which enables effect transfer after posting the power. It only shows up if ActiveEffects are stored in the power that transfer upon targeting.