### PR TITLE
Improved trait selector dropdown

### DIFF
--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -2542,23 +2542,22 @@ font-size:12px;
 	height:18px;
 	margin:2px;
 }
+#trait-selector .trait.has-children .trait-list{
+	columns:2;
+}
 #trait-selector .trait-list .trait.has-children>.expand{
 	font-size:0.8em;
 	opacity:0.75;
 }
-#trait-selector .trait-list .trait.has-children>.expand:focus-within{
-	pointer-events:none;
-}
-#trait-selector .trait-list .trait.has-children>.expand:focus-within.fa-chevron-down::before{
+#trait-selector .trait-list .trait.has-children>.expand.fa-chevron-down.toggle-on::before{
     content:"\f077";
 }
-#trait-selector .trait-list .trait.has-children>.trait-list{
-	max-height:0;
-	overflow-y:hidden;
-	transition:max-height 0.3s;
+#trait-selector .trait-list .trait.has-children .trait{
+	display:none;
 }
-#trait-selector .trait-list .trait.has-children>.expand:focus-within~.trait-list{
-	max-height:calc(100vh + 10em);
+#trait-selector .trait-list .trait.has-children>.expand.toggle-on~.trait-list .trait,
+#trait-selector .trait-list .trait.has-children .trait.toggle-on{
+	display:block;
 }
 /* Tooltip text */
 .tooltip .tooltipcontent{

--- a/templates/apps/trait-selector.html
+++ b/templates/apps/trait-selector.html
@@ -3,13 +3,13 @@
     {{#*inline "traitList"}}
     <ol class="trait-list">
         {{#each choices as |choice key|}}
-        <li class="trait{{#if choice.children}} has-children{{/if}}">
+        <li class="trait toggleable{{#if choice.children}} has-children{{/if}}{{#if choice.chosen}} toggle-on{{/if}}" tabindex="-1">
             <label class="checkbox">
-                <input type="checkbox" name="{{key}}" data-dtype="Boolean" {{checked choice.chosen}}>
+                <input type="checkbox" name="{{key}}" data-dtype="Boolean" {{checked choice.chosen}} onclick="toggle()">
                 {{choice.label}}
             </label>
             {{#if choice.children}}
-			  <i tabindex="0" class="expand fa-solid fa-chevron-down"></i>
+			  <i tabindex="1" class="expand fa-solid fa-chevron-down toggleable" onclick="toggle()"></i>
               {{> traitList choices=choice.children}}
             {{/if}}
         </li>
@@ -26,3 +26,10 @@
     {{/if}}
     <button type="submit" name="submit" value="1"><i class="far fa-save"></i> {{ localize "DND4E.TraitSave"}}</button>
 </form>
+
+<script>
+	function toggle() {		
+		target = event.srcElement.closest(".toggleable");	
+		target.classList.toggle("toggle-on");
+	}
+</script>


### PR DESCRIPTION
PuloDoGato on Discord noticed that dropdowns were not working as intended when you selected items from a child-list. This should correct that, with the added benefit of also displaying selected child-items even when their containing list is collapsed.