### PR TITLE
Roll dialog "attack formula" label

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -520,6 +520,7 @@
 "DND4E.FormulaAttack": "Attack Formula",
 "DND4E.FormulaAttackBonus": "Attack Bonus Formula",
 "DND4E.FormulaAttackBonusTip": "Formula for the bonus added to attack rolls",
+"DND4E.FormulaAttackShort": "Atk",
 "DND4E.FormulaDamage": "Damage Formula",
 "DND4E.FormulaDamageBonus": "Damage Bonus Formula",
 "DND4E.FormulaDamageBonusPrimary": "Primary Damage Bonus Formula",

--- a/lang/en.json
+++ b/lang/en.json
@@ -520,6 +520,7 @@
 "DND4E.FormulaAttack": "Attack Formula",
 "DND4E.FormulaAttackBonus": "Attack Bonus Formula",
 "DND4E.FormulaAttackBonusTip": "Formula for the bonus added to attack rolls",
+"DND4E.FormulaAttackShort": "Atk",
 "DND4E.FormulaDamage": "Damage Formula",
 "DND4E.FormulaDamageBonus": "Damage Bonus Formula",
 "DND4E.FormulaDamageBonusPrimary": "Primary Damage Bonus Formula",

--- a/module/dice.js
+++ b/module/dice.js
@@ -87,7 +87,7 @@ export async function d20Roll({parts=[],  partsExpressionReplacements = [], item
 			targDataArray.targets.push({
 				'name': targetArr[targ].name,
 				'status': targetArr[targ].actor.statuses,
-				'attackMod': data?.item?.attack?.ability || 'str',
+				'attackMod': data?.item?.attack?.ability || '',
 				'attackDef': options.attackedDef || 'ac',
 				'immune': targetArr[targ].actor.system.defences[options.attackedDef]?.none || false,
 				'meleeVsProne': meleeVsProne,
@@ -100,7 +100,7 @@ export async function d20Roll({parts=[],  partsExpressionReplacements = [], item
 		targDataArray.targets.push({
 			'name':'',
 			'status':[],
-			'attackMod': data?.item?.attack?.ability || 'str',
+			'attackMod': data?.item?.attack?.ability || '',
 			'attackDef': data?.item?.attack?.def || 'ac',
 			'immune': false
 		});

--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -3011,7 +3011,7 @@ body.theme-light .dnd4e:is(.default,.standard-form){
 		align-items:center;
 		select{
 			flex:1;
-			max-width:60px;
+			max-width:65px;
 		}
 		label{
 			flex:0;

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -49,7 +49,9 @@
 				<label>{{localize 'DND4EUI.AttackVersus'}}</label>
 				<div class="score-vs-def">
 					<select class="attackMod" name="{{n}}.attackMod" disabled>
+						<option value="" {{#if (eq t.attackMod "")}}selected{{/if}}></option>
 						{{selectOptions ../config.abilityScores selected=t.attackMod labelAttr='labelShort'}}
+						<option value="form" {{#if (eq t.attackMod "form")}}selected{{/if}}>{{ localize "DND4E.FormulaAttackShort" }}</option>
 					</select> 
 					<label>{{localize 'DND4E.VS'}}</label>
 					<select class="attackDef" name="{{n}}.attackDef">


### PR DESCRIPTION
The roll dialog's attack ability display was limited to the six ability scores and defaulted to Strength. Now it will correctly handle the none and attack formula options that powers can be set up with.

Closes #548.