### PR TITLE
Re-refresh ring color after flashing damage

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -157,7 +157,11 @@ export class Actor4e extends Actor {
 
 		for ( const token of tokens ) {
 			if ( !token.object?.visible || token.isSecret ) continue;
-			if ( token.hasDynamicRing ) token.flashRing(key, pct, value < 0);
+			if ( token.hasDynamicRing ) {
+				token.flashRing(key, pct, value < 0).then(() => {
+					token.object?.renderFlags.set({ refreshRingVisuals: true });
+				});
+			}
 			const t = token.object;
 			canvas.interface.createScrollingText(t.center, value.signedString(), {
 				anchor: CONST.TEXT_ANCHOR_POINTS.TOP,

--- a/module/documents/token.js
+++ b/module/documents/token.js
@@ -107,6 +107,6 @@ export default class TokenDocument4e extends TokenDocument {
 		else {
 			options.easing = foundry.canvas.placeables.tokens.TokenRing.easePingPong;
 		}
-		this.object.ring?.flashColor(Color.from(color), options);
+		return this.object.ring?.flashColor(Color.from(color), options);
 	}
 }


### PR DESCRIPTION
If the dead status is applied during the dynamic ring damage flash animation, the ring color fails to update to the dimmed dead color. This isn't typically going to matter in module-less games, but when the dead status is automatically applied, for example by Drac's module, the two things trying to set ring color will collide. To be friendlier to Drac's module, let's refresh our ring color once the damage flash is done animating.