### PR TITLE
ActiveEffects access to @bloodied

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -73,9 +73,7 @@ export class Actor4e extends Actor {
 
 	/** Get all ActiveEffects stored in the actor or transferred from items */
 	getActiveEffects() {
-		const effects = this.effects.contents; // Effects stored in actor
-		const transferred = this.items.map(item => item.effects.filter(e => e.transfer)).flat(); // Stored in items
-		return effects.concat(transferred);
+		return Array.from(this.allApplicableEffects());
 	}
 
 	/* --------------------------------------------- */

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -113,7 +113,6 @@ export class Actor4e extends Actor {
 
 	/** @inheritdoc */
 	getRollData() {
-		this.prepareDerivedData();
 		const data = super.getRollData();
 		data["strMod"] = data.abilities["str"].mod
 		data["conMod"] = data.abilities["con"].mod
@@ -135,10 +134,9 @@ export class Actor4e extends Actor {
 		return data;
 	}
 
-	/**
-	 * Currently this only does attributes, but can increase it in future if there are more things we want in effects
-	 */
 	prepareDerivedData() {
+		// Get the Actor's data object
+		const actorData = this;
 		const system = this.system;
 		const bonuses = getProperty(system, "bonuses.abilities") || {};
 
@@ -165,21 +163,7 @@ export class Actor4e extends Actor {
 
 			abl.label = game.i18n.localize(DND4EBETA.abilities[id]);
 		}
-	}
 
-
-	/**
-	 * Augment the basic actor data with additional dynamic data.
-	 */
-	prepareData() {
-		super.prepareData();
-		// Get the Actor's data object
-		const actorData = this;
-		const system = this.system;
-
-		this.prepareDerivedData();
-		this.defaultSecondWindEffect();
-		
 		//HP auto calc
 		if(system.attributes.hp.autototal)
 		{
@@ -635,6 +619,18 @@ export class Actor4e extends Actor {
 		
 		//Magic Items
 		system.magicItemUse.perDay = Math.clamped(Math.floor(( system.details.level - 1 ) /10 + 1),1,3) + system.magicItemUse.bonusValue + system.magicItemUse.milestone;
+	}
+
+
+	/**
+	 * Augment the basic actor data with additional dynamic data.
+	 */
+	prepareData() {
+		super.prepareData(); // calls, in order: data reset (clear active effects),
+		// prepareBaseData(), prepareEmbeddedDocuments() (including active effects),
+		// prepareDerivedData()
+
+		this.defaultSecondWindEffect();
 	}
 
 

--- a/module/helper.js
+++ b/module/helper.js
@@ -398,7 +398,7 @@ export class Helper {
 				newFormula = newFormula.replaceAll("@heroicOrParagon", actorInnerData.details.level < 21 ? 1 : 0);
 				newFormula = newFormula.replaceAll("@paragonOrEpic", actorInnerData.details.level >= 11 ? 1 : 0);
 
-				newFormula = newFormula.replaceAll("@bloodied",  actorInnerData.attributes.hp.value <= actorInnerData.attributes.hp.max/2 ? 1 : 0);
+				newFormula = newFormula.replaceAll("@bloodied",  actorInnerData.details.isBloodied ? 1 : 0);
 			}
 			else {
 				console.log("An actor data object without a .data property was passed to common replace. Probably passed actor.system by mistake!.  Replacing: " + formula)


### PR DESCRIPTION
This addresses [issue #333](https://github.com/EndlesNights/dnd4eBeta/issues/333#issue-2040768517) where active effects would not access `@bloodied` properly. I think the reason was that `@bloodied` would resolve to a calculation involving `system.attributes.hp.max`, a derived value when hp autocalc is on. From what I found on the [Foundry Wiki](https://foundryvtt.wiki/en/development/guides/SD-tutorial/SD06-Extending-the-Actor-class), active effects are applied during the call to `Actor#prepareData()` as part of the `Actor#prepareEmbeddedDocuments` method. The calculation of `system.attributes.hp.max` happens after that, so active effects may not resolve `@bloodied` correctly. I changed that to use `system.details.isBloodied` instead, which is written to the database and is always available. Fixed the issue in my environment...

The last commit doesn't change much, but is something I was wondering about - the placement of derived data calculations. Should we move this stuff into the Actor#prepareDerivedData() method?