### PR TITLE
Add field to Powers for "Attack Text Details"

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -127,6 +127,7 @@
 "DND4E.ArmourProfShieldHeavy": "Heavy Shield",
 "DND4E.Attack": "Attack",
 "DND4E.AttackDetails": "Attack Details",
+"DND4E.AttackDetailsText": "Attack Text Details",
 "DND4E.AttackModeCharge": "Roll as Charge",
 "DND4E.AttackModeOpp": "Roll as Opportunity Attack",
 "DND4E.AttackPl": "Attacks",

--- a/lang/en.json
+++ b/lang/en.json
@@ -127,6 +127,7 @@
 "DND4E.ArmourProfShieldHeavy": "Heavy Shield",
 "DND4E.Attack": "Attack",
 "DND4E.AttackDetails": "Attack Details",
+"DND4E.AttackDetailsText": "Attack Text Details",
 "DND4E.AttackModeCharge": "Roll as Charge",
 "DND4E.AttackModeOpp": "Roll as Opportunity Attack",
 "DND4E.AttackPl": "Attacks",

--- a/module/helper.js
+++ b/module/helper.js
@@ -1107,22 +1107,29 @@ export class Helper {
 				attackTotal = game.i18n.localize("DND4E.Attack");
 			}
 			
-			if(chatData.attack.ability === "form"){				
-				powerDetail += `<p class="attack"><strong>${game.i18n.localize("DND4E.Attack")}:</strong> <a class="attack-bonus" data-tooltip="${attackValues}">${attackTotal}</a>`;
+			if(chatData.attack.detail) {
+				let attackDetail = chatData.attack.detail.replaceAll('@attackValues', `${attackValues}`);
+				attackDetail = attackDetail.replaceAll('@attackTotal', `${attackTotal}`);
+				powerDetail += `<p class="attack"><strong>${game.i18n.localize("DND4E.Attack")}:</strong> ${attackDetail}</p>`;
 			}
-			else if(chatData.attack.ability){
-				powerDetail += `<p class="attack"><strong>${game.i18n.localize("DND4E.Attack")}</strong>: <a class="attack-bonus" data-tooltip="`;		
-				if(game.settings.get("dnd4e","cardAtkDisplay")=="bonus"){
-					powerDetail += `${CONFIG.DND4E.abilities[chatData.attack.ability]} (${attackValues})">${attackTotal}</a>`;
-				} else if (game.settings.get("dnd4e","cardAtkDisplay")=="both"){
-					powerDetail += `(${attackValues})">${CONFIG.DND4E.abilities[chatData.attack.ability]} (${attackTotal})</a>`;
-				} else{
-					powerDetail += `${attackTotal} (${attackValues})">${CONFIG.DND4E.abilities[chatData.attack.ability]}</a>`;
+			else {
+				if(chatData.attack.ability === "form"){				
+					powerDetail += `<p class="attack"><strong>${game.i18n.localize("DND4E.Attack")}:</strong> <a class="attack-bonus" data-tooltip="${attackValues}">${attackTotal}</a>`;
 				}
-			} else {
-				powerDetail += `<p class="attack"><strong>${game.i18n.localize("DND4E.Attack")}</strong>: ${game.i18n.localize("DND4E.Attack")}`;
+				else if(chatData.attack.ability){
+					powerDetail += `<p class="attack"><strong>${game.i18n.localize("DND4E.Attack")}</strong>: <a class="attack-bonus" data-tooltip="`;		
+					if(game.settings.get("dnd4e","cardAtkDisplay")=="bonus"){
+						powerDetail += `${CONFIG.DND4E.abilities[chatData.attack.ability]} (${attackValues})">${attackTotal}</a>`;
+					} else if (game.settings.get("dnd4e","cardAtkDisplay")=="both"){
+						powerDetail += `(${attackValues})">${CONFIG.DND4E.abilities[chatData.attack.ability]} (${attackTotal})</a>`;
+					} else{
+						powerDetail += `${attackTotal} (${attackValues})">${CONFIG.DND4E.abilities[chatData.attack.ability]}</a>`;
+					}
+				} else {
+					powerDetail += `<p class="attack"><strong>${game.i18n.localize("DND4E.Attack")}</strong>: ${game.i18n.localize("DND4E.Attack")}`;
+				}
+				powerDetail += ` ${game.i18n.localize("DND4E.VS")} ${CONFIG.DND4E.defensives[chatData.attack.def].abbreviation}</p>`;
 			}
-			powerDetail += ` ${game.i18n.localize("DND4E.VS")} ${CONFIG.DND4E.defensives[chatData.attack.def].abbreviation}</p>`;
 		}
 
 		if (chatData.hit.detail){

--- a/template.json
+++ b/template.json
@@ -1087,6 +1087,7 @@
 					"abilityBonus": 0,
 					"def": "ac",
 					"defBonus": 0,
+					"detail": "",
 					"formula": "@wepAttack + @powerMod + @lvhalf"
 				},
 				"hit": {

--- a/templates/items/parts/item-power-template.html
+++ b/templates/items/parts/item-power-template.html
@@ -197,6 +197,11 @@
 	</div>
 
 	<div class="form-group stacked">
+		<label>{{ localize "DND4E.AttackDetailsText" }}</label>
+		<input type="text" name="system.attack.detail" value="{{system.attack.detail}}" placeholder="{{ localize 'DND4E.PowerTextFieldsPlaceholder'}}"/>
+	</div>
+
+	<div class="form-group stacked">
 		<label>{{ localize "DND4E.FormulaAttack" }}</label>
 		<input type="text" name="system.attack.formula" value="{{system.attack.formula}}"/>
 	</div>


### PR DESCRIPTION
This field is to accommodate powers such as the rogue's Jumping Blade Assault and Shadow Steel Roll, which include additional details in their Attack lines. The existing behavior is defaulted to if nothing is entered into this field.

'@attackValues' and '@attackTotal' are provided as helpers so that the existing tooltip behavior is still possible with custom text entered into this field.

Example use:
`<a class="attack-bonus" data-tooltip="@attackTotal (@attackValues)">Dexterity</a> vs. AC</p><p class="white indent"><strong>Artful Dodger:</strong> If you use this power as part of a charge, you can target Reflex instead of AC.`
produces:
<img width="664" height="104" alt="image" src="https://github.com/user-attachments/assets/12bfde44-e11e-4237-a650-e1bbcc7704e9" />