### PR TITLE
Damage calculation refactor

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1507,15 +1507,15 @@
 },
 
 "DND4E.TOKEN.MOVEMENT.ACTIONS": {
-    "charge": {
-        "label": "Charge"
-    },
-    "shift": {
-        "label": "Shift"
-    },
-    "teleport": {
-        "label": "Teleport"
-    }
+	"charge": {
+		"label": "Charge"
+	},
+	"shift": {
+		"label": "Shift"
+	},
+	"teleport": {
+		"label": "Teleport"
+	}
 },
 
 "EFFECT.DurationEndInit": "Effect End Time",
@@ -1741,6 +1741,10 @@
 "SETTINGS.4eChatSchemeAuto": "Match UI (default)",
 "SETTINGS.4eCollapseSituationalBonusL": "If checked: all common situational modifiers will be computed and added as a single modifier to @bonus. Otherwise each will be displayed individually in the resulting formula",
 "SETTINGS.4eCollapseSituationalBonusN": "Collapse Common Attack Mods",
+"SETTINGS.4eCompoundDamageTypesN": "Compound damage types rule",
+"SETTINGS.4eCompoundDamageTypesL": "Determine how compound damage types are combined. All-inclusive considers that an entire damage roll has all of its terms' types, while Disjoint combines terms that have any types in common but leaves separate terms that share no types.",
+"SETTINGS.4eCompoundDamageAllInclusive": "All-inclusive",
+"SETTINGS.4eCompoundDamageDisjoint": "Disjoint",
 "SETTINGS.4eCurWtL": "Carried currency affects character load following the rules on PHB pg. 212.",
 "SETTINGS.4eCurWtN": "Apply Currency Weight",
 "SETTINGS.4eCustomSkillsL": "Configure Custom Skills",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1507,15 +1507,15 @@
 },
 
 "DND4E.TOKEN.MOVEMENT.ACTIONS": {
-    "charge": {
-        "label": "Charge"
-    },
-    "shift": {
-        "label": "Shift"
-    },
-    "teleport": {
-        "label": "Teleport"
-    }
+	"charge": {
+		"label": "Charge"
+	},
+	"shift": {
+		"label": "Shift"
+	},
+	"teleport": {
+		"label": "Teleport"
+	}
 },
 
 "EFFECT.DurationEndInit": "Effect End Time",
@@ -1739,8 +1739,12 @@
 "SETTINGS.4eChatSchemeL": "Choose light/dark chat log, or follow core UI setting",
 "SETTINGS.4eChatSchemeN": "Chat Log Colour Scheme",
 "SETTINGS.4eChatSchemeAuto": "Match UI (default)",
-"SETTINGS.4eCollapseSituationalBonusL": "If checked: all common situational modifiers will be computed and added as a single modifier to @bonus.  Otherwise each will be displayed individually in the resulting formula",
+"SETTINGS.4eCollapseSituationalBonusL": "If checked: all common situational modifiers will be computed and added as a single modifier to @bonus. Otherwise each will be displayed individually in the resulting formula",
 "SETTINGS.4eCollapseSituationalBonusN": "Collapse Common Attack Mods",
+"SETTINGS.4eCompoundDamageTypesN": "Compound damage types rule",
+"SETTINGS.4eCompoundDamageTypesL": "Determine how compound damage types are combined. All-inclusive considers that an entire damage roll has all of its terms' types, while Disjoint combines terms that have any types in common but leaves separate terms that share no types.",
+"SETTINGS.4eCompoundDamageAllInclusive": "All-inclusive",
+"SETTINGS.4eCompoundDamageDisjoint": "Disjoint",
 "SETTINGS.4eCurWtL": "Carried currency affects character load following the rules on PHB pg. 212.",
 "SETTINGS.4eCurWtN": "Apply Currency Weight",
 "SETTINGS.4eCustomSkillsL": "Configure Custom Skills",
