### PR TITLE
Embed chat data for non-consumables

### DIFF
--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -925,9 +925,7 @@ export default class Item4e extends Item {
 		};
 		
 		// If the Item was destroyed in the process of displaying its card - embed the item data in the chat message
-		if ( (this.type === "consumable") && !this.actor.items.has(this.id) ) {
-			chatData.flags["dnd4e.itemData"] = templateData.item;
-		}
+		chatData.flags["dnd4e.itemData"] = templateData.item;
 		
 		// Embed variance in the chat message, so buttons can be aware of it
 		if (variance) {

--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -924,8 +924,10 @@ export default class Item4e extends Item {
 			}
 		};
 		
-		// If the Item was destroyed in the process of displaying its card - embed the item data in the chat message
-		chatData.flags["dnd4e.itemData"] = templateData.item;
+		// In case the Item was destroyed in the process of rolling - embed the item data in the chat message
+		if (!this.actor.items.has(this.id)) {
+			chatData.flags["dnd4e.itemData"] = templateData.item;
+		}
 		
 		// Embed variance in the chat message, so buttons can be aware of it
 		if (variance) {


### PR DESCRIPTION
Currently, if a consumable item is deleted as part of the roll process, its data is embedded in the chat card to ensure attack/damage rolls can be made. This updates that line so that non-consumable powers can also take advantage of this behaviour, to model temporary powers granted by items etc.