### PR TITLE
Fix issue causing self-applied effects to fail to be applied

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -361,14 +361,14 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 	
 		if(game.settings.get("dnd4e", "autoApplyEffects")){
 			if(targetData.targetHit.length){
-				Helper.applyEffectsToTokens(options.powerEffects, targetData.targetHit, "hit", options.parent);
-				Helper.applyEffectsToTokens(options.powerEffects, targetData.targetHit, "hitOrMiss", options.parent);
-				Helper.applyEffectsToTokens(options.powerEffects, [options.parent], "selfHit", options.parent);
+				Helper.applyEffectsToTokens(options.powerEffects, targetData.targetHit, "hit", attacker);
+				Helper.applyEffectsToTokens(options.powerEffects, targetData.targetHit, "hitOrMiss", attacker);
+				Helper.applyEffectsToTokens(options.powerEffects, [attacker], "selfHit", attacker);
 			}
 			if(targetData.targetMissed.length){
-				Helper.applyEffectsToTokens(options.powerEffects, targetData.targetMissed, "miss", options.parent);
-				Helper.applyEffectsToTokens(options.powerEffects, targetData.targetMissed, "hitOrMiss", options.parent);
-				Helper.applyEffectsToTokens(options.powerEffects, [options.parent], "selfMiss", options.parent);
+				Helper.applyEffectsToTokens(options.powerEffects, targetData.targetMissed, "miss", attacker);
+				Helper.applyEffectsToTokens(options.powerEffects, targetData.targetMissed, "hitOrMiss", attacker);
+				Helper.applyEffectsToTokens(options.powerEffects, [attacker], "selfMiss", attacker);
 			}
 		}
 	}
@@ -376,7 +376,7 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 	// Move this so that it only gets called when attacks are made, not all d20 rolls?
 	if(options.powerEffects && game.settings.get("dnd4e", "autoApplyEffects")) {
 		// Always apply these effects after the attack, even if the player forgot to select targets
-		Helper.applyEffectsToTokens(options.powerEffects, [options.parent], "selfAfterAttack", options.parent);
+		Helper.applyEffectsToTokens(options.powerEffects, [attacker], "selfAfterAttack", attacker);
 	}
 
 	// Convert the roll to a chat message and return the roll


### PR DESCRIPTION
`attacker` was created as a variable but never used, causing errors when trying to call `newActiveEffect` on a string.