### PR TITLE
Fix: Very High Monster Defs when using advanced Calcs

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -844,7 +844,7 @@ export class Actor4e extends Actor {
 			if(data.advancedCals){
 				let modBonus =  def.ability != "" ? data.abilities[def.ability].mod : 0;
 
-				def.value += def.base + modBonus + def.armour + def.class + def.enhance + def.temp + defBonusValue;
+				def.value = def.base + modBonus + def.armour + def.class + def.enhance + def.temp + defBonusValue;
 				
 				if(!game.settings.get("dnd4e", "halfLevelOptions")) {
 					def.value += Math.floor(data.details.level / 2);
@@ -854,7 +854,7 @@ export class Actor4e extends Actor {
 				def.value += globalBonus.bonusValue;
 				
 			} else {
-				def.value += def.base;
+				def.value = def.base;
 			}
 
 			def.value += Math.max(def.feat || 0, globalBonus.feat);


### PR DESCRIPTION
def.value was being incremented rather than set leading to monsters with Defences in the 30-40 range.  