### PR TITLE
Fix: Generate Tooptip for TAH

### DIFF
--- a/module/hooks.js
+++ b/module/hooks.js
@@ -56,5 +56,5 @@ TokenBarHooks.powersBySheetGroup = (actor) => {
 }
 
 //v3 hook.  _generateItemSummary returns a jquery selector that the sheet wants.  Give the caller back just the html.
-TokenBarHooks.generateItemTooltip = async (actor, item) => (await actor._sheet._generateItemSummary(item)).get(0).outerHTML
+TokenBarHooks.generateItemTooltip = async (actor, item) => ""
 


### PR DESCRIPTION
V13 Application V2 removed the method this depends on causing TAH to explode.

Honestly I am not sure how to get this back right now, so canning it as a quick fix.