### PR TITLE
Fix: Token Size not being updated

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -46,9 +46,9 @@ export class Actor4e extends Actor {
 		if ( newSize && (options.forceSizeUpdate === true || (newSize !== foundry.utils.getProperty(this, "system.details.size")) )) {
 			let size = CONFIG.DND4E.tokenSizes[newSize];
 			if ( this.isToken ) this.token.update({height: size, width: size});
-			else if ( !data["token.width"] && !hasProperty(data, "token.width") ) {
-				data["token.height"] = size;
-				data["token.width"] = size;
+			else if ( !data["prototypeToken.width"] && !hasProperty(data, "prototypeToken.width") ) {
+				data["prototypeToken.height"] = size;
+				data["prototypeToken.width"] = size;
 			}
 		}
 


### PR DESCRIPTION
token property on Actor moved to prototypeToken, so player actors and important monsters will now scale again nicely.  This issue only affects where the token was linked to actor data, non linked tokens were caught by `if ( this.isToken ) this.token.update({height: size, width: size});`

Note that this will not resize existing tokens for a linked actor when you change it.  While we could go down there using the getDependantTokens property I decided that was too deep down a rabbit hole for the update method on the actor.