### PR TITLE
Fix `@powMax` when there's no weapon

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -806,6 +806,7 @@ export class Helper {
 			if(newFormula.includes("@powMax")) {
 				let dice = "";
 				let quantity = powerInnerData.hit.baseQuantity;
+				quantity = this.commonReplace(quantity, actorData, powerInnerData, weaponInnerData, 0)
 				let diceType = powerInnerData.hit.baseDiceType.toLowerCase();
 				let rQuantity = new Roll(`${quantity}`)
 				rQuantity.evaluateSync({maximize: true});


### PR DESCRIPTION
Noticed that @powMax wasn't working for my Sneak Attack crit line, and now I know why.