### PR TITLE
Suggest combat advantage from prone/flanking per target

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -62,30 +62,36 @@ export async function d20Roll({parts=[],  partsExpressionReplacements = [], item
 			targDataArray.targNameArray.push(targName);
 			const targetDist = Helper.computeDistance(actor, targetArr[targ]);
 			//console.debug(data);
+			let meleeVsProne = false
 			if (targetArr[targ].actor.statuses.has('prone') && (['melee','touch','reach'].includes(item?.system.rangeType) || (item?.system.rangeType === 'weapon' && weaponUse?.system.weaponType.slice(-1) === 'M'))) {
-				targDataArray.meleeVsProne = true;
+				meleeVsProne = true;
 				if(item?.system.rangeType === 'weapon'){
 					if (weaponUse?.system.properties.thv || weaponUse?.system.properties.tlg) {
 						const meleeRange = weaponUse.system.properties.rch ? 2 : 1;
 						if (targetDist > meleeRange) {
 							//Not in melee range so it must have been thrown
-							targDataArray.meleeVsProne = false;
+							meleeVsProne = false;
 						}
 					}
 				}
 			}
+			let longRange = false;
 			if ((item?.system.rangeType === 'range' && item?.system.range.long && targetDist > item?.system.rangePower) || (item?.system.rangeType === 'weapon' && weaponUse?.system.range.long && targetDist > weaponUse?.system.range.value)) {
-				targDataArray.longRange = true;
+				longRange = true;
 			}
+			let isFlanking = false;
 			if (Helper.computeFlankingStatus(Helper.tokenForActor(actor), targetArr[targ])) {
-				targDataArray.isFlanking = true;
+				isFlanking = true;
 			}
 			targDataArray.targets.push({
 				'name': targetArr[targ].name,
 				'status': targetArr[targ].actor.statuses,
 				'attackMod': data?.item?.attack?.ability || 'str',
 				'attackDef': options.attackedDef || 'ac',
-				'immune': targetArr[targ].actor.system.defences[options.attackedDef]?.none || false
+				'immune': targetArr[targ].actor.system.defences[options.attackedDef]?.none || false,
+				'meleeVsProne': meleeVsProne,
+				'longRange': longRange,
+				'isFlanking': isFlanking
 			});
 		}
 	} else {

--- a/templates/chat/roll-dialog.html
+++ b/templates/chat/roll-dialog.html
@@ -66,7 +66,6 @@
 					{{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if ../../isCharge}}checked="true" disabled{{/if}}{{/if}}
 				
 					{{#if (eq b 'marked')}}{{#if ../../targetData.ignoringMark}}checked="true"{{/if}}{{/if}}
-					{{#if (eq b 'longRange')}}{{#if ../../targetData.longRange}}checked="true"{{/if}}{{/if}}
 				 
 					{{#if (eq b 'prone')}}{{#if (contains 'prone'../../userStatus)}}checked="true"{{/if}}{{/if}}
 					{{#if (eq b 'restrained')}}{{#if (contains 'restrained'../../userStatus)}}checked="true"{{/if}}{{/if}}
@@ -91,8 +90,8 @@
 								{{#if (contains 'squeezing' t.status)}}checked="true"{{/if}}
 								{{#if (contains 'running' t.status)}}checked="true"{{/if}}
 								{{#if (contains 'grantingCA' t.status)}}checked="true"{{/if}}
-								{{#if ../../targetData.meleeVsProne}}checked="true"{{/if}}
-								{{#if ../../targetData.isFlanking}}checked="true"{{/if}}
+								{{#if t.meleeVsProne}}checked="true"{{/if}}
+								{{#if t.isFlanking}}checked="true"{{/if}}
 							{{/if}}
 							
 							{{#if (eq b 'conceal')}}
@@ -109,6 +108,10 @@
 							
 							{{#if (eq b 'coverSup')}}
 								{{#if (contains 'coverSup' t.status)}}checked="true"{{/if}}
+							{{/if}}
+
+							{{#if (eq b 'longRange')}}
+								{{#if t.longRange}}checked="true"{{/if}}
 							{{/if}}
 								
 						{{/if}}


### PR DESCRIPTION
We had mistakenly been suggesting combat advantage from prone or flanking and long range for all targets if appropriate for ANY target. This will now only suggest the relevant checkbox for the specific targets each is relevant to.

Closes #510.