### PR TITLE
Disable input fields if indirectly modified

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -856,7 +856,7 @@ ${parseInt(data.system.movement.walk.value)} ${game.i18n.localize("DND4EBETA.Mov
 
 		//Disabels and adds warning to input fields that are being modfied by active effects
 		if (this.isEditable) {
-			for ( const override of this._getActorOverrides() ) {
+			for ( const override of this._getAllActorOverrides(["system.details.surges.value"]) ) {
 				html.find(`input[name="${override}"],select[name="${override}"]`).each((i, el) => {
 					el.disabled = true;
 					el.dataset.tooltip = "DND4EBETA.ActiveEffectOverrideWarning";
@@ -873,6 +873,36 @@ ${parseInt(data.system.movement.walk.value)} ${game.i18n.localize("DND4EBETA.Mov
 	 */
 	_getActorOverrides() {
 		return Object.keys(foundry.utils.flattenObject(this.object.overrides || {}));
+	}
+
+
+		/* -------------------------------------------- */
+	/**
+	 * Retrieve the list of fields that are directly modified by Active Effects, or indirectly modified via feat, item etc. bonuses.
+	 * @param excluded Array of candidate keys to exclude.
+	 * @returns {string[]}
+	 */
+	_getAllActorOverrides(excluded = []) {
+		const overrides = new Set(this._getActorOverrides());
+		const actorKeys = new Set(Object.keys(foundry.utils.flattenObject(this.actor)));
+		const candidateKeys = new Set();
+		const accumulatorSuffixes = [".value", ".max"]; // Suffixes used for the accumulation of feat, item etc. bonuses.
+		const bonusSuffixes = [/.feat$/, /.item$/, /.power$/, /.race$/, /.untyped$/]; // Suffixes for bonuses.
+
+		// Construct a list of candidate keys
+		for (const key of overrides) {
+			for (const bonus of bonusSuffixes) {
+				accumulatorSuffixes.forEach(accumulator => candidateKeys.add(key.replace(bonus, accumulator)));
+			}
+		}
+
+		// Remove excluded keys
+		for (const key of excluded) {
+			candidateKeys.delete(key);
+		}
+
+		// Return keys that exist in the actor
+		return Array.from(overrides.union(candidateKeys).intersection(actorKeys));
 	}
 
 	/* -------------------------------------------- */

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -99,15 +99,18 @@ export class Actor4e extends Actor {
 		dhp = Number(dhp);
 		const tokens = this.isToken ? [this.token?.object] : this.getActiveTokens(true);
 		for ( let t of tokens ) {
-			const pct = Math.clamped(Math.abs(dhp) / this.system.attributes.hp.max, 0, 1);
-			canvas.interface.createScrollingText(t.center, dhp.signedString(), {
-				anchor: CONST.TEXT_ANCHOR_POINTS.TOP,
-				fontSize: 16 + (32 * pct), // Range between [16, 48]
-				fill: CONFIG.DND4EBETA.tokenHPColors[dhp < 0 ? "damage" : "healing"],
-				stroke: 0x000000,
-				strokeThickness: 4,
-				jitter: 0.25
-			});
+			console.log(t);
+			if ( !t.document.hidden || game.user.isGM ){
+			    const pct = Math.clamped(Math.abs(dhp) / this.system.attributes.hp.max, 0, 1);
+			    canvas.interface.createScrollingText(t.center, dhp.signedString(), {
+				    anchor: CONST.TEXT_ANCHOR_POINTS.TOP,
+				    fontSize: 16 + (32 * pct), // Range between [16, 48]
+				    fill: CONFIG.DND4EBETA.tokenHPColors[dhp < 0 ? "damage" : "healing"],
+				    stroke: 0x000000,
+				    strokeThickness: 4,
+				    jitter: 0.25
+			    });
+			}
 		}
 	}
 

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -163,6 +163,26 @@ export class Actor4e extends Actor {
 			abl.label = game.i18n.localize(DND4EBETA.abilities[id]);
 		}
 
+		//AC mod check, check if light armour (or somthing else that add/negates adding mod)
+		if((system.defences.ac.light || this.checkLightArmour() ) && system.defences.ac.altability !== "none") {
+			system.defences.ac.ability = (system.abilities.dex.value >= system.abilities.int.value) ? "dex" : "int";
+			if(system.defences.ac.altability != "")
+			{
+				// if(data.abilities[data.defences.ac.altability].value > data.abilities[data.defences.ac.ability].value)
+				{
+					system.defences.ac.ability = system.defences.ac.altability;
+				}
+			}
+		}
+		else {
+			system.defences.ac.ability = "";
+		}
+		
+		//set mods for defences
+		system.defences.fort.ability = (system.abilities.str.value >= system.abilities.con.value) ? "str" : "con";
+		system.defences.ref.ability = (system.abilities.dex.value >= system.abilities.int.value) ? "dex" : "int";
+		system.defences.wil.ability = (system.abilities.wis.value >= system.abilities.cha.value) ? "wis" : "cha";
+
 	}
 
 	prepareDerivedData() {
@@ -318,26 +338,6 @@ export class Actor4e extends Actor {
 
 		if (system.attributes.temphp.value <= 0 )
 			system.attributes.temphp.value = null;
-
-		//AC mod check, check if light armour (or somthing else that add/negates adding mod)
-		if((system.defences.ac.light || this.checkLightArmour() ) && system.defences.ac.altability !== "none") {
-			system.defences.ac.ability = (system.abilities.dex.value >= system.abilities.int.value) ? "dex" : "int";
-			if(system.defences.ac.altability != "")
-			{
-				// if(data.abilities[data.defences.ac.altability].value > data.abilities[data.defences.ac.ability].value)
-				{
-					system.defences.ac.ability = system.defences.ac.altability;
-				}
-			}
-		}
-		else {
-			system.defences.ac.ability = "";
-		}
-		
-		//set mods for defences
-		system.defences.fort.ability = (system.abilities.str.value >= system.abilities.con.value) ? "str" : "con";
-		system.defences.ref.ability = (system.abilities.dex.value >= system.abilities.int.value) ? "dex" : "int";
-		system.defences.wil.ability = (system.abilities.wis.value >= system.abilities.cha.value) ? "wis" : "cha";
 
 		// Skill modifiers
 		//Calc defence stats


### PR DESCRIPTION
This is a small tweak for when input fields get inactivated. It inactivates input if the value gets modified indirectly via the new bonus types. (the healing surge field was still active when modified by a feat/untyped etc. bonus)

The method is a bit clumsy as it relies on the specific naming of the accumulator keys (`.value`, `.max`), but I hope it covers most cases.