### PR TITLE
Adjusted text regen chat card

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -2500,7 +2500,8 @@ export class Actor4e extends Actor {
 			if(applicableDoTs.length){
 				for(const dot of applicableDoTs){
 					const dmgTaken = ( dot.type == "healing" ? Math.min(dot.amount, this.system.attributes.hp.max - this.system.attributes.hp.value) : await this.calcDamageInner([[dot.amount,dot.type]]));
-					//console.debug(this.calcDamageInner([[dot.amount,dot.type]]));
+					if (dmgTaken === 0 && dot.type == "healing") continue;
+                    //console.debug(this.calcDamageInner([[dot.amount,dot.type]]));
 					let dmgImpact = "neutral";
 					
 					let chatRecipients = [Helper.firstOwner(this)];
@@ -2549,7 +2550,7 @@ export class Actor4e extends Actor {
 						user: Helper.firstOwner(this),
 						speaker: {actor: this, alias: this.isToken ? this.token.name : this.name},
 						content: html,
-						flavor: `${game.i18n.localize ("DND4E.OngoingDamage")}: ${dot.effectName}`,
+						flavor: `${dot.type === "healing" ? game.i18n.localize ("EFFECT.statusRegen") : game.i18n.localize ("DND4E.OngoingDamage")}: ${dot.effectName}`,
 						whisper: chatRecipients,
 						//rollMode: "gmroll",
 						/*rolls: [{


### PR DESCRIPTION
Chat card produced by regeneration effect will no longer say "ongoing damage" but "regeneration" instead. Additionally, no longer print a chat card if regen value is 0; there's value in seeing that ongoing damage was resisted, but I feel it's just clutter when it's regen. Example circumstance under which it would be 0 is an effect that only grants regen while bloodied; value gets multiplied by `@bloodied` which is 0 when not bloodied. I don't think anyone wants a chat card every turn in that situation. But it is definitely a more subjective change, which is why I'm explaining myself, haha

Couldn't decide whether or not to create a new string for the regen label either. Decided to start by re-using the status label to create less work for translators.