### PR TITLE
Speculative fix for 379

### DIFF
--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -811,7 +811,7 @@ export default class Item4e extends Item {
 		const consume = itemData.consume || {};
 		if ( !consume.type ) return true;
 		const actor = this.actor;
-		consume.log(CONFIG.DND4E.abilityConsumptionTypes[consume.type])
+		console.log(CONFIG.DND4E.abilityConsumptionTypes[consume.type])
 		const typeLabel = CONFIG.DND4E.abilityConsumptionTypes[consume.type];
 		const amount =  parseInt(consume.amount) || parseInt(consume.amount) === 0 ? parseInt(consume.amount) : 1;
 


### PR DESCRIPTION
I think this fixes 379 - console.log had been typoed to consume.log, you only saw this behaviour if you used an item or power that used the resource consumption field.  

However I am doing this on the github web interface so coding a bit blind! I don't know if it had been the only problem as I can't test it.