### PR TITLE
Fix: right click Apply Damage/Healing not working

### DIFF
--- a/module/chat.js
+++ b/module/chat.js
@@ -367,15 +367,16 @@ function applyChatCardDamageInner(roll, multiplier, trueDamage=false) {
 	let surgeValueAmount = 0; //how many healing surges of healing
 
 	//count surges used, shouldn't be more than 1, but you never know....
+	// flavor can be null
 	if(multiplier < 0 ){
 		roll.terms.forEach(e => {
-			if(e.options.flavor.includes("surgeValue")){
+			if(e.flavor?.includes("surgeValue")){
 				surgeValueAmount++;
 			}
-			else if(e.options.flavor.includes("surgeCost")){
+			else if(e.flavor?.includes("surgeCost")){
 				surgeAmount++;
 			}
-			else if(e.options.flavor.includes("surge")){
+			else if(e.flavor?.includes("surge")){
 				surgeAmount++;
 				surgeValueAmount++;
 			}
@@ -389,12 +390,13 @@ function applyChatCardDamageInner(roll, multiplier, trueDamage=false) {
 			return a.applyDamage(roll.total, multiplier, {surgeAmount, surgeValueAmount});
 		}));
 	}
-	
+
 	//Sort damage and damage type from roll terms into simpler array
+	//there can be multiple different term types, the most common are Die (e.g. 2d10), operator (e.g. +) or numeric (e.g. 10).
+	//They all have a total property which is a numeric in the case of dice and numeric.  See https://foundryvtt.com/api/classes/foundry.dice.terms.RollTerm.html
 	roll.terms.forEach(e => {
-		if(typeof e.roll?.terms[0].number === "number"){
-		//Is using [0] here okay? I don't know if there is ever more than one entry.
-			if(e.options.flavor){
+		if(typeof e.total === "number"){
+			if(e.flavor){
 				//console.log(`Damage type found: ${e.options.flavor}`);
 				damageDealt.push([e.total,e.options.flavor]);
 				rollTotalRemain -= e.total;


### PR DESCRIPTION
Ironically the check was causing the issue as it was not coping with the fact that the Terms of a roll have mulitple different types, and the roll property varies between them.

while roll? was fine for a flat numeric term, it was an async method on a Die term.  Safer just to use the .total property, which always returns the evaluated total of the term, and then check if that is numeric or a string.

Similarly we were digging into the options to get the flavour of a roll, which is undefined if there was no flavour, leading to NPE's in the healing surge calculation if you tried to heal without using a flavoured roll.  Changed to the API and added a null check, though  think the API always seems to return empty string, but there is no guarentee of that on the docs so put a ? in there.