### PR TITLE
Effect tweaks

### DIFF
--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -2014,7 +2014,8 @@ export default class Item4e extends Item {
 		else if ( action === "applyEffect" ) {
 			//apply the single effect from button
 			const effect = await fromUuid(button.closest("[data-uuid]")?.dataset.uuid);
-			Helper.applyEffectsToTokens([effect], canvas.tokens.controlled, effect.flags.dnd4e.effectData.powerEffectTypes, actor);
+			const targets = game.settings.get("dnd4e", "applyEffectsToSelection") ? canvas.tokens.controlled : game.user.targets;
+			Helper.applyEffectsToTokens([effect], targets, effect.flags.dnd4e.effectData.powerEffectTypes, actor);
 		} 
 		else if ( action === "effect" ) Helper.applyAllXEffectsToTokens(item.effects, actor, effectTargets);
 		else if ( action === "hitEffect" ) Helper.applyEffectsToTokens(item.effects, effectTargets, "hit", actor);

--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -628,7 +628,9 @@ export default class Item4e extends Item {
 		// Set up html div for effect Tool Tips
 		if(this.effects.size){
 			for(const e of this.effects){
-				e.descriptionToolTip = `<div class="effect-tooltip" >${e.description}</div>`;
+				if (e.description){
+					e.descriptionToolTip = `<div class="effect-tooltip" >${e.description}</div>`;
+				}
 			}
 		}
 

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -222,6 +222,7 @@ export default class ItemSheet4e extends ItemSheet {
 				else if(e.flags.dnd4e?.effectData?.powerEffectTypes === "selfAfterAttack") categories.selfAfterAttack.effects.push(e);
 				else if(e.flags.dnd4e?.effectData?.powerEffectTypes === "allies") categories.allies.effects.push(e);
 				else if(e.flags.dnd4e?.effectData?.powerEffectTypes === "enemies") categories.enemies.effects.push(e);
+				else if(e.flags.dnd4e?.effectData?.powerEffectTypes === "all") categories.all.effects.push(e);
 				else categories.misc.effects.push(e);
 			}
 		}

--- a/templates/chat/item-card.html
+++ b/templates/chat/item-card.html
@@ -121,7 +121,7 @@
 						<span class="subtitle">{{ duration.label }}</span>
 					</div>
 					<button type="button" class="apply-effect" data-action="applyEffect"
-							data-tooltip="DND4E.EffectsApplyTokens" aria-label="{{ localize "DND4E.EffectsApplyTokens" }}">
+							data-tooltip="DND4E.EffectsApplyTokens" aria-label="{{ localize 'DND4E.EffectsApplyTokens' }}">
 						<i class="fas fa-reply-all fa-flip-horizontal"></i>
 					</button>
 				</li>


### PR DESCRIPTION
Great work on the new effects buttons! This is suuuper useful.

I tweaked some minor things:

- An empty tooltip showed up when the effect description was empty. This should be suppressed now.
- The "apply effects to selected tokens" option in the settings did nothing. This should now toggle between selected and targeted tokens.
- When adding "apply to all targets" effects, they showed up in the misc section.