### PR TITLE
Macro and effect improvements

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1495,7 +1495,7 @@
 "DND4E.Tier.Tier": "Tier",
 "DND4E.Tier.TierName": "{tier} Tier",
 
-"EFFECT.DurationEndInit": "Effect End Time*",
+"EFFECT.DurationEndInit": "Effect End Time",
 "EFFECT.Priority": "Priority",
 "EFFECT.statusAmmoCount": "Ammo Charges",
 "EFFECT.statusAttackDown": "Attack Down",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1495,7 +1495,7 @@
 "DND4E.Tier.Tier": "Tier",
 "DND4E.Tier.TierName": "{tier} Tier",
 
-"EFFECT.DurationEndInit": "Effect End Time*",
+"EFFECT.DurationEndInit": "Effect End Time",
 "EFFECT.Priority": "Priority",
 "EFFECT.statusAmmoCount": "Ammo Charges",
 "EFFECT.statusAttackDown": "Attack Down",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1812,40 +1812,38 @@ export class Actor4e extends Actor {
 			
 		}
 		
-		if(!this.system.attributes.hp.temprest)
-			updateData[`system.attributes.temphp.value`] = "";
+		if(!this.system.attributes.hp.temprest) updateData[`system.attributes.temphp.value`] = "";
 		
-		updateData[`system.details.secondwind`] = false;
 		updateData[`system.actionpoints.encounteruse`] = false;
-		updateData[`system.magicItemUse.encounteruse`] = false;
 		
 		Helper.rechargeItems(this, ["enc", "round"]);
 		Helper.endEffects(this, ["endOfTargetTurn","endOfUserTurn","startOfTargetTurn","startOfUserTurn","endOfEncounter","endOfUserCurrent"]);
 		
 		if(this.type === "Player Character"){
+			updateData[`system.details.secondwind`] = false;
+			updateData[`system.magicItemUse.encounteruse`] = false;
+			
 			console.log(updateData[`system.attributes.hp.value`])
 			console.log(this.system.attributes.hp.value)
+			
 			ChatMessage.create({
 				user: game.user.id,
 				speaker: {actor: this, alias: this.name},
 				content: options.surge >= 1 ? `${this.name} ${game.i18n.localize('DND4E.ShortRestChat')}, ${game.i18n.localize('DND4E.Spending')} ${options.surge} ${game.i18n.localize('DND4E.SurgesSpendRegain')} ${(updateData[`system.attributes.hp.value`] - Math.max(0, this.system.attributes.hp.value))} ${game.i18n.localize('DND4E.HPShort')}.`
 					: `${this.name} ${game.i18n.localize('DND4E.ShortRestChat')}`
 				
-			});				
-		}
-
-		for (let r of Object.entries(this.system.resources)) {
-			if(r[1].label && r[1].sr && r[1].max != null) {
-				updateData[`system.resources.${r[0]}.value`] = r[1].max;
+			});
+			
+			if(!game.settings.get("dnd4e", "deathSaveRest")){
+				updateData[`system.details.deathsavefail`] = 0;
 			}
-		}
 
-		if(!game.settings.get("dnd4e", "deathSaveRest")){
-			updateData[`system.details.deathsavefail`] = 0;
+			for (let r of Object.entries(this.system.resources)) {
+				if(r[1].label && r[1].sr && r[1].max != null) {
+					updateData[`system.resources.${r[0]}.value`] = r[1].max;
+				}
+			}		
 		}
-
-		// console.log(updateData[`system.attributes.hp.value`]);
-		// console.log(this.system.attributes.hp.value);
 
 		await this.update(updateData);
 	}
@@ -1867,7 +1865,7 @@ export class Actor4e extends Actor {
 				updateData[`system.attributes.hp.value`] = this.system.attributes.hp.max;
 			}
 
-			if (game.settings.get("dnd4e", "deathSaveRest") <= 1){
+			if(this.type === "Player Character" && game.settings.get("dnd4e", "deathSaveRest") <= 1){
 				updateData[`system.details.deathsavefail`] = 0;
 			}
 		}