@@ -1752,7 +1756,7 @@
 "SETTINGS.4eDamageCalcPHB": "PHB Damage Rules",
 "SETTINGS.4eDeathSaveRestL": "Choose a reset condition for failed death saves. Useful if you want to run a more deadly campaign than the default of \"short rest\" provides.",
 "SETTINGS.4eDeathSaveRestN": "Death Saving Throw Reset",
-"SETTINGS.4eDebugPowerEffectsL": "Will output a lot of debug information to the console when attempting to apply effects to power attack and damage rolls.  Useful to see why a given effect is applying at a given value",
+"SETTINGS.4eDebugPowerEffectsL": "Will output a lot of debug information to the console when attempting to apply effects to power attack and damage rolls. Useful to see why a given effect is applying at a given value",
 "SETTINGS.4eDebugPowerEffectsN": "Debug Power Effects",
 "SETTINGS.4eFastFowardSettingsL": "All rolls and actions buttons will now default to using the fast-forward option that skips dialog boxes. To have the roll dialog box while in this mode, use the key binds normally associated with fast-forward",
 "SETTINGS.4eFastFowardSettingsN": "Fast Forward Default",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -52,6 +52,8 @@ export class Actor4e extends Actor {
 	/** @override */
 	async update(data, options={}) {
 		if(!data) { return super.update(data, options); }
+
+		data = foundry.utils.flattenObject(data);
 		
 		//console.debug(this);
 		//console.debug(data);
@@ -92,6 +94,8 @@ export class Actor4e extends Actor {
 				}
 			}
 		}
+
+		data = foundry.utils.expandObject(data);
 		return super.update(data, options);
 	}
 
@@ -2382,68 +2386,89 @@ export class Actor4e extends Actor {
 		}
 	}
 
