### PR TITLE
Fix attack roll chat card select hit behavior

### DIFF
--- a/module/chat.js
+++ b/module/chat.js
@@ -324,7 +324,7 @@ function selectTargetTokens(li, targetType){
 	if(targetType === "hit"){
 		console.log("hit")
 		for(const roll of message.rolls){
-			if(['hit','crit'].includes(roll.options.multirollData.hitstate)){
+			if(['hit','critical'].includes(roll.options.multirollData.hitstate)){
 				canvas.tokens.get(roll.options.multirollData.targetID).control({releaseOthers: false});
 			}
 		}


### PR DESCRIPTION
The "select hit targets" context option was not selecting targets that suffered crits.

Closes #507 