@@ -1879,36 +1877,36 @@ export class Actor4e extends Actor {
 			updateData[`system.details.surgeEnv.value`] = 0;
 			updateData[`system.details.surgeEnv.bonus`] = [{}];
 
-			if(game.settings.get("dnd4e", "deathSaveRest") <= 2){
+			if(this.type === "Player Character" && game.settings.get("dnd4e", "deathSaveRest") <= 2){
 				updateData[`system.details.deathsavefail`] = 0;
 			}
 		}
 
 		updateData[`system.attributes.temphp.value`] = "";
 		updateData[`system.actionpoints.value`] = 1;
-		updateData[`system.magicItemUse.milestone`] = 0;
-		updateData[`system.magicItemUse.dailyuse`] = this.system.magicItemUse.perDay;
-		
-		updateData[`system.details.secondwind`] = false;
 		updateData[`system.actionpoints.encounteruse`] = false;
-		updateData[`system.magicItemUse.encounteruse`] = false;
 		
 		Helper.rechargeItems(this, ["enc", "day", "round"]);
 		Helper.endEffects(this, ["endOfTargetTurn", "endOfUserTurn","startOfTargetTurn","startOfUserTurn","endOfEncounter","endOfDay","endOfUserCurrent"]);
 
 
 		if(this.type === "Player Character"){
+			updateData[`system.magicItemUse.milestone`] = 0;
+			updateData[`system.magicItemUse.encounteruse`] = false;
+			updateData[`system.magicItemUse.dailyuse`] = this.system.magicItemUse.perDay;
+			updateData[`system.details.secondwind`] = false;
+			
 			ChatMessage.create({
 				user: game.user.id,
 				speaker: {actor: this, alias: this.system.name},
 				// flavor: restFlavor,
 				content: `${this.name} ${game.i18n.localize('DND4E.LongRestResult')}.`
 			});
-		}
 		
-		for (let r of Object.entries(this.system.resources)) {
-			if((r[1].sr || r[1].lr) && r[1].label && r[1].max != null) {
-				updateData[`system.resources.${r[0]}.value`] = r[1].max;
+			for (let r of Object.entries(this.system.resources)) {
+				if((r[1].sr || r[1].lr) && r[1].label && r[1].max != null) {
+					updateData[`system.resources.${r[0]}.value`] = r[1].max;
+				}
 			}
 		}
 

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -2394,7 +2394,6 @@ export class Actor4e extends Actor {
 	}
 
 	async newActiveEffect(effectData){
-		console.log(effectData)
 		return this.createEmbeddedDocuments("ActiveEffect", [{
 			name: effectData.name,
 			description: effectData.description,
@@ -2402,10 +2401,10 @@ export class Actor4e extends Actor {
 			origin: effectData.origin,
 			sourceName: effectData.sourceName,
 			statuses: Array.from(effectData.statuses),
-			// duration: effectData.duration, //Not too sure why this fails, but it does
-			duration: {rounds: effectData.rounds, turns: effectData.turns},
+			//"duration": effectData.duration, //Not too sure why this fails, but it does
+			"duration": {"rounds": effectData.duration.rounds, "turns": effectData.duration.turns, "startRound": effectData.duration.startRound},
 			tint: effectData.tint,
-			flags: effectData.flags,
+			"flags": effectData.flags,
 			changes: effectData.changes
 		}]);
 	}
@@ -2418,7 +2417,7 @@ export class Actor4e extends Actor {
 			origin: effectData.origin,
 			sourceName: effectData.sourceName,
 			statuses: Array.from(effectData.statuses),
-			duration: {rounds: effectData.rounds, rounds: effectData.turns},
+			"duration": {"rounds": effectData.duration.rounds, "turns": effectData.duration.turns, "startRound": effectData.duration.startRound},
 			tint: effectData.tint,
 			flags: effectData.flags,
 			changes: effectData.changes

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -940,7 +940,7 @@ export class Actor4e extends Actor {
 		}
 		const secondwindEffect = {
 			name: game.i18n.localize("DND4E.SecondWind"),
-			icon: "icons/magic/life/heart-glowing-red.webp",
+			img: "icons/magic/life/heart-glowing-red.webp",
 			origin: this.uuid,
 			disabled:false,
 			description: game.i18n.localize("DND4E.SecondWindEffect"),
@@ -2041,9 +2041,9 @@ export class Actor4e extends Actor {
 	*/
 	
 	async usePower(item, {configureDialog=true, fastForward=false, variance={}}={}) {
-		//if not a valid type of item to use
 		//console.debug(variance);
 		
+		//if not a valid type of item to use		
 		if ( item.type !=="power" ) throw new Error("Wrong Item type");
 		const itemData = item.system;
 		//configure Powers data
@@ -2398,12 +2398,12 @@ export class Actor4e extends Actor {
 		return this.createEmbeddedDocuments("ActiveEffect", [{
 			name: effectData.name,
 			description: effectData.description,
-			icon:effectData.icon,
+			img:effectData.img,
 			origin: effectData.origin,
 			sourceName: effectData.sourceName,
 			statuses: Array.from(effectData.statuses),
 			// duration: effectData.duration, //Not too sure why this fails, but it does
-			duration: {rounds: effectData.rounds, startRound: effectData.startRound},
+			duration: {rounds: effectData.rounds, turns: effectData.turns},
 			tint: effectData.tint,
 			flags: effectData.flags,
 			changes: effectData.changes
@@ -2414,11 +2414,11 @@ export class Actor4e extends Actor {
 		const data = {
 			name: effectData.name,
 			description: effectData.description,
-			icon:effectData.icon,
+			img:effectData.img,
 			origin: effectData.origin,
 			sourceName: effectData.sourceName,
 			statuses: Array.from(effectData.statuses),
-			duration: {rounds: effectData.rounds, startRound: effectData.startRound},
+			duration: {rounds: effectData.rounds, rounds: effectData.turns},
 			tint: effectData.tint,
 			flags: effectData.flags,
 			changes: effectData.changes

--- a/module/apps/turns.js
+++ b/module/apps/turns.js
@@ -29,31 +29,32 @@ export class Turns{
 					continue;
 				}
 				else if(durationType === "endOfTargetTurn"){
-					if(currentInit <= effectData.durationTurnInit && currentRound >= e.duration.rounds && t.id === game.combat.combatant.id
-						|| (currentRound > e.duration.rounds && t.id === game.combat.combatant.id) ){
+					if(currentInit <= effectData.durationTurnInit && currentRound >= effectData.durationRound && t.id === game.combat.combatant.id
+						|| (currentRound > effectData.durationRound && t.id === game.combat.combatant.id) ){
 							toDelete.push(e.id);
 					}
 				}
 				else if(durationType === "endOfUserTurn" || durationType === "endOfUserCurrent" ){
-					if(currentInit <= effectData.durationTurnInit && currentRound >= e.duration.rounds){
+					if(currentInit <= effectData.durationTurnInit && currentRound >= effectData.durationRound){
 							toDelete.push(e.id);
 					}
 				}
 				else if(durationType === "startOfTargetTurn" || durationType === "startOfUserTurn"){
-					if((nextInit <= effectData.durationTurnInit && currentRound == e.duration.rounds || currentRound > e.duration.rounds)
-					||  (nextTurn <= currentTurn && nextInit <= effectData.durationTurnInit && currentRound+1 == e.duration.rounds)){
+					if((nextInit <= effectData.durationTurnInit && currentRound == effectData.durationRound || currentRound > effectData.durationRound)
+					||  (nextTurn <= currentTurn && nextInit <= effectData.durationTurnInit && currentRound+1 == effectData.durationRound)){
 							toDelete.push(e.id);
 					}
 				}
-				// else if(durationType === "endOfUserCurrent"){
-				// 	if(currentInit < effectData.durationTurnInit && currentRound >= e.duration.rounds){
-				// 		toDelete.push(e.id);
-				// 	}
-				// }
+				
+				if((!durationType || durationType === "custom") && (effectData?.durationRound && effectData?.durationRound)){
+					if(currentInit <= effectData.durationTurnInit && currentRound >= effectData.durationRound){
+							toDelete.push(e.id);
+					}
+				}
 	
 				if(currentTurn === game.combat.combatants.size){
 					if(durationType === "endOfUserTurn"){
-						if(effectData.durationTurnInit < currentInit && e.duration.rounds <= currentRound){
+						if(effectData.durationTurnInit < currentInit && effectData.durationRound <= currentRound){
 							toDelete.push(e.id);
 						}
 					}

--- a/module/effects/effects.js
+++ b/module/effects/effects.js
@@ -387,7 +387,7 @@
 	}
 	
 	prepareDerivedData() {
-		if(this.flags?.dnd4e?.effectData?.durationType != undefined){
+		if(!this.flags?.dnd4e?.effectData?.durationType){
 			// Re-calc duration data for Actor-owned effects
 			try{
 				const combat = game.combat;		
@@ -399,9 +399,9 @@
 					let targetInit = userInit;
 					if(this.parent.id != this.origin){
 						if(typeof this.parent == "item4e"){
-							targetInit = this.parent.parent.token.combatant.initiative;
+							targetInit = this.parent.parent?.token?.combatant?.initiative || targetInit;
 						}else{
-							targetInit = this.parent.token.combatant.initiative;
+							targetInit = this.parent?.token?.combatant?.initiative || targetInit;
 						}
 					}
 					const currentInit = game.helper.getCurrentTurnInitiative();

--- a/module/helper.js
+++ b/module/helper.js
@@ -1,6 +1,6 @@
 export class Helper {
 
-	static executeMacro(item) {
+	static async executeMacro(item) {
 		const macro = new Macro ({
 			name : item.name,
 			type : item.system.macro.type,

--- a/module/helper.js
+++ b/module/helper.js
@@ -1312,18 +1312,17 @@ export class Helper {
 						img: e.img,
 						origin: parent.uuid,
 						sourceName: parent.name,
-						// duration: duration, //Not too sure why this fails, but it does
-						// duration: {rounds: duration.rounds, startRound: duration.startRound},
-						rounds: e.duration?.rounds || null,
-						turns: e.duration?.turns || null,
+						//"duration": duration, //Not too sure why this fails, but it does
+						"duration": {startRound: duration?.startRound, rounds: duration.rounds, turns: duration.turns},
+						rounds: duration.rounds,
+						turns: duration.turns,
 						startRound: duration.startRound,
 						statuses: e.statuses,
 						tint: e.tint,
-						flags: flags,
+						"flags": flags,
 						changes: e.changes,
 						changesID: e.uuid
 					};
-					//console.debug(newEffectData);
 					
 					let actor;
 					if(t?.actor){
@@ -1345,7 +1344,7 @@ export class Helper {
 						});
 					}
 					
-					//console.log(`Effect setup fired for ${e.name} on ${actor.name}.`);
+					console.log(`Effect setup fired for ${e.name} on ${actor.name}.`);
 				}
 			}
 		}

--- a/module/helper.js
+++ b/module/helper.js
@@ -1274,6 +1274,7 @@ export class Helper {
 					const flags = e.flags;
 					duration.combat = combat?.id || "None Combat";
 					duration.startRound = combat?.round || 0;
+					/*Removing the initial timing calc after 0.6.11 since it's now redundant with the effect's derived data routine
 					flags.dnd4e.effectData.startTurnInit =	combat?.turns[combat?.turn]?.initiative || 0;
 
 					const userTokenId = this.getTokenIdForLinkedActor(parent);
@@ -1282,27 +1283,39 @@ export class Helper {
 					const currentInit = this.getCurrentTurnInitiative();
 
 					if(flags.dnd4e.effectData.durationType === "endOfTargetTurn" || flags.dnd4e.effectData.durationType === "startOfTargetTurn"){
-						duration.rounds = combat? currentInit > targetInit ? combat.round : combat.round + 1 : 0;
+						flags.dnd4e.effectData.durationRound = combat? currentInit > targetInit ? combat.round : combat.round + 1 : 0;
 						flags.dnd4e.effectData.durationTurnInit = t ? targetInit : userInit;						
 					}
 					else if(flags.dnd4e.effectData.durationType === "endOfUserTurn" || flags.dnd4e.effectData.durationType === "startOfUserTurn" ){
-						duration.rounds = combat? currentInit > userInit ? combat.round : combat.round + 1 : 0;
+						flags.dnd4e.effectData.durationRound = combat? currentInit > userInit ? combat.round : combat.round + 1 : 0;
 						flags.dnd4e.effectData.durationTurnInit = userInit;
 					}
 					else if(flags.dnd4e.effectData.durationType === "endOfUserCurrent") {
-						duration.rounds = combat? combat.round : 0;
+						flags.dnd4e.effectData.durationRound = combat? combat.round : 0;
 						flags.dnd4e.effectData.durationTurnInit = combat? currentInit : 0;
 					}
+					else if(flags.dnd4e.effectData.durationType === "custom" && (duration?.rounds || duration?.turns)){
+						flags.dnd4e.effectData.durationRound = duration.startRound + (duration?.rounds || 0);
+						let initCount = duration?.turns || 0;
+						for (const [i, turn] of combat.turns.entries()) {
+							if (turn.initiative == currentInit){
+								initCount += i;
+							}
+						}
+						initCount = Math.min(initCount,this.duration?.turns,combat.turns.length);
+						flags.dnd4e.effectData.durationTurnInit = combat.turns[initCount].initiative;
+					}*/
 
 					const newEffectData = {
 						name: e.name,
 						description: e.description ? e.description : '',
-						icon: e.icon,
+						img: e.img,
 						origin: parent.uuid,
 						sourceName: parent.name,
 						// duration: duration, //Not too sure why this fails, but it does
 						// duration: {rounds: duration.rounds, startRound: duration.startRound},
-						rounds: duration.rounds,
+						rounds: e.duration?.rounds || null,
+						turns: e.duration?.turns || null,
 						startRound: duration.startRound,
 						statuses: e.statuses,
 						tint: e.tint,
@@ -1310,6 +1323,8 @@ export class Helper {
 						changes: e.changes,
 						changesID: e.uuid
 					};
+					//console.debug(newEffectData);
+					
 					let actor;
 					if(t?.actor){
 						actor = t.actor;

--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -855,7 +855,7 @@ export default class Item4e extends Item {
 		//console.debug(variance);
 
 		if(["both", "pre", "sub"].includes(this.system.macro?.launchOrder)) {
-			await Helper.executeMacro(this)
+			await Helper.executeMacro(this);
 			if (this.system.macro.launchOrder === "sub") return;
 		}
 		const cardData = await ( async () => {
@@ -956,10 +956,8 @@ export default class Item4e extends Item {
 			}
 		};
     
-		// In case the Item was destroyed in the process of rolling - embed the item data in the chat message
-		if (!this.actor.items.has(this.id)) {
-			chatData.flags["dnd4e.itemData"] = templateData.item;
-		}
+		// In case the Item was destroyed or tweaked in the process of rolling - embed the item data in the chat message
+		chatData.flags["dnd4e.itemData"] = templateData.item;
 		
 		// Embed variance in the chat message, so buttons can be aware of it
 		if (variance) {
@@ -981,7 +979,7 @@ export default class Item4e extends Item {
 			ChatMessage.create(chatData);
 
 			if(["both", "post"].includes(this.system.macro?.launchOrder)) {
-				Helper.executeMacro(this)
+				await Helper.executeMacro(this)
 			}
 		}
 		else return chatData;

--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -2361,7 +2361,10 @@ export default class Item4e extends Item {
 		// Effects
 		else if ( action === "applyEffect" ) {
 			//apply the single effect from button
-			const effect = await fromUuid(button.closest("[data-uuid]")?.dataset.uuid);
+			const effectId = button.closest("[data-uuid]")?.dataset.uuid.split('.').pop();
+			//const effect = effects.await fromUuid(button.closest("[data-uuid]")?.dataset.uuid);
+			//Get effect from embedded data, in case the source has been expended/deleted
+			const effect = item.effects.get(effectId);
 			const targets = game.settings.get("dnd4e", "applyEffectsToSelection") ? canvas.tokens.controlled : game.user.targets;
 			Helper.applyEffectsToTokens([effect], targets, effect.flags.dnd4e.effectData.powerEffectTypes, actor);
 		} 

--- a/module/item/item-document.js
+++ b/module/item/item-document.js
@@ -855,7 +855,7 @@ export default class Item4e extends Item {
 		//console.debug(variance);
 
 		if(["both", "pre", "sub"].includes(this.system.macro?.launchOrder)) {
-			Helper.executeMacro(this)
+			await Helper.executeMacro(this)
 			if (this.system.macro.launchOrder === "sub") return;
 		}
 		const cardData = await ( async () => {

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -271,7 +271,7 @@ export default class ItemSheet4e extends ItemSheet {
 					icon: this.item.img || "icons/svg/aura.svg",
 					origin: this.item.uuid,
 					"flags.dnd4e.effectData.powerEffectTypes": li.dataset.effectType,
-					"duration.rounds": li.dataset.effectType === "temporary" ? 1 : undefined,
+					"flags.dnd4e.effectData.durationType": li.dataset.effectType === "temporary" ? "endOfUserTurn" : undefined,
 					disabled: li.dataset.effectType === "inactive"
 				}]);
 				return;

--- a/module/roll/multi-attack-roll.js
+++ b/module/roll/multi-attack-roll.js
@@ -99,7 +99,7 @@ export class MultiAttackRoll extends Roll {
                 }
             }
 
-            const chatData = r.getChatData(false)
+            const chatData = r.getChatData(false);
 
             this._multirollData.push({
                 formula : chatData.formula,
@@ -115,7 +115,7 @@ export class MultiAttackRoll extends Roll {
 				def: vsDef,
 				mod: atkMod,
 				deftext: CONFIG.DND4E.defensives[vsDef].abbreviation,
-				modtext: CONFIG.DND4E.abilityScores[atkMod].labelShort,
+				modtext: CONFIG.DND4E.abilityScores[atkMod]?.labelShort || '',
 				immune: targDataArray?.targImmArray[i] || false,
             });
         };

--- a/templates/sheets/active-effect-config.html
+++ b/templates/sheets/active-effect-config.html
@@ -84,20 +84,17 @@
             <label>{{ localize 'DND4E.DurationType' }}</label>
             <div class="form-fields">
 					<select class="durationType refreshes" name="flags.dnd4e.effectData.durationType">
-						 {{#select effect.flags.dnd4e.effectData.durationType}}
+						 {{#selectOptions config.durationType labelAttr='label' selected=effect.flags.dnd4e.effectData.durationType blank=''}}
 						 <option value=""></option>
-						 {{#each config.durationType as |label type|}}
-						 <option value="{{type}}">{{label}}</option>
-						 {{/each}}
-						 {{/select}}
+						 {{/selectOptions}}
 					</select>
 					{{#if (eq effect.flags.dnd4e.effectData.durationType "saveEnd")}}
 						  <label>{{ localize 'DND4E.AbbreviationDC' }}</label>
-						  <input type="text" class="number saveDC" name="flags.dnd4e.effectData.saveDC" value="{{#if effect.flags.dnd4e.effectData.saveDC}}{{ effect.flags.dnd4e.effectData.saveDC }}{{else}}10{{/if}}" placeholder="10" data-dtype="number" />
+						  <input type="text" class="number saveDC" name="flags.dnd4e.effectData.saveDC" value="{{#if effect.flags.dnd4e.effectData.saveDC}}{{effect.flags.dnd4e.effectData.saveDC}}{{else}}10{{/if}}" placeholder="10" data-dtype="number" />
 					{{/if}}
 				</div>
         </div>
-        <div class="form-group">
+        <!--<div class="form-group">
             <label>{{ localize 'EFFECT.DurationSecs' }}</label>
             <div class="form-fields">
                 <input type="number" name="duration.seconds" value="{{ data.duration.seconds }}"/>
@@ -109,36 +106,61 @@
                 <input type="number" name="duration.startTime" value="{{ data.duration.startTime }}"/>
             </div>
         </div>
-        <hr/>
-        <div class="form-group">
-            <label>{{ localize 'EFFECT.DurationEndInit' }}</label>
-            <div class="form-fields">
-                <label>{{ localize 'COMBAT.Rounds' }}</label>
-                <input type="number" name="duration.rounds" value="{{ data.duration.rounds }}"/>
-                <label>{{ localize 'COMBAT.Turns' }}</label>
-                <!-- <input type="number" name="duration.turns" value="{{ data.duration.turns }}"/> -->
-                <input type="number" step="0.01" name="flags.dnd4e.effectData.durationTurnInit" value="{{ effect.flags.dnd4e.effectData.durationTurnInit }}"/>
-                
-            </div>
-        </div>
-        <div class="form-group">
+        <hr/>-->
+		
+		{{#if (eq effect.flags.dnd4e.effectData.durationType "custom")}}		
+			<div class="form-group effect-duration">
+				<label>{{ localize 'Duration' }}</label>
+				<div class="form-fields">					
+						<label>{{ localize 'COMBAT.Rounds' }}</label>
+						<input class="refreshes" type="number" name="duration.rounds" value="{{data.duration.rounds}}" step="1" />
+						<label>{{ localize 'COMBAT.Turns' }}</label>
+						<input class="refreshes" type="number" name="duration.turns" value="{{data.duration.turns}}" step="1" />                
+				</div>
+			</div>
+		{{/if}}
+
+		{{#if effect.flags.dnd4e.effectData.durationType}}
+		
+			<div class="form-group effect-start">
+				<label>{{ localize 'EFFECT.StartTime' }}</label>
+				<div class="form-fields">
+					<label>{{ localize 'COMBAT.Round' }}</label>
+					<label>{{data.duration.startRound}}</label>
+					<label>{{ localize 'DND4E.Initiative' }}</label>
+					<label data-tooltip="{{ localize 'DND4EUI.Tiebreaker' }}: {{effect.flags.dnd4e.effectData.startTurnInit}}">{{numberFormat effect.flags.dnd4e.effectData.startTurnInit decimals=0}}</label>
+				</div>
+			</div>
+			
+			{{#unless (eq effect.flags.dnd4e.effectData.durationType "saveEnd")}}
+			{{#unless (eq effect.flags.dnd4e.effectData.durationType "endOfEncounter")}}
+			{{#unless (eq effect.flags.dnd4e.effectData.durationType "endOfDay")}}
+		
+			<div class="form-group effect-end">
+				<label>{{ localize 'EFFECT.DurationEndInit' }}</label>
+				<div class="form-fields">
+					{{#if effect.flags.dnd4e.effectData.durationRound}}
+					<label>{{ localize 'COMBAT.Round' }}</label>
+					<label>{{effect.flags.dnd4e.effectData.durationRound}}</label>
+					{{/if}}
+					{{#if effect.flags.dnd4e.effectData.durationTurnInit}}
+					<label>{{ localize 'DND4E.Initiative' }}</label>
+					<label data-tooltip="{{ localize 'DND4EUI.Tiebreaker' }}: {{effect.flags.dnd4e.effectData.durationTurnInit}}">{{numberFormat effect.flags.dnd4e.effectData.durationTurnInit decimals=0}}</label>
+					{{/if}}			
+				</div>
+			</div>
+			
+			{{/unless}}
+			{{/unless}}
+			{{/unless}}
+		{{/if}}
+		
+        <!--<div class="form-group">
             <label>{{ localize 'EFFECT.Combat' }}</label>
             <div class="form-fields">
                 <input type="text" name="duration.combat" value="{{ data.duration.combat }}" disabled/>
             </div>
-        </div>
-
-        <div class="form-group">
-            <label>{{ localize 'EFFECT.StartTurns' }}</label>
-            <div class="form-fields">
-                <label>{{ localize 'COMBAT.Round' }}</label>
-                <input type="number" name="duration.startRound" value="{{ data.duration.startRound }}"/>
-                <label>{{ localize 'COMBAT.Turn' }}</label>
-                <!-- <input type="number" name="duration.startTurn" value="{{ data.duration.startTurn }}"/> -->
-                <input type="number" step="0.01" name="flags.dnd4e.effectData.startTurnInit" value="{{ effect.flags.dnd4e.effectData.startTurnInit }}"/>
-
-            </div>
-        </div>
+        </div>-->
     </section>
 
     <!-- Effects Tab -->

--- a/templates/sheets/active-effect-config.html
+++ b/templates/sheets/active-effect-config.html
@@ -120,7 +120,8 @@
 			</div>
 		{{/if}}
 
-		{{#if effect.flags.dnd4e.effectData.durationType}}
+		{{#if effect.flags.dnd4e.effectData.durationType}}{{!-- Prevents duration display for passive effects --}}
+		{{#if data.duration.startRound}}{{!-- Prevents duration display for power effects which aren't yet applied --}}
 		
 			<div class="form-group effect-start">
 				<label>{{ localize 'EFFECT.StartTime' }}</label>
@@ -153,6 +154,8 @@
 			{{/unless}}
 			{{/unless}}
 			{{/unless}}
+			
+		{{/if}}
 		{{/if}}
 		
         <!--<div class="form-group">


### PR DESCRIPTION
### Improves item macro behaviour & usability
Finally a way to enable modal power behaviour. As in we can do Augmentable now without needing duplicate powers! :D
- Adds async to item's executeMacro function, and await to macro activation during power usage. This allows the chat card to wait on macros with the pre-power-use trigger, meaning you can manipulate power data before the chat card is printed, which allows for a good amount of modal power behaviour.
- Embeds chat data into the chat card for all items, not just for items deleted during use. This allows macros better manipulation of powers at roll-time.
- Previously, applying effects from the chat card would fail if the source item had been expended/deleted; now the function uses embedded data instead. Since I changed item rolls to always embed power data, all chat cards can use embedded data, so for the moment I have used this method for all cards. However, there might be a reason to use live data instead if available. I've commented the old line instead of removing it, in case it needs to be reinstated.

Of course, a system-specific implementation of modal powers would be better, but that's a big project and this is pretty low-hanging fruit by comparison :)

This could be further improved by adding item macro triggers for attack and damage rolls as well!

### Improves effect duration handling
Updates the Duration tab on effect sheets to better reflect the chosen duration setting. This should make effect config less confusing for users.
- Disambiguates user-entered custom duration info and system-provided expiry timing
- Hides fields not relevant to the current duration type (e.g. no "effect ends" for save ends duration).
- Enables custom duration type to use user-entered rounds/turns values if provided. Null values are still valid for temporary effects with no defined expiry (we should make sure to keep this behaviour, for the sake of differentiation between passive and temporary effects).
- Hides start/end times for effects which are still awaiting application (e.g. will be applied on power use)

### Misc
- Fixes a bug in the multiroll dialogue which caused an error in attacks not based on a stat (ie NPC-style flat formula rolls)
- Fixes a bug where short/extended rest routines would fail for NPCs using the newer data model