### PR TITLE
Restore Difficult Terrain icon

### DIFF
--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -107,6 +107,18 @@
 	}
 }
 
+.region-behavior-config i.difficult-terrain-icon{
+    content:url('/systems/dnd4e/icons/ui/difficultTerrain.svg');
+    height:1em;
+}
+.region-config i.difficult-terrain-icon{
+    content:url('/systems/dnd4e/icons/ui/difficultTerrain.svg');
+    filter:var(--white-svg-filter);
+    height:1em;
+    position:relative;
+    top:2px;
+}
+
 .dnd4e{
 	.window-content{
 		padding:0.5em;
@@ -135,17 +147,6 @@
 	}
 	.effect-tooltip{
 		text-align:left;
-	}
-	.region-behavior-config i.difficult-terrain-icon{
-		content:url('/systems/dnd4e/icons/ui/difficultTerrain.svg');
-		height:1em;
-	}
-	.region-config i.difficult-terrain-icon{
-		content:url('/systems/dnd4e/icons/ui/difficultTerrain.svg');
-		filter:var(--white-svg-filter);
-		height:1em;
-		position:relative;
-		top:2px;
 	}
 	input,select,textarea,code-mirror{
 		--input-background-color:var(--override-input-background-color);


### PR DESCRIPTION
Pull this css out from under `dnd4e` so that they actually get picked up in the region dialogs.