### PR TITLE
Add option for area powers to auto target tokens within their placed templates

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -142,7 +142,7 @@
 "DND4E.Attuned": "Attuned",
 "DND4E.Augmentable": "Augmentable",
 "DND4E.AutoTarget": "Auto Target",
-"DND4E.AutoTargetIncludeUser": "Include User",
+"DND4E.AutoTargetIncludeSelf": "Include User",
 "DND4E.Aura": "Aura",
 "DND4E.AutoanimationHookAttack": "On Attack",
 "DND4E.AutoanimationHookDamage": "On Damage",

--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -141,6 +141,8 @@
 "DND4E.Attributes": "Attributes",
 "DND4E.Attuned": "Attuned",
 "DND4E.Augmentable": "Augmentable",
+"DND4E.AutoTarget": "Auto Target",
+"DND4E.AutoTargetIncludeUser": "Include User",
 "DND4E.Aura": "Aura",
 "DND4E.AutoanimationHookAttack": "On Attack",
 "DND4E.AutoanimationHookDamage": "On Damage",
@@ -1415,6 +1417,11 @@
 "DND4E.Weight": "Weight",
 "DND4E.WIL": "WILL",
 "DND4E.Zone": "Zone",
+
+"DND4E.AutoTargetModes.None": "None",
+"DND4E.AutoTargetModes.All": "All",
+"DND4E.AutoTargetModes.Allies": "Allies",
+"DND4E.AutoTargetModes.Enemies": "Enemies",
 
 "DND4E.Equipment.Alt.Alt": "Alternative Reward",
 "DND4E.Equipment.Alt.Blessing": "Blessing",

--- a/lang/en.json
+++ b/lang/en.json
@@ -142,7 +142,7 @@
 "DND4E.Attuned": "Attuned",
 "DND4E.Augmentable": "Augmentable",
 "DND4E.AutoTarget": "Auto Target",
-"DND4E.AutoTargetIncludeUser": "Include User",
+"DND4E.AutoTargetIncludeSelf": "Include Self",
 "DND4E.Aura": "Aura",
 "DND4E.AutoanimationHookAttack": "On Attack",
 "DND4E.AutoanimationHookDamage": "On Damage",

--- a/lang/en.json
+++ b/lang/en.json
@@ -141,6 +141,7 @@
 "DND4E.Attributes": "Attributes",
 "DND4E.Attuned": "Attuned",
 "DND4E.Augmentable": "Augmentable",
+"DND4E.AutoTarget": "Auto Target",
 "DND4E.Aura": "Aura",
 "DND4E.AutoanimationHookAttack": "On Attack",
 "DND4E.AutoanimationHookDamage": "On Damage",
@@ -1415,6 +1416,11 @@
 "DND4E.Weight": "Weight",
 "DND4E.WIL": "WILL",
 "DND4E.Zone": "Zone",
+
+"DND4E.AutoTargetModes.None": "None",
+"DND4E.AutoTargetModes.All": "All",
+"DND4E.AutoTargetModes.Allies": "Allies",
+"DND4E.AutoTargetModes.Enemies": "Enemies",
 
 "DND4E.Equipment.Alt.Alt": "Alternative Reward",
 "DND4E.Equipment.Alt.Blessing": "Blessing",

--- a/lang/en.json
+++ b/lang/en.json
@@ -142,6 +142,7 @@
 "DND4E.Attuned": "Attuned",
 "DND4E.Augmentable": "Augmentable",
 "DND4E.AutoTarget": "Auto Target",
+"DND4E.AutoTargetIncludeUser": "Include User",
 "DND4E.Aura": "Aura",
 "DND4E.AutoanimationHookAttack": "On Attack",
 "DND4E.AutoanimationHookDamage": "On Damage",

--- a/module/config.js
+++ b/module/config.js
@@ -1234,6 +1234,13 @@ DND4E.powerDiceTypes = {
 	"d20": "d20"
 };
 
