### PR TITLE
Check weaponInnerData exists when checking for proficiency

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -249,8 +249,10 @@ export class Helper {
 					switch(powerInnerData.weaponType){
 						case "none": break;
 						case "implement":
-							if(weaponInnerData.proficientI) suitableKeywords.push('proficient');
-							break;
+							if(weaponInnerData) {
+								if(weaponInnerData.proficientI) suitableKeywords.push('proficient');
+								break;
+							}
 						case "any":
 							if(weaponInnerData) {
 								 if(weaponInnerData.WeaponType === "implement") {
@@ -259,7 +261,9 @@ export class Helper {
 								}
 							}	
 						default:
-							if(weaponInnerData.proficient) suitableKeywords.push('proficient');
+							if(weaponInnerData) {
+								if(weaponInnerData.proficient) suitableKeywords.push('proficient');
+							}
 					}
 				}
 				


### PR DESCRIPTION
Previously, if a power had a weaponType other than None or any, it would attempt to access weaponInnerData to check for proficiency, which fails if weaponInnerData is null (either due to poor configuration of power details or lack of an equipped weapon).

For classes like Psion, their powers do not actually require an implement despite having the tag, so this failure can happen within normal gameplay loop.

In addition, if this happens when trying to roll damage for a power via a chat card, it does not provide the user any error message, instead just leaving the damage button disabled as the code never comes back around to making the roll/displaying the roll settings dialog box and thus never re-enables the button to be clicked again.

P.S. I'm not familiar with contributing to open source stuff, so sorry if I've done something wrong or rude!