### PR TITLE
Saving Throw enhancements

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -956,6 +956,7 @@
 "DND4E.Round": "Round",
 "DND4E.Runic": "Runic",
 "DND4E.Save": "Save",
+"DND4E.SaveAgainst": "Save Against Effect",
 "DND4E.SavingThrow": "Saving Throw",
 "DND4E.SavingThrowBonus": "Bonuses to Saving Throws",
 "DND4E.SavingThrowMods": "Saving Throw Mods",

--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -956,7 +956,7 @@
 "DND4E.Round": "Round",
 "DND4E.Runic": "Runic",
 "DND4E.Save": "Save",
-"DND4E.SaveAgainst": "Save Against Effect",
+"DND4E.SaveAgainst": "Save Against Effect:",
 "DND4E.SavingThrow": "Saving Throw",
 "DND4E.SavingThrowBonus": "Bonuses to Saving Throws",
 "DND4E.SavingThrowMods": "Saving Throw Mods",

--- a/lang/en.json
+++ b/lang/en.json
@@ -956,6 +956,7 @@
 "DND4E.Round": "Round",
 "DND4E.Runic": "Runic",
 "DND4E.Save": "Save",
+"DND4E.SaveAgainst": "Save Against Effect",
 "DND4E.SavingThrow": "Saving Throw",
 "DND4E.SavingThrowBonus": "Bonuses to Saving Throws",
 "DND4E.SavingThrowMods": "Saving Throw Mods",

--- a/lang/en.json
+++ b/lang/en.json
@@ -956,7 +956,7 @@
 "DND4E.Round": "Round",
 "DND4E.Runic": "Runic",
 "DND4E.Save": "Save",
