### PR TITLE
Fixed DoTs from transferred effects

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -2024,7 +2024,7 @@ export class Actor4e extends Actor {
 		if(autoDoTs != "none"){
 			let applicableDoTs = {};
 			
-			for(const e of this.effects){
+			for(const e of this.getActiveEffects()){
 				if(e.flags.dnd4e?.dots.length && e.disabled === false){
 					for (let dot of e.flags.dnd4e.dots){
 						


### PR DESCRIPTION
Regeneration/DoTs did not work if transferred from an item, as reported on the Discord. This now uses `Actor4e#getActiveEffects()`.