### PR TITLE
Updated item properties & eval swappy

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -1072,8 +1072,9 @@ ${parseInt(data.system.movement.walk.value)} ${game.i18n.localize("DND4E.Movemen
 			}
 		} else {
 			div = $(`<div class="item-summary">${chatData.description.value}</div>`);
-			let props = $(`<div class="item-properties"></div>`);
-			chatData.properties.forEach(p => props.append(`<span class="tag">${p}</span>`));
+			let props = $(`<ul class="item-properties tags"></ul>`);
+			//console.debug(chatData.properties);
+			chatData.properties.forEach(p => props.append(p));
 			div.append(props);
 		}
 		return div

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -858,7 +858,7 @@ export class Actor4e extends Actor {
 					//Bonuses entered through the sheet are assumed to be managed manually, so we will collect them without biggest/smallest only logic.			
 					let resBonusValue = 0;
 					if(!(res.bonus.length === 1 && jQuery.isEmptyObject(res.bonus[0]))) {
-						for( const b of res.bonus) {
+						for(const b of res.bonus) {
 
 							if(!b.active) continue;
 							let val;
@@ -867,7 +867,7 @@ export class Actor4e extends Actor {
 							}		
 							else {
 								val = Helper.commonReplace(b.value, actorData);
-								val = eval(Helper.replaceData(val, system));
+								val = Roll.safeEval(Helper.replaceData(val, system));
 							}
 							res.vuln += Math.min(val,0);
 							res.res += Math.max(val,0);
@@ -907,7 +907,7 @@ export class Actor4e extends Actor {
 
 			}
 		}catch (e){	
-			console.err(e);
+			console.error(e);
 		}
 	}
 	_prepareDerivedDataMagicItemUse(actorData, system){

--- a/module/config.js
+++ b/module/config.js
@@ -193,7 +193,7 @@ DND4E.abilityActivationTypes = {
 		abbreviation: "DND4E.ActionOpportunityShort"
 	},
 };
-preLocalize("abilityActivationTypes", { keys: ["label"] });
+preLocalize("abilityActivationTypes", { keys: ["label","laberShort","abbreviation"] });
 
 DND4E.abilityActivationTypesShort = {
 	"none": "DND4E.NoActionShort",

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -155,8 +155,8 @@ export default class ItemSheet4e extends ItemSheet {
 		//data.isFlatDC = foundry.utils.getProperty(itemData.system, "save.scaling") === "flat";
 
 		// Vehicles
-		data.isCrewed = itemData.system.activation?.type === 'crew';
-		data.isMountable = this._isItemMountable(itemData);
+		//data.isCrewed = itemData.system.activation?.type === 'crew';
+		//data.isMountable = this._isItemMountable(itemData);
 	
 		// Prepare Active Effects
 		data.effects = ActiveEffect4e.prepareActiveEffectCategories(this.item.effects);
@@ -571,90 +571,89 @@ export default class ItemSheet4e extends ItemSheet {
 	_getItemProperties(item) {
 		//console.debug(this.item.labels);
 		const props = [];
-		const labels = this.item.labels || [];
+		const labels = this.item.labels || {};
+		
 		if ( item?.type === "weapon" ) {
 			props.push(CONFIG.DND4E.weaponTypes[item.system.weaponType]);
 			const shortType = item.system.weaponType.substring(0,3) || "";
 			
 			if (item.system.enhance != 0){				
-				props.push(`${game.i18n.localize('DND4E.Enhancement')}\n +${item.system.enhance} ${game.i18n.localize('DND4E.RollsAtkDmg')}`);
+				props.push(`<li class="enhancement">${game.i18n.localize('DND4E.Enhancement')}\n +${item.system.enhance} ${game.i18n.localize('DND4E.RollsAtkDmg')}</li>`);
 			}
 
 			props.push(...Object.entries(item.system.properties)
 				.filter(e => e[1] === true && e[0] != shortType)
 				//Second filter avoids double instance of "Implement"
 				.map(e => {
-					if(e[0] === "bru") return `${CONFIG.DND4E.weaponProperties[e[0]]} ${item.system.brutalNum}`;
-					return CONFIG.DND4E.weaponProperties[e[0]]
+					if(e[0] === "bru") return `<li class="${e[0]}">${CONFIG.DND4E.weaponProperties[e[0]]} ${item.system.brutalNum}</li>`;
+					return `<li class="${e[0]}">${CONFIG.DND4E.weaponProperties[e[0]]}</li>`
 				})
 			);
 			
 			props.push(...Object.entries(item.system.damageType)
 				.filter(e => e[1] === true && e[0] != "physical")
-				.map(e => CONFIG.DND4E.damageTypes[e[0]])
+				.map(e => `<li class="${e[0]}">${CONFIG.DND4E.damageTypes[e[0]]}</li>`)
 			);
 			
 			if(item.system?.implementGroup){
 				props.push(...Object.entries(item.system?.implementGroup)
 					.filter(e => e[1] === true)
-					.map(e => CONFIG.DND4E.implement[e[0]])
+					.map(e => `<li class="${e[0]}">${CONFIG.DND4E.implement[e[0]]}</li>`)
 				);
 			}
 			
 			props.push(...Object.entries(item.system.weaponGroup)
 				.filter(e => e[1] === true)
-				.map(e => CONFIG.DND4E.weaponGroup[e[0]])
+				.map(e => `<li class="${e[0]}">${CONFIG.DND4E.weaponGroup[e[0]]}</li>`)
 			);
 
 			if(item.system.isRanged)
-				props.push(`${game.i18n.localize("DND4E.Range")}: ${item.system.range.value} / ${item.system.range.long}`);
+				props.push(`<li class="range">${game.i18n.localize("DND4E.Range")}: ${item.system.range.value} / ${item.system.range.long}</li>`);
 
 		}
 
 		else if ( item.type === "power" ) {
 			for (const [key, value] of Object.entries(labels)) {
-				props.push(value)
+				props.push(`<li class="${key}">${value}</li>`)
 			}
 		}
 
 		else if ( item.type === "equipment" ) {
-			props.push(CONFIG.DND4E.equipmentTypes[item.system.armour.type]);
-			props.push(labels.armour);
-			props.push(labels.fort);
-			props.push(labels.ref);
-			props.push(labels.wil);
-			props.push(labels.enh);
+			if(item.system.armour.type) props.push(`<li class="slot">${CONFIG.DND4E.equipmentTypes[item.system.armour.type].label}</li>`);
+			if(labels.armour) props.push(`<li class="ac-bonus">${labels.armour}</li>`);
+			if(labels.fort) props.push(`<li class="fort-bonus">${labels.fort}</li>`);
+			if(labels.ref) props.push(`<li class="ref-bonus">${labels.ref}</li>`);
+			if(labels.wil) props.push(`<li class="will-bonus">${labels.wil}</li>`);
+			if(labels.enh) props.push(`<li class="enhancement">${labels.enh}</li>`);
 		}
 
 		else if ( item.type === "feature" ) {
-			props.push(labels.aura);
-			props.push(labels.tier);
-			props.push(labels.source);
-			props.push(labels.group);
-			props.push(labels.reqs);
+			if(labels.aura) props.push(`<li class="aura-size">${labels.aura}</li>`);
+			if(labels.tier) props.push(`<li class="tier">${labels.tier}</li>`);
+			if(labels.source) props.push(`<li class="source">${labels.source}</li>`);
+			if(labels.group) props.push(`<li class="feature-set">${labels.group}</li>`);
+			if(labels.reqs) props.push(`<li class="reqs">${labels.reqs}</li>`);
 		}
 
 		else if ( item.type === "ritual" ) {
-			props.push(labels.category);
+			if(labels.category) props.push(`<li class="category">${labels.category}</li>`);
 		}
 		
 		// Action type
 		if ( (item.type !== "power") && item.system?.actionType ) {
-			props.push(CONFIG.DND4E.itemActionTypes[item.system.actionType]);
+			if(item.system.actionType) props.push(`<li class="action ${item.system.actionType}">${CONFIG.DND4E.itemActionTypes[item.system.actionType]}</li>`);
 		}
 
 		// Action usage
 		if ( !['weapon','power'].includes(item.type) && item.system?.activation && !foundry.utils.isEmpty(item.system.activation) ) {
-			props.push(
-				labels.attribute,
-				labels.activation,
-				labels.range,
-				labels.target,
-				labels.castTime,
-				labels.duration,
-				labels.component,
-				labels.componentCost
-			)
+			if(labels.attribute) props.push(`<li class="atk-attribute">${labels.attribute}</li>`);
+			if(labels.activation) props.push(`<li class="action">${labels.activation}</li>`);
+			if(labels.range) props.push(`<li class="range">${labels.range}</li>`);
+			if(labels.target) props.push(`<li class="target">${labels.target}</li>`);
+			if(labels.castTime) props.push(`<li class="cast-time">${labels.castTime}</li>`);
+			if(labels.duration) props.push(`<li class="duration">${labels.duration}</li>`);
+			if(labels.component) props.push(`<li class="components">${labels.component}</li>`);
+			if(labels.componentCost) props.push(`<li class="component-cost">${labels.componentCost}</li>`);
 		}
 		return props.filter(p => !!p);
 	}

--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -694,7 +694,10 @@ textarea{
 	margin:0 0 0 0;
 	padding:0 0 0 4px;
 }
-.dnd4e .tag{
+.dnd4e ul.item-properties.tags{
+	padding-left:0;
+}
+.dnd4e ul.item-properties.tags li{
 	display:inline-block;
 	margin:0 2px 0 0;
 	padding:0 3px;

--- a/template.json
+++ b/template.json
@@ -941,7 +941,7 @@
 			"attributes.init.base": 0,
 			"attributes.init.ability": "",
 			"details.role": {
-				"primary": "soldier",
+				"primary": "brute",
 				"secondary": "standard",
 				"leader" : false
 			},

--- a/templates/items/consumable.html
+++ b/templates/items/consumable.html
@@ -153,12 +153,26 @@
 					{{#if system.isArea}}
 					<span>{{ localize "DND4E.AreaOf" }}</span>
 					<input type="text" name="system.area" value="{{system.area}}"/>
-					{{/if}}
+					{{/if}}					
+					
 					{{#if system.isRange}}
 					{{#if system.isArea}}<span class="range-within-of">{{ localize "DND4E.RangeWithinOf" }}</span>{{/if}}
-					{{#unless system.isArea}}<span class="range-of">{{ localize "DND4E.RangeOf" }}</span>{{/unless}}
-					<input type="text" name="system.rangePower" value="{{system.rangePower}}" data-dtype="Number"/>
+					
+					{{#unless system.isArea}}<div class="form-fields">{{/unless}}
+					
+					<input type="text" name="system.rangePower" data-tooltip="{{ localize 'DND4E.WeaponRangeShort' }}: {{ localize 'DND4E.WeaponRangeShortTip' }}" value="{{system.rangePower}}" data-dtype="Number"/>
+					
+					{{#unless system.isArea}}
+						<input class="hidden" type="text" name="system.range.value" value="{{#if system.range.long}}{{system.rangePower}}{{/if}}" data-dtype="Number" />
+						{{#if (eq system.rangeType 'range')}}
+							<span class="sep">/</span>
+							<input type="text" name="system.range.long" value="{{system.range.long}}" data-tooltip="{{ localize 'DND4E.WeaponRangeLong' }}: {{ localize 'DND4E.WeaponRangeLongTip' }}" placeholder="{{ localize 'DND4E.WeaponRangeLong' }}" data-dtype="Number" onClick="this.select();"/>
+						{{/if}}
+					{{/unless}}
+					
+					{{#unless system.isArea}}</div>{{/unless}}					
 					{{/if}}
+					
 				</div>
 			</div>
 			{{!-- Attack--}}

--- a/templates/items/parts/item-description.html
+++ b/templates/items/parts/item-description.html
@@ -23,15 +23,15 @@
 		</div>
 		{{/if}}--}}
 
-		<ol class="properties-list">
+		<ul class="properties-list tags">
 			{{#each itemProperties}}
 				{{#if this.label}}
-					<li>{{{this.label}}}</li>
+					{{{this.label}}}
 				{{else}}
-					<li>{{{this}}}</li>
+					{{{this}}}
 				{{/if}}
 			{{/each}}
-		</ol>
+		</ul>
 	</div>
 
 	<section class="description">

--- a/templates/npc-sheet.html
+++ b/templates/npc-sheet.html
@@ -19,6 +19,8 @@
 					
 					<li class="summary-role">
 						<select class="actor-role-prim" name="system.details.role.primary">
+							{{#if (eq system.details.role.secondary 'minion')}}<option value=""{{#unless system.details.role}} selected{{/unless}}></option>{{/if}}
+							{{#if (eq system.details.role.secondary 'other')}}<option value=""{{#unless system.details.role}} selected{{/unless}}></option>{{/if}}
 							{{selectOptions config.creatureRole selected=system.details.role.primary labelAttr="label"}}
 						</select>
 					</li>


### PR DESCRIPTION
- Enables short/long range for consumables
- Revises item properties to include their keys in the HTML output, to allow for non-language-dependent CSS/JS manipulation. This involved digging to the labels -> props translation in both item sheet data and Chat Data formulation. Also updates sheets accordingly.
- Fixes a bug where the word "feature" would repeat in the summary line of features with a certain combination of traits.
- Updates SagaTympana's res/vuln value improvement to use `Roll.safeEval` rather than JS `eval`.