-"DND4E.SaveAgainst": "Save Against Effect",
+"DND4E.SaveAgainst": "Save Against Effect:",
 "DND4E.SavingThrow": "Saving Throw",
 "DND4E.SavingThrowBonus": "Bonuses to Saving Throws",
 "DND4E.SavingThrowMods": "Saving Throw Mods",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -407,19 +407,22 @@ export class Actor4e extends Actor {
 		//Normal Saving Throw
 		if(isNaN(parseInt(system.details.saves?.absolute))){ //All logic only required if there is no usable absolute value
 	
+			let bonusValue = 0;
 			if(!(system.details.saves.bonus.length === 1 && jQuery.isEmptyObject(system.details.saves.bonus[0]))) {
 				for( const b of system.details.saves.bonus) {
 					if(b.active && Helper._isNumber(b.value)) {
-						system.details.saves.value += parseInt(b.value);
+						bonusValue += parseInt(b.value);
 					}
 					else if(b.active){
 						let val = Helper.replaceData(b.value,system)
 						if(Helper._isNumber(val)){
-							system.details.saves.value += parseInt(val);
+							bonusValue += parseInt(val);
 						}
 					}
 				}
 			}
+			system.details.saves.bonusValue = bonusValue;
+			system.details.saves.value += bonusValue;
 			system.details.saves.value += system.details.saves?.feat || 0;
 			system.details.saves.value += system.details.saves?.item || 0;
 			system.details.saves.value += system.details.saves?.power || 0;
@@ -1688,16 +1691,24 @@ export class Actor4e extends Actor {
 		}else{
 			message = `${game.i18n.localize("DND4E.RollSave")} ${message}`;
 		}
-		
-		const parts = [this.system.details.saves.value];
-		if (options.save) {
-			parts.push(options.save)
+
+		const parts = [];
+		const partsExpressionReplacements = [];
+		if(options.save) {		
+			parts.push(Helper.commonReplace(options.save, this));
+			partsExpressionReplacements.push({value : options.save, target: parts[0]});
+			// add the substitutions that were used in the expression to the data object for later
+			options.formulaInnerData = Helper.commonReplace(options.save, this, null, null, 1, true);
 		}
+
+		const rollData = this.getRollData();
+		await Helper.applySaveEffects([parts], rollData, this, this.effects.get(options.effectId));
 
 		const rollConfig = foundry.utils.mergeObject({
 			parts,
+			partsExpressionReplacements,
 			actor: this,
-			data: {},
+			data: rollData,
 			title: "",
 			flavor: message,
 			speaker: ChatMessage.getSpeaker({actor: this}),
@@ -1706,8 +1717,10 @@ export class Actor4e extends Actor {
 			rollMode: options.rollMode
 		});
 		rollConfig.event = event;
-		rollConfig.critical = options.dc - this.system.details.saves.value - options.save || 10;
-		rollConfig.fumble = options.dc -1 - this.system.details.saves.value - options.save || 9;
+		
+		rollConfig.critical = 21;
+		rollConfig.fumble = 0;
+		rollConfig.targetValue = Number(options.dc);
 		
 		const saveDC = options.dc || 10;
 		const r = await d20Roll(rollConfig);

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -2478,6 +2478,7 @@ export class Actor4e extends Actor {
 						
 						// Combine the types array into a usable string
 						let types = (dot.typesArray.includes("healing") ? "healing" : dot.typesArray.join(','));
+						// If no type was assigned, treat as untyped/physical
 						if (!types) types = "physical";
 						
 						/* Use logic pinched from ActiveEffect4e.safeEvalEffectValue() to 

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -2477,7 +2477,8 @@ export class Actor4e extends Actor {
 					for (let dot of e.flags.dnd4e.dots){
 						
 						// Combine the types array into a usable string
-						const types = (dot.typesArray.includes("healing") ? "healing" : dot.typesArray.join(','));
+						let types = (dot.typesArray.includes("healing") ? "healing" : dot.typesArray.join(','));
+						if (!types) types = "physical";
 						
 						/* Use logic pinched from ActiveEffect4e.safeEvalEffectValue() to 
 						evaluate variables in "amount" string */

--- a/module/apps/save-throw.js
+++ b/module/apps/save-throw.js
@@ -23,18 +23,18 @@ export class SaveThrowDialog extends DocumentSheet4e {
 		const actor = this.object;
 		if (actor && !options.effectSave) {
 			Array.from(actor.effects).forEach((e) => {
-				if (e.getFlag('dnd4e', 'effectData').durationType === 'saveEnd') savableEffects.push({name: e.name, id: e.id});
+				if (e.flags.dnd4e?.effectData?.durationType === 'saveEnd') savableEffects.push({name: e.name, id: e.id});
 			});
 		}
 		if (savableEffects.length) {
 			savableEffects = [{name: game.i18n.format("DND4E.None"), id:''}].concat(savableEffects);
 		}
 		return {
-			system: this.object.system,
+			system: actor.system,
 			rollModes: CONFIG.Dice.rollModes,
-			effectName: ( options.effectSave ? this.object.effects.get(options.effectId).name : null ),
+			effectName: ( options.effectSave ? actor.effects.get(options.effectId).name : null ),
 			effectId: this.options.saveAgainst,
-			saveDC: ( options.effectSave ? this.object.effects.get(options.effectId).flags.dnd4e?.effectData?.saveDC : this.options.saveDC ),
+			saveDC: ( options.effectSave ? actor.effects.get(options.effectId).flags.dnd4e?.effectData?.saveDC : this.options.saveDC ),
 			savableEffects: savableEffects
 		};
 	}

--- a/module/apps/save-throw.js
+++ b/module/apps/save-throw.js
@@ -19,11 +19,22 @@ export class SaveThrowDialog extends DocumentSheet4e {
 	/** @override */
 	getData() {
 		const options = this.options;
+		let savableEffects = [];
+		const actor = this.object;
+		if (actor && !options.effectSave) {
+			Array.from(actor.effects).forEach((e) => {
+				if (e.getFlag('dnd4e', 'effectData').durationType === 'saveEnd') savableEffects.push({name: e.name, id: e.id});
+			});
+		}
+		if (savableEffects.length) {
+			savableEffects = [{name: game.i18n.format("DND4E.None")}].concat(savableEffects);
+		}
 		return {
 			system: this.object.system,
 			rollModes: CONFIG.Dice.rollModes,
 			effectName: ( options.effectSave ? this.object.effects.get(options.effectId).name : null ),
-			saveDC: ( options.effectSave ? this.object.effects.get(options.effectId).flags.dnd4e?.effectData?.saveDC : null )
+			saveDC: ( options.effectSave ? this.object.effects.get(options.effectId).flags.dnd4e?.effectData?.saveDC : null ),
+			savableEffects: savableEffects
 		};
 	}
 
@@ -32,6 +43,10 @@ export class SaveThrowDialog extends DocumentSheet4e {
 		options.dc = formData.dc;
 		options.save = formData.save;
 		options.rollMode = formData.rollMode;
+		if (formData.saveAgainst) {
+			options.effectSave = true;
+			options.effectId = formData.saveAgainst
+		}
 
 		this.document.rollSave(event, options);
 	}

--- a/module/apps/save-throw.js
+++ b/module/apps/save-throw.js
@@ -27,15 +27,24 @@ export class SaveThrowDialog extends DocumentSheet4e {
 			});
 		}
 		if (savableEffects.length) {
-			savableEffects = [{name: game.i18n.format("DND4E.None")}].concat(savableEffects);
+			savableEffects = [{name: game.i18n.format("DND4E.None"), id:''}].concat(savableEffects);
 		}
 		return {
 			system: this.object.system,
 			rollModes: CONFIG.Dice.rollModes,
 			effectName: ( options.effectSave ? this.object.effects.get(options.effectId).name : null ),
-			saveDC: ( options.effectSave ? this.object.effects.get(options.effectId).flags.dnd4e?.effectData?.saveDC : null ),
+			effectId: this.options.saveAgainst,
+			saveDC: ( options.effectSave ? this.object.effects.get(options.effectId).flags.dnd4e?.effectData?.saveDC : this.options.saveDC ),
 			savableEffects: savableEffects
 		};
+	}
+
+	async _onChangeInput(event) {
+		const target = event.target;
+		if (target?.name !== "saveAgainst") return;
+		this.options.saveDC = this.object.effects.get(target.value)?.flags.dnd4e?.effectData?.saveDC;
+		this.options.saveAgainst = target.value;
+		this.render();
 	}
 
 	async _updateObject(event, formData) {

--- a/module/chat.js
+++ b/module/chat.js
@@ -20,7 +20,7 @@ export const highlightCriticalSuccessFailure = function(message, html, data) {
 
 		// Highlight successes and failures
 		const critical = d.options.critical || 20;
-		const fumble = d.options.fumble || 1;
+		const fumble = typeof(d.options.fumble) === 'number' ? d.options.fumble : 1;
 		if ( d.total >= critical ) {
 			html.find(`.dice-total`)[i].classList.add("critical");
 		}

--- a/module/helper.js
+++ b/module/helper.js
@@ -429,6 +429,10 @@ export class Helper {
 					statuses.forEach((s) => suitableKeywords.push(s));
 				}
 
+				if (effectData?.flags.dnd4e?.dots.length) {
+					suitableKeywords.push('ongoing');
+				}
+
 				if (debug) {
 					console.debug(rollData);
 					console.debug(`${debug} based on effect keywords the following effect keys are suitable`);

--- a/module/helper.js
+++ b/module/helper.js
@@ -431,6 +431,13 @@ export class Helper {
 
 				if (effectData?.flags.dnd4e?.dots.length) {
 					suitableKeywords.push('ongoing');
+					effectData.flags.dnd4e.dots.forEach((d) => {
+						d.typesArray.forEach((t) => {
+							suitableKeywords.push(t);
+							// Since game text describes this as "untyped" let's allow users to use that language in effect keys.
+							if (t === 'physical') suitableKeywords.push('untyped');
+						})
+					});
 				}
 
 				if (debug) {

--- a/module/helper.js
+++ b/module/helper.js
@@ -362,7 +362,7 @@ export class Helper {
 					console.debug(`${debug} ${suitableKeywords.join(", ")}`);
 				}
 
-				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, debug);
+				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug);
 			}
 		}
 	}
@@ -447,16 +447,16 @@ export class Helper {
 					console.debug(`${debug} ${suitableKeywords.join(", ")}`);
 				}
 
-				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, debug);
+				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, 'save', debug);
 			}
 		}
 	}
 
