### PR TITLE
Fixed attribute consumption + "added" resources

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -918,6 +918,7 @@
 "DND4E.Remaining": "Remaining",
 "DND4E.RequiredMaterials": "Required Materials",
 "DND4E.Requirements": "Requirements",
+"DND4E.Resource": "Resources",
 "DND4E.Resources": "Resources",
 "DND4E.ResourcePrimary": "Resource 1",
 "DND4E.ResourceSecondary": "Resource 2",

--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -918,6 +918,7 @@
 "DND4E.Remaining": "Remaining",
 "DND4E.RequiredMaterials": "Required Materials",
 "DND4E.Requirements": "Requirements",
+"DND4E.Resources": "Resources",
 "DND4E.ResourcePrimary": "Resource 1",
 "DND4E.ResourceSecondary": "Resource 2",
 "DND4E.ResourceTertiary": "Resource 3",

--- a/lang/en.json
+++ b/lang/en.json
@@ -919,6 +919,7 @@
 "DND4E.Remaining": "Remaining",
 "DND4E.RequiredMaterials": "Required Materials",
 "DND4E.Requirements": "Requirements",
+"DND4E.Resources": "Resources",
 "DND4E.ResourcePrimary": "Resource 1",
 "DND4E.ResourceSecondary": "Resource 2",
 "DND4E.ResourceTertiary": "Resource 3",

--- a/lang/en.json
+++ b/lang/en.json
@@ -919,6 +919,7 @@
 "DND4E.Remaining": "Remaining",
 "DND4E.RequiredMaterials": "Required Materials",
 "DND4E.Requirements": "Requirements",
