### PR TITLE
Fix bug where certain weapon types could break the item sheet

### DIFF
--- a/templates/items/parts/details-weapon.hbs
+++ b/templates/items/parts/details-weapon.hbs
@@ -47,7 +47,9 @@
   <select name="system.weaponBaseType">
     <option value=""{{#if (eq ../system.weaponBaseType '')}} selected{{/if}}>{{ localize 'DND4E.None' }}</option>
     <option value="custom"{{#if (eq ../system.weaponBaseType 'custom')}} selected{{/if}}>{{ localize 'DND4E.Custom' }}</option>
+    {{#if weaponBaseTypes}}
     {{selectOptions weaponBaseTypes selected=system.weaponBaseType localize=true}}
+    {{/if}}
   </select>
 </div>
 


### PR DESCRIPTION
We were trying to run `selectOptions` on an object that isn't guaranteed to exist.

Closes #540 