-	static async _applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, debug) {
+	static async _applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug) {
 		// filter out to just the relevant effects by keyword
 		const matchingEffects = effectsToProcess.filter((effect) => {
 			const keyParts = effect.key.split(".")
-			if (keyParts.length >= 4 && keyParts[1] === 'save'){
+			if (keyParts.length >= 4 && keyParts[1] === effectType){
 				const keywords = keyParts.slice(2, -1);
 				for (const keyword of keywords) {
 					if (!suitableKeywords.includes(keyword)) {

--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -3038,12 +3038,12 @@ span.flavor-text.probable-miss{
 	font-weight:bold;
 }
 .dice-roll .dice-total.success{
-	color:inherit;
+	color:var(--color-text-good);
 	background:#c7d0c0;
 	border:1px solid #006c00;
 }
 .dice-roll .dice-total.failure{
-	color:inherit;
+	color:var(--color-text-bad);
 	background:#ffdddd;
 	border:1px solid #6e0000;
 }

--- a/templates/apps/save-throw.html
+++ b/templates/apps/save-throw.html
@@ -5,6 +5,20 @@
 		{{localize 'DND4E.SavePrompt'}} 
 	{{/if}}
 	</p>
+	{{#unless effectName}}
+	{{#if savableEffects.length}}
+		<div class="form-group">
+			<label>{{ localize "DND4E.SaveAgainst" }}</label>
+			<select name="saveAgainst">
+			{{#select saveAgainst}}
+			{{#each savableEffects as |effect|}}
+				<option value="{{effect.id}}">{{localize effect.name}}</option>
+			{{/each}}
+			{{/select}}
+			</select>
+		</div>
+	{{/if}}
+	{{/unless}}
 	<div class="form-group">
 		<label>{{localize 'DND4E.SaveDCSet'}}:</label>
 		<input type="text" name="dc" value="{{#if saveDC}}{{saveDC}}{{else}}10{{/if}}" placeholder="10" onClick="this.select();"/>

--- a/templates/apps/save-throw.html
+++ b/templates/apps/save-throw.html
@@ -10,11 +10,7 @@
 		<div class="form-group">
 			<label>{{ localize "DND4E.SaveAgainst" }}</label>
 			<select name="saveAgainst">
-			{{#select saveAgainst}}
-			{{#each savableEffects as |effect|}}
-				<option value="{{effect.id}}">{{localize effect.name}}</option>
-			{{/each}}
-			{{/select}}
+				{{selectOptions savableEffects selected=effectId localise=true valueAttr="id" labelAttr="name"}}
 			</select>
 		</div>
 	{{/if}}


### PR DESCRIPTION
Adds a dropdown to the save dialog when rolled from the character sheet allowing the user to select an effect to save against. This dropdown only appears if there are effects that can be ended on a save and the save wasn't already being prompted for a specific effect (as with auto saves).
<img width="634" height="287" alt="image" src="https://github.com/user-attachments/assets/0c4586c0-aabb-4439-9988-735a0f4b8b56" />


Also adds handling for active effect keys of the form `effect.save.[period-separated list of keywords].[bonusType]`

These bonuses apply to saving throws against effects that match the list of keywords in the bonus key. Relevant keywords includes the normal keywords you can add to active effects, custom keywords added to active effects, and conditions or ongoing damage that active effects apply.

For example, a +1 feat bonus to saving throws against fear effects would look like:
`effect.save.fear.feat || Upgrade || 1`

And a power bonus equal to your charisma modifier to saving throws against the dazed condition would look like:
`effect.save.dazed.power || Upgrade || @chaMod`

A +2 untyped bonus to saving throws against ongoing psychic damage may look like:
`effect.save.ongoing.psychic.untyped || Add || 2`

I've also changed how success/failure coloring is handled for saving throws, which I can rip out if it's not desired. But, this method should ensure that we never get any mismatch between the color on the chat card and the actual result (caveat: when the chat card is expanded, the d20 icon is still colored for natural 1s and 20s, and that color may not line up with the success or failure of the roll, but I decided that was fine).