+"DND4E.Resource": "Resources",
 "DND4E.Resources": "Resources",
 "DND4E.ResourcePrimary": "Resource 1",
 "DND4E.ResourceSecondary": "Resource 2",

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -330,6 +330,7 @@ ${parseInt(data.system.movement.walk.value)} ${game.i18n.localize("DND4E.Movemen
 <br>${parseInt(data.system.movement.run.value)} ${game.i18n.localize("DND4E.MovementUnit")} ${game.i18n.localize("DND4E.MovementSpeedRunning")}
 <br>${parseInt(data.system.movement.charge.value)} ${game.i18n.localize("DND4E.MovementUnit")} ${game.i18n.localize("DND4E.MovementSpeedCharging")}
 <br>${parseInt(data.system.movement.climb.value)} ${game.i18n.localize("DND4E.MovementUnit")} ${game.i18n.localize("DND4E.MovementSpeedClimbing")}
+<br>${parseInt(data.system.movement.swim.value)} ${game.i18n.localize("DND4E.MovementUnit")} ${game.i18n.localize("DND4E.MovementSpeedSwimming")}
 <br>${parseInt(data.system.movement.shift.value)} ${game.i18n.localize("DND4E.MovementUnit")} ${game.i18n.localize("DND4E.MovementSpeedShifting")}`;
 
 		if(data.system.movement.custom){

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -494,11 +494,48 @@ ${parseInt(data.system.movement.walk.value)} ${game.i18n.localize("DND4E.Movemen
 	}
 
 	_checkPowerAvailable(itemData) {
-		if( (!itemData.system.uses.value && itemData.system.preparedMaxUses)
-			|| !itemData.system.prepared) {
-				itemData.system.notAvailable = true;
-
+		if( (!itemData.system.uses.value && itemData.system.preparedMaxUses) || !itemData.system.prepared) {
+			itemData.system.notAvailable = true;
 		}
+		
+		//If there's a consumed asset, check its availability	
+		const consume = itemData.system.consume || {};
+		console.debug(consume);
+		if ( consume.type && consume.target && consume.amount) {
+			console.debug(`${itemData.name} has consume type and target: ${consume.type} ${consume.target}`);
+			const actor = this.actor;
+			console.debug(actor);
+			const amount =  parseInt(consume.amount) || parseInt(consume.amount) === 0 ? parseInt(consume.amount) : 0;
+
+			// Identify the consumed resource and its quantity
+			let consumed = null;
+			let quantity = 0;
+			switch ( consume.type ) {
+				case "resource":
+				case "attribute":
+					consumed = foundry.utils.getProperty(actor.system, consume.target);
+					quantity = consumed || 0;
+					break;
+				case "ammo":
+				case "material":
+					consumed = actor.items.get(consume.target);
+					quantity = consumed ? consumed.system.quantity : 0;
+					break;
+				case "charges":
+					consumed = actor.items.get(consume.target);
+					quantity = consumed ? consumed.system.uses.value : 0;
+					break;
+			}
+
+			// Mark unavailable is the needed resource is insufficient
+			if ( ![null, undefined].includes(consumed) ) {
+				let remaining = quantity - amount;
+				if ( remaining < 0) {
+					itemData.system.notAvailable = true;
+				}
+			}
+		}			
+	
 	}
   /* -------------------------------------------- */
 	/**

--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -500,11 +500,9 @@ ${parseInt(data.system.movement.walk.value)} ${game.i18n.localize("DND4E.Movemen
 		
 		//If there's a consumed asset, check its availability	
 		const consume = itemData.system.consume || {};
-		console.debug(consume);
 		if ( consume.type && consume.target && consume.amount) {
-			console.debug(`${itemData.name} has consume type and target: ${consume.type} ${consume.target}`);
+			//console.debug(`${itemData.name} has consume type and target: ${consume.type} ${consume.target}`);
 			const actor = this.actor;
-			console.debug(actor);
 			const amount =  parseInt(consume.amount) || parseInt(consume.amount) === 0 ? parseInt(consume.amount) : 0;
 
 			// Identify the consumed resource and its quantity

--- a/module/config.js
+++ b/module/config.js
@@ -209,10 +209,11 @@ DND4E.abilityActivationTypesShort = {
 
 DND4E.abilityConsumptionTypes = {
 	"": {label: "DND4E.None"},
+	"resource": {label: "DND4E.Resource"},
 	"ammo": {label: "DND4E.ConsumeAmmunition"},
-	"attribute": {label: "DND4E.ConsumeAttribute"},
 	"material": {label: "DND4E.ConsumeMaterial"},
-	"charges": {label: "DND4E.ConsumeCharges"}
+	"charges": {label: "DND4E.ConsumeCharges"},
+	"attribute": {label: "DND4E.ConsumeAttribute"}
 };
 preLocalize("abilityConsumptionTypes", { keys: ["label"] });
 

--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -862,9 +862,10 @@ export default class Item4e extends Item {
 		// const itemData = this.system;
 	
 		const consume = itemData.consume || {};
+		console.debug(consume);
 		if ( !consume.type ) return true;
 		const actor = this.actor;
-		const typeLabel = CONFIG.DND4E.abilityConsumptionTypes[consume.type];
+		const typeLabel = CONFIG.DND4E.abilityConsumptionTypes[consume.type].label;
 		const amount =  parseInt(consume.amount) || parseInt(consume.amount) === 0 ? parseInt(consume.amount) : 1;
 
 		// Only handle certain types for certain actions
@@ -876,10 +877,11 @@ export default class Item4e extends Item {
 			return false;
 		}
 
-		// Identify the consumed resource and it's quantity
+		// Identify the consumed resource and its quantity
 		let consumed = null;
 		let quantity = 0;
 		switch ( consume.type ) {
+			case "resource":
 			case "attribute":
 				consumed = foundry.utils.getProperty(actor.system, consume.target);
 				quantity = consumed || 0;
@@ -909,7 +911,8 @@ export default class Item4e extends Item {
 		// Update the consumed resource
 		switch ( consume.type ) {
 			case "attribute":
-				await this.actor.update({[`system.${consume.target}`]: remaining});
+			case "resource":
+				await this.actor.update({[`system.${consume.target}`]: `${remaining}`});
 				break;
 			case "ammo":
 			case "material":

--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -862,7 +862,7 @@ export default class Item4e extends Item {
 		// const itemData = this.system;
 	
 		const consume = itemData.consume || {};
-		console.debug(consume);
+		//console.debug(consume);
 		if ( !consume.type ) return true;
 		const actor = this.actor;
 		const typeLabel = CONFIG.DND4E.abilityConsumptionTypes[consume.type].label;

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -369,13 +369,25 @@ export default class ItemSheet4e extends ItemSheet {
 
 		const actor = this.item.actor;
 
-		// Attributes
+		// Attributes (and Resources)
 		// this can work separate to an actor as the actors model is known at compile time
 		// if separate from an actor it will default to the PC model, as unlikely to be set with an NPC
-		if (consume.type === "attribute") {
+		if (consume.type === "attribute" || consume.type === "resource") {
 			if (actor) {
 				const attributes = TokenDocument.getTrackedAttributes(actor.system)
 				attributes.bar.forEach(a => a.push("value"));
+				
+				if(consume.type === "resource"){
+					return {"": game.i18n.localize("DND4E.None"), ...attributes.bar.concat(attributes.value).reduce((obj, a) => {
+						console.debug(a);
+						let k = a.join(".");
+						if(k.startsWith("resources") && k.endsWith("value")){
+							obj[k] = a[1];
+						}
+						return obj;
+					}, {})};
+				}
+				
 				return {"": game.i18n.localize("DND4E.None"), ...attributes.bar.concat(attributes.value).reduce((obj, a) => {
 					let k = a.join(".");
 					obj[k] = k;
@@ -384,6 +396,17 @@ export default class ItemSheet4e extends ItemSheet {
 			}
 			else {
 				const attributes = game.model.Actor['Player Character']
+				
+				if(consume.type === "resource"){
+					const resourceKeys = Object.keys(foundry.utils.flattenObject(attributes.resources)).reduce((obj, a) => {
+						//console.debug(obj);
+						if(a.endsWith("value")) obj[`system.resources.${a}`] = a.replace(".value","");
+						return obj;
+					}, {});
+					console.debug(resourceKeys);
+					return {"": game.i18n.localize("DND4E.None"), ...resourceKeys};
+				}
+				
 				const attributeKeys = Object.keys(foundry.utils.flattenObject(attributes)).reduce((obj, a) => {
 					obj[a] = a;
 					return obj;

--- a/template.json
+++ b/template.json
@@ -386,22 +386,22 @@
 				},
 				"resources": {
 					"primary": {
-						"value": 0,
-						"max": 0,
-						"sr": 0,
-						"lr": 0
+						"value": "",
+						"max": "",
+						"sr": false,
+						"lr": false
 					},
 					"secondary": {
-						"value": 0,
-						"max": 0,
-						"sr": 0,
-						"lr": 0
+						"value": "",
+						"max": "",
+						"sr": false,
+						"lr": false
 					},
 					"tertiary": {
-						"value": 0,
-						"max": 0,
-						"sr": 0,
-						"lr": 0
+						"value": "",
+						"max": "",
+						"sr": false,
+						"lr": false
 					}
 				},
 				"skills": {

--- a/templates/actors/parts/actor-details.html
+++ b/templates/actors/parts/actor-details.html
@@ -7,7 +7,7 @@
 				   placeholder="{{res.placeholder}}" />
 		</h4>
 		<div class="attribute-value flexrow">
-			<input name="system.resources.{{res.name}}.value" type="number" value="{{res.value}}" placeholder="0"/>
+			<input name="system.resources.{{res.name}}.value" type="text" value="{{res.value}}" placeholder="0"/>
 			<span class="sep"> / </span>
 			<input name="system.resources.{{res.name}}.max" type="number" value="{{res.max}}" placeholder="0"/>
 		</div>


### PR DESCRIPTION
- Converted update value for "attribute" type consumption to a string, which seems to fix the issue with consumption breaking the attribute when empty (fixes EndlesNights#384)
- Added a separate consumption setting for "resource", which offers only the `resources.[number].value` keys, labelled with `[number]`. Under the hood this uses the same logic as attribute consumption, but presenting only the custom resources here should hopefully make it easier for a novice to set up resource consumption.
- Extended the power availability check to also check the availability of consumed assets, and return unavailable if the resource is insufficient. This should be very useful for custom resources, especially in combination with something like TAH where you'd like powers to be faded or hidden when unavailable.