### PR TITLE
Fix suppression of transferred effects

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -82,7 +82,7 @@ export class Actor4e extends Actor {
 	applyActiveEffects() {
 		// The Active Effects do not have access to their parent at preparation time so we wait until this stage to
 		// determine whether they are suppressed or not.
-		this.effects.forEach(e => e.determineSuppression());
+		this.getActiveEffects().forEach(e => e.determineSuppression());
 		return super.applyActiveEffects();
 	}
 

--- a/module/effects/effects.js
+++ b/module/effects/effects.js
@@ -136,20 +136,10 @@
 	 determineSuppression() {
 		this.isSuppressed = false;
 
-		if ( this.disabled || (this.parent.documentName !== "Actor") ) return;
-
-		const [parentType, parentId, documentType, documentId] = this.origin?.split(".") ?? [];
 		const originArray = this.origin?.split(".");
+		if ( this.disabled || !originArray || originArray[0] !== "Actor" || originArray.indexOf("Item") < 0 ) return;
 
-		// if ( (parentType !== "Actor") || (parentId !== this.parent.id) || (documentType !== "Item") ) return;
-
-		let indexItemID = originArray?.indexOf('Item') > 0 ? originArray.indexOf('Item') + 1 : -1;
-		if(indexItemID < 1){
-			return;
-		}
-		// const item = this.parent.items.get(documentId);
-		const item = this.parent.items.get(originArray[indexItemID]);
-
+		const item = this.parent;
 		if ( !item ) return;
 
 		//types of items that can be equipted


### PR DESCRIPTION
This is a fix for the effect suppression of unequipped items. It stopped working with the switch to the new effect transfer method.