+DND4E.autoTargetModes = {
+    "none": "None",
+    "all": "All",
+    "allies": "Allies",
+    "enemies": "Enemies"
+}
+
 /* -------------------------------------------- */
 /**
  * Character senses options

--- a/module/dnd4e.js
+++ b/module/dnd4e.js
@@ -413,6 +413,7 @@ Hooks.on('renderCombatTracker', (app,html,context) => {
 });
 
 Hooks.on('createMeasuredTemplate', async (templateDoc) => {
+	if (game.user.id !== templateDoc.author.id) return;
 	const originUuid = templateDoc.getFlag('dnd4e', 'origin');
 	// Item may be deleted from the actor when we get here, so get the item data from the template if we have to
 	const flagDocument = await fromUuid(originUuid) || templateDoc.getFlag('dnd4e', 'item');
@@ -428,6 +429,8 @@ Hooks.on('createMeasuredTemplate', async (templateDoc) => {
 	}
 	let shape = templateDoc.object?.shape;
 	if (!shape) return;
+	game.user.updateTokenTargets();
+	game.user.broadcastActivity({targets: []});
 	const excludeUser = !flagDocument.system.autoTarget.includeUser || flagDocument.system.autoTarget.mode === 'enemies';
 	for (let token of canvas.tokens.placeables) {
 		if ((excludeUser && token.actor.uuid === actorUuid) || token.actor.statuses.has('dead')) continue;

--- a/module/dnd4e.js
+++ b/module/dnd4e.js
@@ -431,7 +431,7 @@ Hooks.on('createMeasuredTemplate', async (templateDoc) => {
 	if (!shape) return;
 	game.user.updateTokenTargets();
 	game.user.broadcastActivity({targets: []});
-	const excludeUser = !flagDocument.system.autoTarget.includeUser || flagDocument.system.autoTarget.mode === 'enemies';
+	const excludeUser = !flagDocument.system.autoTarget.includeSelf || flagDocument.system.autoTarget.mode === 'enemies';
 	for (let token of canvas.tokens.placeables) {
 		if ((excludeUser && token.actor.uuid === actorUuid) || token.actor.statuses.has('dead')) continue;
 		switch (flagDocument.system.autoTarget.mode) {

--- a/module/dnd4e.js
+++ b/module/dnd4e.js
@@ -413,7 +413,6 @@ Hooks.on('renderCombatTracker', (app,html,context) => {
 });
 
 Hooks.on('createMeasuredTemplate', async (templateDoc) => {
-	// TODO
 	const originUuid = templateDoc.getFlag('dnd4e', 'origin');
 	const flagDocument = await fromUuid(originUuid);
 	if (!flagDocument || flagDocument.system.autoTarget.mode === 'none') return;
@@ -452,48 +451,4 @@ Hooks.on('createMeasuredTemplate', async (templateDoc) => {
 				break;
 			}
 	}
-	/*let shape = templateDoc.object?.shape;
-	let scene = templateDoc.parent;
-	let tokens = new Set();
-	if (!shape && !scene) return tokens;
-	let {size} = scene.grid;
-	let sceneTokens = scene.tokens;
-	for (let token of sceneTokens) {
-		let {width, height, x: tokX, y: tokY} = token;
-		let startX = width >= 1 ? 0.5 : width / 2;
-		let startY = height >= 1 ? 0.5 : height / 2;
-		for (let x = startX; x < width; x++) {
-			for (let y = startY; y < width; y++) {
-				let curr = {
-					x: tokX + x * size - templateDoc.x,
-					y: tokY + y * size - templateDoc.y
-				};
-				let contains = shape.contains(curr.x, curr.y);
-				let isOn = shape.getBounds().pointIsOn(curr);
-				if (contains && !isOn) {
-					tokens.add(token.object);
-					continue;
-				}
-			}
-		}
-	}
-	if (tokens.size) {
-		for (const token in tokens) {
-			switch (flagDocument.system.autoTarget) {
-				case 'all':
-					game.user.targets.add(token);
-					break;
-				case 'allies':
-					if (token.document.dispoition === disposition) {
-						game.users.targets.add(token);
-					}
-					break;
-				case 'enemies':
-					if (token.document.disposition === -1 * disposition) {
-						game.users.targets.add(token);
-					}
-					break;
-			}
-		}
-	}*/
 });