-	async calcDamageErrata(damage, multiplier, surges){
+	calcTotalInner(damage, typesSet, isOngoing=false){
 		let totalDamage = 0;
+		const actorRes = this.system.resistances;
+		const isDamageImmune = actorRes['damage'].immune;
+		const resAll = isOngoing ? Helper.sumExtremes([resAll,actorRes['ongoing'].value] || 0) : actorRes['damage'].value;
 
-		//console.log(damage)
-		for(let d of damage){
-			console.log(d);
-			//get all the damageTypes in this term
-			let damageTypesArray = d[1].replace(/ /g,'').split(',');
-			console.log(damageTypesArray);
-			const actorRes = this.system.resistances;
-			console.log(actorRes);
-			
-			let resAll = actorRes['damage'].value;
-			let isDamageImmune = actorRes['damage'].immune;
-			
-			/* Special logic for ongoing damage.
-				Compare our "ongoing" res/immunity to our "all" res/immunity and use the best/highest value */
-			if ( damageTypesArray.includes("ongoing") ){
-				if (actorRes['ongoing'].immune) isDamageImmune = actorRes['ongoing'].immune;
+		let isImmuneAll = true; //starts as true, but as soon as one false it can not be changed back to true
+		let lowestRes = Infinity; // will attempt to replace this with the lowest resistance / highest vulnerability
 
-				resAll = Helper.sumExtremes([resAll,actorRes['ongoing'].value] || 0);
-			}
-			
-			let isImmuneAll = true; //starts as true, but as soon as one false it can not be changed back to true
-			let lowestRes = Infinity; // will attempt to replace this with the lowest resistance / highest vulnerability
-
-			for(let dt of damageTypesArray){
-				const type = dt && actorRes[dt] ? dt : 'damage';
-				//Skip if we're immune, or if the current type is ongoing (that's handled in a special way later)
-				if( dt == "ongoing" || actorRes[type]?.immune ) continue;
-				
-				//Adjust specific resistance with "resist all" value, according to combining resistance/vulnerability rules
-				const currentRes = Helper.sumExtremes([resAll,actorRes[type]?.value || 0]);
-	
-				if(currentRes !== 0){ //if has resistances or vulnerability
-					isImmuneAll = false;
-					console.log(`Modifier found: ${type} ${actorRes[type].value}`);
-					if(currentRes < lowestRes){
-						lowestRes = currentRes;
+		for (let dt of typesSet) {
+			const currentRes = Helper.sumExtremes([resAll,actorRes[dt]?.value || 0]);
+			if(currentRes !== 0){ //if has resistances or vulnerability
+				isImmuneAll = false;
+				console.log(`Modifier found: ${dt} ${actorRes[dt].value}`);
+				if(currentRes < lowestRes){
+					lowestRes = currentRes;
+				}
+			} else {
+				if(!isDamageImmune) {
+					isImmuneAll=false;
+					if(resAll){ //"Resist all" will stand in for any other damage that does not have a value
+						if(resAll < lowestRes){
+							lowestRes = resAll || 0;
+						}
 					}
-				} else {
-					if(!isDamageImmune) {
-						isImmuneAll=false;
-						if(resAll){ //"Resist all" will stand in for any other damage that does not have a value
-							if(resAll < lowestRes){
-								lowestRes = resAll || 0;
-							}
-						}
-						else if(currentRes < lowestRes){
-							lowestRes = currentRes || 0;
-						}
+					else if(currentRes < lowestRes){
+						lowestRes = currentRes || 0;
 					}
 				}
 			}
+		}
+		if(!isImmuneAll) {
+			totalDamage += Math.max(0, damage - lowestRes);
+		}
+		return totalDamage;
+	}
 
-			if(!isImmuneAll) {
-				totalDamage += Math.max(0, d[0] - lowestRes);
-				//console.log(`DamagePart:${d[0]}, DamageTypes: ${damageTypesArray.join(',')}\nImmuneto All? ${isImmuneAll}\nLowest Res: ${lowestRes}`);
-			} else{
-				//console.log(`DamagePart:${d[0]}, DamageTypes: ${damageTypesArray.join(',')}\nImmuneto All? ${isImmuneAll}`);
+	async calcDamageErrata(damage, multiplier, surges){
+		let totalDamage = 0;
+		let disjointDamageArray = [];
+		let combinedDamageTypes = new Set();
+		let combinedDamage = 0
+		let combinedOngoingDamageTypes = new Set();
+		let combinedOngoingDamage = 0;
+
+		for (let d of damage) {
+			//get all the damageTypes in this term
+			let typesArray = d[1].replace(/ /g,'').split(',');
+			let typesSet = new Set(typesArray);
+			if (typesSet.has('ongoing')){
+				combinedOngoingDamageTypes = new Set([...combinedOngoingDamageTypes, ...typesSet]);
+				combinedOngoingDamage += d[0];
 			}
-			// console.log(`Lowest Res: ${lowestRes}`)
+			else {
+				combinedDamageTypes = new Set([...combinedDamageTypes, ...typesSet]);
+				combinedDamage += d[0];
+			}
+			let existingDisjointDamage = disjointDamageArray.find(d => (d.types.isSubsetOf(typesSet) || typesSet.isSubsetOf(d.types)) && ((typesSet.union(d.types).has('ongoing')) || !(typesSet.has('ongoing') || d.types.has('ongoing'))));
+			if (existingDisjointDamage) {
+				existingDisjointDamage.value += d[0];
+			}
+			else {
+				let disjointDamage = {
+					types: typesSet,
+					value: d[0]
+				}
+				disjointDamageArray.push(disjointDamage);
+			}
+		}
+
+		if (game.settings.get("dnd4e", "compoundDamageTypes") === "allInclusive") {
+			if (combinedDamageTypes.size) {
+				totalDamage += this.calcTotalInner(combinedDamage, combinedDamageTypes)
+			}
+			if (combinedOngoingDamageTypes.size) {
+				const IS_ONGOING = true;
+				totalDamage += this.calcTotalInner(combinedOngoingDamage, combinedOngoingDamageTypes, IS_ONGOING)
+			}
+		}
+		else {
+			for (let d of disjointDamageArray){
+				totalDamage += this.calcTotalInner(d.value, d.types);
+			}
 		}
 
 		if(this.statuses.has("insubstantial")) totalDamage = Math.floor(totalDamage / 2);

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -92,7 +92,6 @@ export class Actor4e extends Actor {
 				}
 			}
 		}
-
 		return super.update(data, options);
 	}
 

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -2473,58 +2473,72 @@ export class Actor4e extends Actor {
 	}
 
 	async calcDamagePHB(damage, multiplier, surges){
-		let damageDealt = {};
 		let totalDamage = 0;
-		const actorRes = this.system.resistances;
-		console.log(damage);
+		let disjointDamageArray = [];
+		let combinedDamageTypes = new Set();
+		let combinedDamage = 0
+		let combinedOngoingDamageTypes = new Set();
+		let combinedOngoingDamage = 0;
 
-		for(let d of damage){
-			// Check if "ongoing" is in our types array, and if so remove it before dividing up the damage.
-			const isOngoing = d[1].includes("ongoing");
-			if(isOngoing) d[1] = d[1].replaceAll(/(,| )*ongoing(,| )*/g,"");
-			
-			let damageTypesArray = d[1].replace(/ /g,'').split(',');
-
-			let i = 0;
-			for(let dt of damageTypesArray){
-				if(damageDealt[dt] === undefined){
-					damageDealt[dt] = 0|d[0]/damageTypesArray.length+(i<d[0]%damageTypesArray.length);
-				} else{
-					damageDealt[dt] += 0|d[0]/damageTypesArray.length+(i<d[0]%damageTypesArray.length);
-				}
-				i++;
+		for (let d of damage) {
+			//get all the damageTypes in this term
+			let typesArray = d[1].replace(/ /g,'').split(',');
+			let typesSet = new Set(typesArray);
+			if (typesSet.has('ongoing')){
+				combinedOngoingDamageTypes = new Set([...combinedOngoingDamageTypes, ...typesSet]);
+				combinedOngoingDamage += d[0];
 			}
-
-			let resAll = actorRes['damage'].value;
-			let isDamageImmune = actorRes['damage'].immune;
-			
-			/* Special logic for ongoing damage.
-			Compare our "ongoing" res/immunity to our "all" res/immunity and use the best/highest value */
-			if ( isOngoing ){
-				if (actorRes['ongoing'].immune) isDamageImmune = actorRes['ongoing'].immune;
-
-				resAll = Helper.sumExtremes([resAll,actorRes['ongoing']?.value] || 0);
+			else {
+				combinedDamageTypes = new Set([...combinedDamageTypes, ...typesSet]);
+				combinedDamage += d[0];
 			}
-
-			//If we have immune all, skip the resistance comparisons
-			if ( !isDamageImmune) {
-				for(const d in damageDealt){
-					const damagetype = actorRes[d] ? d : 'damage';
-					if(actorRes[damagetype].immune) continue; //No damage to immune types
-					//if(isDamageImmune && !actorRes[damagetype].value) continue;
-					let res = Helper.sumExtremes([resAll,actorRes[damagetype]?.value || 0]);
-
-					/*Should be unnecessary when adjusting resistances in the previous step
-					if(!res && resAll){
-						res = resAll;
-					}*/
-					
-					totalDamage += Math.max(0, damageDealt[d]-res);
+			let existingDisjointDamage = disjointDamageArray.find(d => (d.types.isSubsetOf(typesSet) || typesSet.isSubsetOf(d.types)) && ((typesSet.union(d.types).has('ongoing')) || !(typesSet.has('ongoing') || d.types.has('ongoing'))));
+			if (existingDisjointDamage) {
+				existingDisjointDamage.value += d[0];
+			}
+			else {
+				let disjointDamage = {
+					types: typesSet,
+					value: d[0]
 				}
+				disjointDamageArray.push(disjointDamage);
 			}
 		}
+
+        if (game.settings.get("dnd4e", "compoundDamageTypes") === "allInclusive") {
+			if (combinedDamageTypes.size) {
+				const damageTypesArray = Array.from(combinedDamageTypes);
+                let i = 0;
+                for (let dt of damageTypesArray) {
+                    let typedDamage = 0 | combinedDamage / damageTypesArray.length + (i < combinedDamage % damageTypesArray.length);
+                    totalDamage += this.calcTotalInner(typedDamage, new Set([dt]));
+                    i++;
+                }
+			}
+			if (combinedOngoingDamageTypes.size) {
+				const ongoingDamageTypesArray = Array.from(combinedOngoingDamageTypes);
+                const IS_ONGOING = true;
+                let i = 0;
+                for (let dt of ongoingDamageTypesArray) {
+                    let typedDamage = 0 | combinedDamage / damageTypesArray.length + (i < combinedDamage % damageTypesArray.length);
+                    totalDamage += this.calcTotalInner(typedDamage, new Set([dt]));
+                    i++;
+                }
+			}
+		}
+		else {
+			for (let d of disjointDamageArray){
+				const damageTypesArray = Array.from(d.types);
+                let i = 0;
+                for (let dt of damageTypesArray) {
+                    let typedDamage = 0 | d.value / damageTypesArray.length + (i < d.value % damageTypesArray.length);
+                    totalDamage += this.calcTotalInner(typedDamage, new Set([dt]));
+                    i++;
+                }
+			}
+		}
+
 		if(this.statuses.has("insubstantial")) totalDamage = Math.floor(totalDamage / 2);
-		console.log(damageDealt);
 		console.log(`Total Damage: ${totalDamage}`)
 		return totalDamage;
 	}

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -52,8 +52,6 @@ export class Actor4e extends Actor {
 	/** @override */
 	async update(data, options={}) {
 		if(!data) { return super.update(data, options); }
-
-		data = foundry.utils.flattenObject(data);
 		
 		//console.debug(this);
 		//console.debug(data);
@@ -95,7 +93,6 @@ export class Actor4e extends Actor {
 			}
 		}
 
-		data = foundry.utils.expandObject(data);
 		return super.update(data, options);
 	}
 

--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -147,7 +147,7 @@ export class RollWithOriginalExpression extends Roll {
         if ( !this._evaluated ) await this.evaluate();
 
         let formulaData = this.getChatData(isPrivate);
-        const divisor = ("divisors" in this.options) ? this.options.divisors[this.options.hitType].value : 1;
+        const divisor = this.options.divisors?.[this.options.hitType].value || 1;
         let divisorString = "";
         if (divisor != 1) {
             const divisorReasons = this.options.divisors[this.options.hitType].reason.join(", ");

--- a/module/settings.js
+++ b/module/settings.js
@@ -34,6 +34,20 @@ export const registerSystemSettings = function() {
 			"phb": "SETTINGS.4eDamageCalcPHB",
 		},
 	});
+
+	// Combined damage type rule setting
+	 game.settings.register("dnd4e", "compoundDamageTypes", {
+		name: "SETTINGS.4eCompoundDamageTypesN",
+		hint: "SETTINGS.4eCompoundDamageTypesL",
+		scope: "world",
+		config: true,
+		default: "disjoint",
+		type: String,
+		choices: {
+			"allInclusive": "SETTINGS.4eCompoundDamageAllInclusive",
+			"disjoint": "SETTINGS.4eCompoundDamageDisjoint",
+		},
+	});
 	
 	// Initiative tiebreaker setting
 	game.settings.register("dnd4e", "initiativeDexTiebreaker", {


### PR DESCRIPTION
Super belatedly, we now treat a whole damage roll as a single "instance" of damage. There are two settings for dealing with compound types, arrived at after... much... discussion on the 4e Discord server. The first will group together damage parts that share at least one type, but apply resistance and vulnerability to each such group separately. The second treats the whole roll as though it has all the types of each of its parts.

I have not touched the PHB damage calculation formula (yet?) because I do not actually understand the PHB rules in this regard.