### PR TITLE
Add "per turn" consumption type

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1212,6 +1212,7 @@
 "DND4E.TraitWeaponProf": "Weapon Proficiencies",
 "DND4E.Transmutation": "Transmutation",
 "DND4E.Trigger": "Trigger",
+"DND4E.Turn": "Turn",
 "DND4E.Type": "Type",
 "DND4E.Unequipped": "Not Equipped",
 "DND4E.Unlimited": "Unlimited",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1212,6 +1212,7 @@
 "DND4E.TraitWeaponProf": "Weapon Proficiencies",
 "DND4E.Transmutation": "Transmutation",
 "DND4E.Trigger": "Trigger",
+"DND4E.Turn": "Turn",
 "DND4E.Type": "Type",
 "DND4E.Unequipped": "Not Equipped",
 "DND4E.Unlimited": "Unlimited",

--- a/module/apps/turns.js
+++ b/module/apps/turns.js
@@ -14,7 +14,8 @@ export class Turns{
 		
 		//t current turn
 		for(let t of game.combat.turns){
-			
+			Helper.rechargeItems(t.token?.actor, ["turn"]);
+
 			if(!t.token?.actor?.effects){
 				continue;
 			}

--- a/module/config.js
+++ b/module/config.js
@@ -311,7 +311,8 @@ DND4E.limitedUsePeriods = {
 	"enc": {label: "DND4E.Encounter"},
 	"day": {label: "DND4E.Day"},
 	"charges": {label: "DND4E.Charges"},
-	"round": {label: "DND4E.Round"}
+	"round": {label: "DND4E.Round"},
+	"turn": {label: "DND4E.Turn"}
 };
 preLocalize("limitedUsePeriods", { keys: ["label"] });
 


### PR DESCRIPTION
This is for features like Sneak Attack or Blurred Step (yes I have a rogue and a battlemind in my group why do you ask) that can be used once per turn.