### PR TITLE
Fix naked html tag in attack roll dialog title bar

### DIFF
--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -923,9 +923,9 @@ export default class Item4e extends Item {
 			  core: { canPopout: true }
 			}
 		};
-		
-		// If the Item was destroyed in the process of displaying its card - embed the item data in the chat message
-		if ( (this.type === "consumable") && !this.actor.items.has(this.id) ) {
+
+		// In case the Item was destroyed in the process of rolling - embed the item data in the chat message
+		if (!this.actor.items.has(this.id)) {
 			chatData.flags["dnd4e.itemData"] = templateData.item;
 		}
 		

--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -1397,13 +1397,13 @@ export default class Item4e extends Item {
 
 		// let title = `${this.name} - ${game.i18n.localize("DND4E.AttackRoll")}`;
 		let title = `${game.i18n.localize("DND4E.AttackRoll")}: ${this.name}`;
-
-		//weapon attack roll check
+        	let flavor = title;
+		
+        	//weapon attack roll check
 		if (weaponUse) {
-			title += `<br />${weaponUse.name}`;
+			title += ` - ${weaponUse.name}`;
+            		flavor += `<br />${weaponUse.name}`;
 		}
-
-		let flavor = title;
 
 		//Defence targeted is now printed per-target
 		/*if(itemData.attack.def) {


### PR DESCRIPTION
Adjusted dialog title to not have a glaring html tag in it.

Before:
<img width="460" height="47" alt="image" src="https://github.com/user-attachments/assets/7b96a509-3933-4837-9a46-729e55e194a8" />
After:
<img width="347" height="43" alt="image" src="https://github.com/user-attachments/assets/9110b336-b9da-4d10-8df3-fbd661ee5b48" />