### PR TITLE
Fix mistaken isCharge check when assessing the relevance of the `opp` key word.

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -340,7 +340,7 @@ export class Helper {
 				};
 				
 				if(powerInnerData.attack?.isCharge || rollData?.isCharge) suitableKeywords.push("charge");
-				if(powerInnerData.attack?.isOpp || rollData?.isCharge) suitableKeywords.push("opp");
+				if(powerInnerData.attack?.isOpp || rollData?.isOpp) suitableKeywords.push("opp");
 				
 				if(powerInnerData.attack?.def){
 					suitableKeywords.push(`vs${powerInnerData.attack.def.capitalize()}`);


### PR DESCRIPTION
This code was checking the roll data for a charge instead of an AoO.

Closes #491