### PR TITLE
Fix custom weapon/armour base values being dropped

### DIFF
--- a/module/data/item/equipment.js
+++ b/module/data/item/equipment.js
@@ -35,6 +35,7 @@ export default class EquipmentData extends foundry.abstract.TypeDataModel {
         })
       }),
       armourBaseType: new StringField({initial: ""}),
+      armourBaseTypeCustom: new StringField({initial: ""}),
       // TODO: is this actually used anywhere?
       speed: new SchemaField({
         value: new StringField({nullable: true, initial: null}),

--- a/module/data/item/weapon.js
+++ b/module/data/item/weapon.js
@@ -28,6 +28,7 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
       weaponType: new StringField({initial: "simpleM"}),
       weaponHand: new StringField({initial: "HMain"}),
       weaponBaseType: new StringField({initial: ""}),
+      weaponBaseTypeCustom: new StringField({initial: ""}),
       properties: new MappingField(new BooleanField({initial: false}), {
         initialKeys: CONFIG.DND4E.weaponProperties,
         initialKeysOnly: true

--- a/templates/items/parts/details-weapon.hbs
+++ b/templates/items/parts/details-weapon.hbs
@@ -45,8 +45,8 @@
 <div class="form-group">
   <label>{{ localize "DND4E.WeaponBase" }}:</label>
   <select name="system.weaponBaseType">
-    <option value=""{{#if (eq ../system.weaponBaseType '')}} selected{{/if}}>{{ localize 'DND4E.None' }}</option>
-    <option value="custom"{{#if (eq ../system.weaponBaseType 'custom')}} selected{{/if}}>{{ localize 'DND4E.Custom' }}</option>
+    <option value=""{{#if (eq system.weaponBaseType '')}} selected{{/if}}>{{ localize 'DND4E.None' }}</option>
+    <option value="custom"{{#if (eq system.weaponBaseType 'custom')}} selected{{/if}}>{{ localize 'DND4E.Custom' }}</option>
     {{#if weaponBaseTypes}}
     {{selectOptions weaponBaseTypes selected=system.weaponBaseType localize=true}}
     {{/if}}


### PR DESCRIPTION
Fixes a bug where values entered in the "custom base" field for armour and weapons would be dropped on update (fixes #592), and and none/custom base selection was improperly detected on the weapon sheet.