### PR TITLE
Add "vs Bloodied" common attack bonus

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -209,6 +209,7 @@
 "DND4E.CommonAttackBonusesConfig": "Bonus to attacks—{condition}",
 "DND4E.CommonAttackBonusesConfigTip": "Configure the bonuses and penalties this creature receives for attacking under specific conditions.",
 "DND4E.CommonAttackBasic": "Basic Attack",
+"DND4E.CommonAttackBloodied": "vs Bloodied",
 "DND4E.CommonAttackComAdv": "Combat Advantage",
 "DND4E.CommonAttackCharge": "Charge",
 "DND4E.CommonAttackConceal": "vs Concealment",

--- a/lang/en.json
+++ b/lang/en.json
@@ -209,6 +209,7 @@
 "DND4E.CommonAttackBonusesConfig": "Bonus to attacks—{condition}",
 "DND4E.CommonAttackBonusesConfigTip": "Configure the bonuses and penalties this creature receives for attacking under specific conditions.",
 "DND4E.CommonAttackBasic": "Basic Attack",
+"DND4E.CommonAttackBloodied": "vs Bloodied",
 "DND4E.CommonAttackComAdv": "Combat Advantage",
 "DND4E.CommonAttackCharge": "Charge",
 "DND4E.CommonAttackConceal": "vs Concealment",

--- a/module/config.js
+++ b/module/config.js
@@ -584,6 +584,7 @@ preLocalize("consumableTypes", { keys: ["label"] });
 
 /* -------------------------------------------- */
 DND4E.commonAttackBonuses = {
+	bloodied: {value: 0, label:"DND4E.CommonAttackBloodied"},
 	comAdv: {value: 2, label:"DND4E.CommonAttackComAdv"},
 	charge: {value: 1, label:"DND4E.CommonAttackCharge"},
 	conceal: {value: -2, label:"DND4E.CommonAttackConceal"},

--- a/module/dice.js
+++ b/module/dice.js
@@ -238,6 +238,8 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 				//Target conditions
 				if(targetStatus.filter(element => ['blinded','dazed','dominated','helpless','restrained','stunned','surprised','squeezing','running','grantingCA'].includes(element)).length > 0) targetBonuses.push('@comAdv');
 				
+				if(targetStatus.includes('bloodied')) targetBonuses.push('@bloodied');
+
 				if(targetStatus.includes('concealed')) targetBonuses.push('@conceal');		
 				
 				if(targetStatus.includes('concealedTotal')) targetBonuses.push('@concealTotal');

--- a/template.json
+++ b/template.json
@@ -626,6 +626,15 @@
 					"immunities" : []
 				},
 				"commonAttackBonuses": {
+					"bloodied": {
+						"value": 0,
+						"feat": 0,
+						"item": 0,
+						"power": 0,
+						"race": 0,
+						"untyped": 0,
+						"bonus": [{}]
+					},
 					"comAdv": {
 						"value": 2,
 						"feat": 0,

--- a/templates/chat/roll-dialog.html
+++ b/templates/chat/roll-dialog.html
@@ -73,6 +73,10 @@
 					{{!-- Only if targets are provided --}}
 						{{#if ../../targetData.hasTarget}}
 							
+                            {{#if (eq b 'bloodied')}}
+                                {{#if (contains 'bloodied' t.status)}}checked="true"{{/if}}
+							{{/if}}
+
 							{{#if (eq b 'comAdv')}}
 								{{#if (contains 'dazed' t.status)}}checked="true"{{/if}}
 								{{#if (contains 'blinded' t.status)}}checked="true"{{/if}}


### PR DESCRIPTION
Motivated entirely by tieflings' Bloodhunt feature. My tiefling player actually remembered to mention that she gets the bonus and I was so proud of her for knowing her character, but with this she won't have to.