### PR TITLE
Improved Melee vs Prone detection

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -350,7 +350,7 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 			let targName = targets[rollExpressionIdx].name;
 			let targDefVal = targets[rollExpressionIdx].document.actor.system.defences[attackedDef]?.value;
 			const defParts = []
-			await Helper.applyEffects([defParts], data, targets[rollExpressionIdx].actor, item, weaponUse, "defense");
+			await Helper.applyEffects([defParts], data, targets[rollExpressionIdx].actor, item, weaponUse, "defence");
 			for (let i=0; i < defParts.length; i++) {
 				const key = defParts[i].slice(1);
 				targDefVal += data[key];

--- a/module/dice.js
+++ b/module/dice.js
@@ -61,16 +61,17 @@ export async function d20Roll({parts=[],  partsExpressionReplacements = [], item
 			const targName = targetArr[targ].name;
 			targDataArray.targNameArray.push(targName);
 			//console.debug(data);
-			if(targetArr[targ].actor.statuses.has('prone') && (item?.system.rangeType === 'melee' || weaponUse?.system.weaponType.slice(-1) === 'M')) {
-				let isThrown = false;
-				if (weaponUse?.system.properties.thv || weaponUse?.system.properties.tlg) {
-					const meleeRange = weaponUse.system.properties.rch ? 2 : 1;
-					if (Helper.computeDistance(actor, targetArr[targ]) > meleeRange) {
-						isThrown = true;
+			if(targetArr[targ].actor.statuses.has('prone') && (['melee','touch','reach'].includes(item?.system.rangeType) || (item?.system.rangeType === 'weapon' && weaponUse?.system.weaponType.slice(-1) === 'M'))) {
+				targDataArray.meleeVsProne = true;
+				if(item?.system.rangeType === 'weapon'){
+					let isThrown = false;
+					if (weaponUse?.system.properties.thv || weaponUse?.system.properties.tlg) {
+						const meleeRange = weaponUse.system.properties.rch ? 2 : 1;
+						if (Helper.computeDistance(actor, targetArr[targ]) > meleeRange) {
+							//Not in melee range so it must have been thrown
+							targDataArray.meleeVsProne = false;
+						}
 					}
-				}
-				if (!isThrown) {
-					targDataArray.meleeVsProne = true;
 				}
 			}
 			targDataArray.targets.push({
@@ -349,7 +350,7 @@ async function performD20RollAndCreateMessage(form, {parts, partsExpressionRepla
 			let targName = targets[rollExpressionIdx].name;
 			let targDefVal = targets[rollExpressionIdx].document.actor.system.defences[attackedDef]?.value;
 			const defParts = []
-			await Helper.applyEffects([defParts], data, targets[rollExpressionIdx].actor, item, weaponUse, "defence");
+			await Helper.applyEffects([defParts], data, targets[rollExpressionIdx].actor, item, weaponUse, "defense");
 			for (let i=0; i < defParts.length; i++) {
 				const key = defParts[i].slice(1);
 				targDefVal += data[key];


### PR DESCRIPTION
Just a few tweaks to SagaTympana's work on melee vs. prone detection:
- Now includes `reach` and `touch` power ranges in the check, since they are melee "subtypes"
- Now only checks the weapon's range if the power inherits it; prevents false positive when using melee weapon with non-melee power (e.g. weapliment use, melee-weapon close burst etc.)
- Now only checks for thrown/reach/distance if the power inherits weapon range (no big problems, just a bit more efficient)