### PR TITLE
Fixed @tier not updating

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -71,10 +71,10 @@ export class Actor4e extends Actor {
 			}
 		}
 
-		if(data[`system.details.level`]){
-			if(this.system.details.tier != Math.clamp(Math.floor(( data[`system.details.level`] - 1 ) /10 + 1),1,3)){
-				this.system.details.tier = Math.clamp(Math.floor(( data[`system.details.level`] - 1 ) /10 + 1),1,3);
-				data[`system.details.tier`] = this.system.details.tier;
+		if(data.system.details.level){
+			if(this.system.details.tier != Math.clamp(Math.floor(( data.system.details.level - 1 ) /10 + 1),1,3)){
+				this.system.details.tier = Math.clamp(Math.floor(( data.system.details.level - 1 ) /10 + 1),1,3);
+				data.system.details.tier = this.system.details.tier;
 			}		
 		}
 


### PR DESCRIPTION
Changed how data.system.details.level was referenced. Before this @tier stayed at 1 no matter what level the character was at. Possibly due to it working in a previous Foundry version.