### PR TITLE
fixed dice roll mode

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -68,7 +68,7 @@ export async function d20Roll({parts=[],  partsExpressionReplacements = [], data
 	let dialogData = {
 		formula: parts.join(" + "),
 		data: data,
-		rollMode: rollMode,
+		rollMode: rollConfig.rollMode,
 		rollModes: CONFIG.Dice.rollModes,
 		config: CONFIG.DND4E,
 		flavor: newFlavor || flavor,


### PR DESCRIPTION
Dice roll mode was not respecting the user's configured roll mode, causing users who had configured their rolls to be private to have to adjust the setting for each attack or damage dialogue.