--- a/module/dnd4e.js
+++ b/module/dnd4e.js
@@ -423,37 +423,28 @@ Hooks.on('createMeasuredTemplate', async (templateDoc) => {
 	if (!actorUuid) return;
 	const token = Helper.tokenForActor(await fromUuid(actorUuid));
 	if (!token) return;
-	const disposition = token.document.disposition;
-	if (!templateDoc.object.shape) {
-		templateDoc.object._refreshShape();
-	}
-	let shape = templateDoc.object?.shape;
-	if (!shape) return;
 	game.user.updateTokenTargets();
 	game.user.broadcastActivity({targets: []});
+	let tokens = Helper.getTokensInTemplate(templateDoc, true);
+	if (!tokens.size) return;
+	const disposition = token.document.disposition;
 	const excludeUser = !flagDocument.system.autoTarget.includeSelf || flagDocument.system.autoTarget.mode === 'enemies';
-	for (let token of canvas.tokens.placeables) {
-		if ((excludeUser && token.actor.uuid === actorUuid) || token.actor.statuses.has('dead')) continue;
+	for (let targetToken of tokens) {
+		if ((excludeUser && targetToken.actor.uuid === actorUuid) || targetToken.actor.statuses.has('dead')) continue;
 		switch (flagDocument.system.autoTarget.mode) {
 			case 'all':
-				if (shape.contains(token.center.x - templateDoc.x, token.center.y - templateDoc.y)) {
-					token.setTarget(true, { releaseOthers: false });
-				}
+					targetToken.setTarget(true, { releaseOthers: false });
 				break;
 			case 'allies':
-				if (token.document.disposition === disposition) {
-					if (shape.contains(token.center.x - templateDoc.x, token.center.y - templateDoc.y)) {
-						token.setTarget(true, { releaseOthers: false });
-					}
+				if (targetToken.document.disposition === disposition) {
+					targetToken.setTarget(true, { releaseOthers: false });
 				}
 				break;
 			case 'enemies':
-				if (token.document.disposition === -1 * disposition) {
-					if (shape.contains(token.center.x - templateDoc.x, token.center.y - templateDoc.y)) {
-						token.setTarget(true, { releaseOthers: false });
-					}
+				if (targetToken.document.disposition === -1 * disposition) {
+					targetToken.setTarget(true, { releaseOthers: false });
 				}
 				break;
-			}
+		}
 	}
 });

--- a/module/dnd4e.js
+++ b/module/dnd4e.js
@@ -428,7 +428,7 @@ Hooks.on('createMeasuredTemplate', async (templateDoc) => {
 	if (!shape) return;
 	const excludeUser = !flagDocument.system.autoTarget.includeUser || flagDocument.system.autoTarget.mode === 'enemies';
 	for (let token of canvas.tokens.placeables) {
-		if (excludeUser && token.actor.uuid === actorUuid) continue;
+		if ((excludeUser && token.actor.uuid === actorUuid) || token.actor.statuses.has('dead')) continue;
 		switch (flagDocument.system.autoTarget.mode) {
 			case 'all':
 				if (shape.contains(token.center.x - templateDoc.x, token.center.y - templateDoc.y)) {

--- a/module/dnd4e.js
+++ b/module/dnd4e.js
@@ -411,3 +411,7 @@ Hooks.on('renderCombatTracker', (app,html,context) => {
 		console.error(`Inititiave display mask failed in combat tracker. ${e}`);
 	}
 });
+
+Hooks.on('createMeasuredTemplate', async (templateDoc) => {
+    // TODO
+});

--- a/module/helper.js
+++ b/module/helper.js
@@ -1743,10 +1743,9 @@ export class Helper {
 							const r = new Ray(origin, dest);
 							if (wallsBlock) {
 								let collisionCheck;
-								collisionCheck = CONFIG.Canvas.polygonBackends.sight.testCollision(origin, dest, { source: t1.document, mode: "any", type: "sight" });
+								collisionCheck = CONFIG.Canvas.polygonBackends.move.testCollision(origin, dest, { source: t1.document, mode: "any", type: "move" });
 								if (collisionCheck)
 									continue;
-								break;
 							}
 							segments.push({ ray: r });
 						}
@@ -1765,6 +1764,46 @@ export class Helper {
 			distance = this.measureDistances([{ ray: new Ray(t1.center, closestPoint) }], { gridSpaces: true });
 		}
 		return Math.max(distance, 0);
+	}
+
+	static getTokensInTemplate(templateDoc, wallsBlock = false) {
+		const scene = templateDoc.parent;
+		let {size} = scene.grid;
+		if (!templateDoc.object.shape) {
+			templateDoc.object._refreshShape();
+		}
+		let shape = templateDoc.object?.shape;
+		if (!shape) return;
+		let tokens = new Set();
+		let sceneTokens = scene.tokens;
+		for (let token of sceneTokens) {
+			let {width, height, x: tokX, y: tokY} = token;
+			let startX = width >= 1 ? 0.5 : width / 2;
+			let startY = height >= 1 ? 0.5 : height / 2;
+			for (let x = startX; x < width; x++) {
+				for (let y = startY; y < width; y++) {
+					let curr = {
+						x: tokX + x * size - templateDoc.x,
+						y: tokY + y * size - templateDoc.y
+					};
+					let contains = shape.contains(curr.x, curr.y);
+					let isOn = shape.getBounds().pointIsOn(curr);
+					if (contains && !isOn) {
+						if (wallsBlock) {
+							let collisionCheck;
+							const originPoint = new PIXI.Point(templateDoc.x, templateDoc.y);
+							const targetPoint = new PIXI.Point(tokX + x * size, tokY + y * size);
+							collisionCheck = CONFIG.Canvas.polygonBackends.move.testCollision(originPoint, targetPoint, { source: templateDoc, mode: "any", type: "move" });
+							if (collisionCheck)
+								continue;
+						}
+						tokens.add(token.object);
+						continue;
+					}
+				}
+			}
+		}
+		return tokens;
 	}
 }
 

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -108,6 +108,7 @@ export default class ItemSheet4e extends ItemSheet {
 		if(itemData.system?.rangeType) {
 			if(!["personal","closeBurst","closeBlast","","touch"].includes(itemData.system.rangeType)) itemData.system.isRange = true;
 			if(["closeBurst","closeBlast","rangeBurst","rangeBlast","wall"].includes(itemData.system.rangeType)) itemData.system.isArea = true;
+			if(["none", "enemies"].includes(itemData.system.autoTarget.mode)) itemData.system.excludeUserFromTargeting = true;
 			
 			itemData.system.isRecharge = itemData.system?.useType === "recharge";
 			

--- a/module/pixi/ability-template.js
+++ b/module/pixi/ability-template.js
@@ -34,7 +34,7 @@ export class MeasuredTemplate4e extends MeasuredTemplate {
 		console.log(item);
 		let distance = this.getDistanceCalc(item);
 
-		let flags = {dnd4e:{templateType:templateShape, item}};
+		let flags = {dnd4e:{templateType:templateShape, item, origin:item.uuid}};
 
 		if(item.system.rangeType === "closeBlast" || item.system.rangeType === "rangeBlast") {
 			distance *= Math.sqrt(2);

--- a/template.json
+++ b/template.json
@@ -1189,6 +1189,10 @@
 			},
 			"target": "",
 			"rangeType": "",
+			"autoTarget": {
+				"mode": "none",
+				"includeSelf": true
+			},
 			"attack": {
 				"isAttack": false,
 				"ability": "",

--- a/template.json
+++ b/template.json
@@ -1340,6 +1340,7 @@
 			"weaponType": "melee",
 			"weaponUse": "default",
 			"rangeType": "weapon",
+			"autoTarget": "none",
 			"rangeTextShort": "",
 			"rangeText": "",
 			"rangePower": "",

--- a/template.json
+++ b/template.json
@@ -1340,7 +1340,10 @@
 			"weaponType": "melee",
 			"weaponUse": "default",
 			"rangeType": "weapon",
-			"autoTarget": "none",
+			"autoTarget": {
+				"mode": "none",
+				"includeUser": true
+			},
 			"rangeTextShort": "",
 			"rangeText": "",
 			"rangePower": "",

--- a/template.json
+++ b/template.json
@@ -1342,7 +1342,7 @@
 			"rangeType": "weapon",
 			"autoTarget": {
 				"mode": "none",
-				"includeUser": true
+				"includeSelf": true
 			},
 			"rangeTextShort": "",
 			"rangeText": "",

--- a/templates/items/parts/item-power-template.html
+++ b/templates/items/parts/item-power-template.html
@@ -108,9 +108,11 @@
 		<div class="form-group short">
 			<label>{{ localize "DND4E.AutoTarget" }}</label>
 			<div class="form-fields auto-target">
-				<select name="system.autoTarget">
-					{{selectOptions config.autoTargetModes selected=system.autoTarget}}
+				<select name="system.autoTarget.mode">
+					{{selectOptions config.autoTargetModes selected=system.autoTarget.mode}}
 				</select>
+				<label>{{ localize "DND4E.AutoTargetIncludeUser" }}</label>
+				<span class="checkbox"><input class="checkbox" type="checkbox" name="system.autoTarget.includeUser" data-dtype="Boolean" {{checked system.autoTarget.includeUser}}/></span>
 			</div>
 		</div>
 	{{/if}}

--- a/templates/items/parts/item-power-template.html
+++ b/templates/items/parts/item-power-template.html
@@ -104,6 +104,17 @@
 		</div>
 	</div>
 
+	{{#if system.isArea}}
+		<div class="form-group short">
+			<label>{{ localize "DND4E.AutoTarget" }}</label>
+			<div class="form-fields auto-target">
+				<select name="system.autoTarget">
+					{{selectOptions config.autoTargetModes selected=system.autoTarget}}
+				</select>
+			</div>
+		</div>
+	{{/if}}
+
 	<div class="form-group">
 		<label>{{ localize "DND4E.Requirements" }}</label>
 		<div class="form-fields">

--- a/templates/items/parts/item-power-template.html
+++ b/templates/items/parts/item-power-template.html
@@ -112,8 +112,8 @@
 					{{selectOptions config.autoTargetModes selected=system.autoTarget.mode}}
 				</select>
 				{{#unless system.excludeUserFromTargeting}}
-					<label>{{ localize "DND4E.AutoTargetIncludeUser" }}</label>
-					<span class="checkbox"><input class="checkbox" type="checkbox" name="system.autoTarget.includeUser" data-dtype="Boolean" {{checked system.autoTarget.includeUser}}/></span>
+					<label>{{ localize "DND4E.AutoTargetIncludeSelf" }}</label>
+					<span class="checkbox"><input class="checkbox" type="checkbox" name="system.autoTarget.includeSelf" data-dtype="Boolean" {{checked system.autoTarget.includeSelf}}/></span>
 				{{/unless}}
 			</div>
 		</div>

--- a/templates/items/parts/item-power-template.html
+++ b/templates/items/parts/item-power-template.html
@@ -111,8 +111,10 @@
 				<select name="system.autoTarget.mode">
 					{{selectOptions config.autoTargetModes selected=system.autoTarget.mode}}
 				</select>
-				<label>{{ localize "DND4E.AutoTargetIncludeUser" }}</label>
-				<span class="checkbox"><input class="checkbox" type="checkbox" name="system.autoTarget.includeUser" data-dtype="Boolean" {{checked system.autoTarget.includeUser}}/></span>
+				{{#unless system.excludeUserFromTargeting}}
+					<label>{{ localize "DND4E.AutoTargetIncludeUser" }}</label>
+					<span class="checkbox"><input class="checkbox" type="checkbox" name="system.autoTarget.includeUser" data-dtype="Boolean" {{checked system.autoTarget.includeUser}}/></span>
+				{{/unless}}
 			</div>
 		</div>
 	{{/if}}


### PR DESCRIPTION
Dependent on #498 (technically already includes it 'cause I needed it to actually test)

This adds a new dropdown to powers with areas of effect that drives some auto-targeting behavior. The valid modes are `none` (default behavior, no change from current), `all`, `allies`, and `enemies`. Additionally, there's a checkbox for whether or not the user should be included as a potential target. When the template is placed, tokens within its bounds will be automatically targeted based on the appropriate rules.