### PR TITLE
Power name tooltip

### DIFF
--- a/templates/actors/parts/actor-powers.html
+++ b/templates/actors/parts/actor-powers.html
@@ -65,7 +65,7 @@
 				<div class="item-name item-image flexrow rollable">
 					<img src="{{item.img}}" width="30" height="30"/>
 				</div>
-				<div class="flexrow power-name {{#if item.system.useType }}ability-usage--{{item.system.useType}}{{else}}ability-usage--blank{{/if}} {{#if item.system.notAvailable}}not-available{{/if}}">
+				<div class="flexrow power-name {{#if item.system.useType }}ability-usage--{{item.system.useType}}{{else}}ability-usage--blank{{/if}} {{#if item.system.notAvailable}}not-available{{/if}}" data-tooltip="{{item.name}}">
 					<div class="item-name flexrow rollable">
 						<h4 class="power-detail">{{#if item.system.level}}[{{item.system.level}}]{{/if}}{{item.name}}</h4>
 					</div>


### PR DESCRIPTION
Small modification: I added a tooltip for power names on the character sheet. This is to help with long names getting clipped.