### PR TITLE
Improved Companion Handling

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -293,37 +293,12 @@
 "DND4E.ContextMenuActionUnattune": "Unattune",
 "DND4E.ContextMenuActionEnable": "Enable",
 "DND4E.ContextMenuActionDisable": "Disable",
+"DND4E.ControllingActor": "Controlling Character",
 "DND4E.ControlledNoActor": "No controlled Actor Detected.",
 "DND4E.ConUnconscious": "Unconscious",
 "DND4E.ConWeakened": "Weakened",
 "DND4E.CostGP": "Cost (GP)",
-"DND4E.CreatureOrigin": "Origin",
-"DND4E.CreatureOriginAberrant": "Aberrant",
-"DND4E.CreatureOriginElemental": "Elemental",
-"DND4E.CreatureOriginFey": "Fey",
-"DND4E.CreatureOriginImmortal": "Immortal",
-"DND4E.CreatureOriginNatural": "Natural",
-"DND4E.CreatureOriginShadow": "Shadow",
-"DND4E.CreatureRoleArtillery": "Artillery",
-"DND4E.CreatureRoleBrute": "Brute",
-"DND4E.CreatureRoleController": "Controller",
-"DND4E.CreatureRoleDefender": "Defender",
-"DND4E.CreatureRoleLeader": "Leader",
-"DND4E.CreatureRoleLurker": "Lurker",
-"DND4E.CreatureRoleSkirmisher": "Skirmisher",
-"DND4E.CreatureRoleStriker": "Striker",
-"DND4E.CreatureRoleSoldier": "Soldier",
-"DND4E.CreatureRoleSecStandard": "Standard",
-"DND4E.CreatureRoleSecElite": "Elite",
-"DND4E.CreatureRoleSecSolo": "Solo",
-"DND4E.CreatureRoleSecMinion": "Minion",
-"DND4E.CreatureRoleSecOther": "Other",
-"DND4E.CreatureSubtypes": "Creature Subtypes",
-"DND4E.CreatureType": "Creature Type",
-"DND4E.CreatureTypeAnimate": "Animate",
-"DND4E.CreatureTypeBeast": "Beast",
-"DND4E.CreatureTypeHumanoid": "Humanoid",
-"DND4E.CreatureTypeMagicalBeaste": "Magical Beast",
+"DND4E.Creature": "Creature",
 "DND4E.Critical": "Critical",
 "DND4E.CriticalHit": "Critical Hit",
 "DND4E.CriticalHitTitle": "Natural D20 Dice roll required for a hit to be considered a critical hit.",
@@ -1121,6 +1096,7 @@
 "DND4E.TerrainMultiplierHint": "Determines the number of squares of movement it takes to move through each grid square of terrain.",
 "DND4E.Theme": "Theme",
 "DND4E.ThingType": "{thing} Type",
+"DND4E.ThingSubtypes": "{thing} Subtypes",
 "DND4E.TimeDay": "Days",
 "DND4E.TimeHour": "Hours",
 "DND4E.TimeInst": "Instantaneous",
@@ -1340,6 +1316,12 @@
 "DND4E.AutoTargetModes.Allies": "Allies",
 "DND4E.AutoTargetModes.Enemies": "Enemies",
 
+"DND4E.CreatureType": {
+	"Animate": "Animate",
+	"Beast": "Beast",
+	"Humanoid": "Humanoid",
+	"MagicalBeast": "Magical Beast"
+},
 "DND4E.Equipment.Alt": {
 	"Alt": "Alternative Reward",
 	"Blessing": "Blessing",
@@ -1420,8 +1402,6 @@
 	"DefenceNullTip": "Click to toggle immunity to attacks vs. {def}"
 },
 
-"DND4E.Item.Type": "{type} Type",
-
 "DND4E.Movement":{
 	"Base": "Base",
 	"Bonus": "Bonuses to {mode} speed",
@@ -1447,6 +1427,15 @@
 	"Walk": "Walk"
 },
 
+"DND4E.Origin": { 
+	"ThingOrigin": "{thing} Origin",
+	"Aberrant": "Aberrant",
+	"Elemental": "Elemental",
+	"Fey": "Fey",
+	"Immortal": "Immortal",
+	"Natural": "Natural",
+	"Shadow": "Shadow"
+},
 "DND4E.RegionBehaviors.DifficultTerrain": {
 	"FIELDS": {
 		"ignoredDispositions": {
@@ -1473,14 +1462,47 @@
 	}
 },
 
-"DND4E.Role.Hazard": {
+"DND4E.Role": {
+	"ThingRole": "{thing} Role",
+	"Role": "Role",
+	"Other": "Other",
+	
+	"Elite": "Elite",
+	"Companion": "Companion",
+	"Minion": "Minion",
+	"Solo": "Solo",
+	"Standard": "Standard",
+	
+	"Artillery": "Artillery",
+	"Brute": "Brute",
+	"Controller": "Controller",
+	"Leader": "Leader",
+	"Lurker": "Lurker",
+	"Skirmisher": "Skirmisher",
+	"Soldier": "Soldier",
+	
+	"Controller": "Controller",
+	"Defender": "Defender",
+	"Leader": "Leader",
+	"Striker": "Striker",
+	
+	"Animal": "Animal Companion",
+	"Beast": "Beast Companion",
+	"Companion": "Companion",
+	"Elemental": "Elemental Companion",
+	"Familiar": "Arcane Familiar",
+	"FeyBeast": "Fey Beast Companion",
+	"Hireling": "Hireling",
+	"Mount": "Mount",
+	"Pet": "Pet",
+	"Summon": "Summoned Creature",
+	
 	"Blaster": "Blaster",
 	"Hazard": "Hazard",
 	"Lurker":"Lurker",
 	"Obstacle": "Obstacle",
 	"Trap": "Trap",
-	"Warder": "Warder",
-	"Other": "Other"
+	"Warder": "Warder"
 },
 
 "DND4E.Sheet": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -293,37 +293,12 @@
 "DND4E.ContextMenuActionUnattune": "Unattune",
 "DND4E.ContextMenuActionEnable": "Enable",
 "DND4E.ContextMenuActionDisable": "Disable",
+"DND4E.ControllingActor": "Controlling Character",
 "DND4E.ControlledNoActor": "No controlled Actor Detected.",
 "DND4E.ConUnconscious": "Unconscious",
 "DND4E.ConWeakened": "Weakened",
 "DND4E.CostGP": "Cost (GP)",
-"DND4E.CreatureOrigin": "Origin",
-"DND4E.CreatureOriginAberrant": "Aberrant",
-"DND4E.CreatureOriginElemental": "Elemental",
-"DND4E.CreatureOriginFey": "Fey",
-"DND4E.CreatureOriginImmortal": "Immortal",
-"DND4E.CreatureOriginNatural": "Natural",
-"DND4E.CreatureOriginShadow": "Shadow",
-"DND4E.CreatureRoleArtillery": "Artillery",
-"DND4E.CreatureRoleBrute": "Brute",
-"DND4E.CreatureRoleController": "Controller",
-"DND4E.CreatureRoleDefender": "Defender",
-"DND4E.CreatureRoleLeader": "Leader",
-"DND4E.CreatureRoleLurker": "Lurker",
-"DND4E.CreatureRoleSkirmisher": "Skirmisher",
-"DND4E.CreatureRoleStriker": "Striker",
-"DND4E.CreatureRoleSoldier": "Soldier",
-"DND4E.CreatureRoleSecStandard": "Standard",
-"DND4E.CreatureRoleSecElite": "Elite",
-"DND4E.CreatureRoleSecSolo": "Solo",
-"DND4E.CreatureRoleSecMinion": "Minion",
-"DND4E.CreatureRoleSecOther": "Other",
-"DND4E.CreatureSubtypes": "Creature Subtypes",
-"DND4E.CreatureType": "Creature Type",
-"DND4E.CreatureTypeAnimate": "Animate",
-"DND4E.CreatureTypeBeast": "Beast",
-"DND4E.CreatureTypeHumanoid": "Humanoid",
-"DND4E.CreatureTypeMagicalBeaste": "Magical Beast",
+"DND4E.Creature": "Creature",
 "DND4E.Critical": "Critical",
 "DND4E.CriticalHit": "Critical Hit",
 "DND4E.CriticalHitTitle": "Natural D20 Dice roll required for a hit to be considered a critical hit.",
@@ -1121,6 +1096,7 @@
 "DND4E.TerrainMultiplierHint": "Determines the number of squares of movement it takes to move through each grid square of terrain.",
 "DND4E.Theme": "Theme",
 "DND4E.ThingType": "{thing} Type",
+"DND4E.ThingSubtypes": "{thing} Subtypes",
 "DND4E.TimeDay": "Days",
 "DND4E.TimeHour": "Hours",
 "DND4E.TimeInst": "Instantaneous",
@@ -1340,6 +1316,13 @@
 "DND4E.AutoTargetModes.Allies": "Allies",
 "DND4E.AutoTargetModes.Enemies": "Enemies",
 
+"DND4E.CreatureType": {
+	"Animate": "Animate",
+	"Beast": "Beast",
+	"Humanoid": "Humanoid",
+	"MagicalBeast": "Magical Beast"
+},
+
 "DND4E.Equipment.Alt": {
 	"Alt": "Alternative Reward",
 	"Blessing": "Blessing",
@@ -1420,8 +1403,6 @@
 	"DefenceNullTip": "Click to toggle immunity to attacks vs. {def}"
 },
 
-"DND4E.Item.Type": "{type} Type",
-
 "DND4E.Movement":{
 	"Base": "Base",
 	"Bonus": "Bonuses to {mode} speed",
@@ -1445,6 +1426,16 @@
 	"TraitsPlaceholder": "e.g. clumsy, hover",
 	"Unit": "sq.",
 	"Walk": "Walk"
+},
+
+"DND4E.Origin": { 
+	"ThingOrigin": "{thing} Origin",
+	"Aberrant": "Aberrant",
+	"Elemental": "Elemental",
+	"Fey": "Fey",
+	"Immortal": "Immortal",
+	"Natural": "Natural",
+	"Shadow": "Shadow"
 },
 
 "DND4E.RegionBehaviors.DifficultTerrain": {
@@ -1473,14 +1464,47 @@
 	}
 },
 
-"DND4E.Role.Hazard": {
+"DND4E.Role": {
+	"ThingRole": "{thing} Role",
+	"Role": "Role",
+	"Other": "Other",
+	
+	"Elite": "Elite",
+	"Companion": "Companion",
+	"Minion": "Minion",
+	"Solo": "Solo",
+	"Standard": "Standard",
+	
+	"Artillery": "Artillery",
+	"Brute": "Brute",
+	"Controller": "Controller",
+	"Leader": "Leader",
+	"Lurker": "Lurker",
+	"Skirmisher": "Skirmisher",
+	"Soldier": "Soldier",
+	
+	"Controller": "Controller",
+	"Defender": "Defender",
+	"Leader": "Leader",
+	"Striker": "Striker",
+	
+	"Animal": "Animal Companion",
+	"Beast": "Beast Companion",
+	"Companion": "Companion",
+	"Elemental": "Elemental Companion",
+	"Familiar": "Arcane Familiar",
+	"FeyBeast": "Fey Beast Companion",
+	"Hireling": "Hireling",
+	"Mount": "Mount",
+	"Pet": "Pet",
+	"Summon": "Summoned Creature",
+	
 	"Blaster": "Blaster",
 	"Hazard": "Hazard",
 	"Lurker":"Lurker",
 	"Obstacle": "Obstacle",
 	"Trap": "Trap",
-	"Warder": "Warder",
-	"Other": "Other"
+	"Warder": "Warder"
 },
 
 "DND4E.Sheet": {

--- a/module/config.js
+++ b/module/config.js
@@ -440,30 +440,23 @@ preLocalize("armourProficiencies");
 
 DND4E.creatureOrigin = {
 	aberrant: {
-		label: "DND4E.CreatureOriginAberrant",
+		label: "DND4E.Origin.Aberrant",
 	},
 	elemental: {
-		label: "DND4E.CreatureOriginElemental",
+		label: "DND4E.Origin.Elemental",
 	},
 	fey: {
-		label: "DND4E.CreatureOriginFey",
+		label: "DND4E.Origin.Fey",
 	},
 	immortal: {
-		label: "DND4E.CreatureOriginImmortal",
+		label: "DND4E.Origin.Immortal",
 	},
 	natural: {
-		label: "DND4E.CreatureOriginNatural",
+		label: "DND4E.Origin.Natural",
 	},
 	shadow: {
-		label: "DND4E.CreatureOriginShadow",
+		label: "DND4E.Origin.Shadow",
 	},
-
-	// "aberrant": "DND4E.CreatureOriginAberrant",
-	// "elemental": "DND4E.CreatureOriginElemental",
-	// "fey": "DND4E.CreatureOriginFey",
-	// "immortal": "DND4E.CreatureOriginImmortal",
-	// "natural": "DND4E.CreatureOriginNatural",
-	// "shadow": "DND4E.CreatureOriginShadow",
 }
 preLocalize("creatureOrigin", { keys: ["label"] });
 
@@ -472,91 +465,96 @@ preLocalize("creatureOrigin", { keys: ["label"] });
 
 DND4E.creatureRole = {
 	artillery: {
-		label: "DND4E.CreatureRoleArtillery",
+		label: "DND4E.Role.Artillery",
 	},
 	brute: {
-		label: "DND4E.CreatureRoleBrute",
+		label: "DND4E.Role.Brute",
 	},
 	controller: {
-		label: "DND4E.CreatureRoleController",
-	},
-	defender: {
-		label: "DND4E.CreatureRoleDefender",
-	},
-	leader: {
-		label: "DND4E.CreatureRoleLeader",
+		label: "DND4E.Role.Controller",
 	},
 	lurker: {
-		label: "DND4E.CreatureRoleLurker",
+		label: "DND4E.Role.Lurker",
 	},
 	skirmisher: {
-		label: "DND4E.CreatureRoleSkirmisher",
-	},
-	striker: {
-		label: "DND4E.CreatureRoleStriker",
+		label: "DND4E.Role.Skirmisher",
 	},
 	soldier: {
-		label: "DND4E.CreatureRoleSoldier",
+		label: "DND4E.Role.Soldier",
 	},
-	
-	// "artillery": "DND4E.CreatureRoleArtillery",
-	// "brute": "DND4E.CreatureRoleBrute",
-	// "controller": "DND4E.CreatureRoleController",
-	// "defender": "DND4E.CreatureRoleDefender",
-	// "leader": "DND4E.CreatureRoleLeader",
-	// "lurker": "DND4E.CreatureRoleLurker",
-	// "skirmisher": "DND4E.CreatureRoleSkirmisher",
-	// "striker": "DND4E.CreatureRoleStriker",
-	// "soldier": "DND4E.CreatureRoleSoldier",
+	controller: {
+		label: "DND4E.Role.Controller",
+	},
+	defender: {
+		label: "DND4E.Role.Defender",
+	},
+	leader: {
+		label: "DND4E.Role.Leader",
+	},
+	striker: {
+		label: "DND4E.Role.Striker",
+	}
 }
-preLocalize("creatureRole", { keys: ["label"], sort: true });
+preLocalize("creatureRole", { keys: ["label"], sort: false });
 
 DND4E.creatureRoleSecond = {
-	"standard": {label: "DND4E.CreatureRoleSecStandard"},
-	"elite": {label: "DND4E.CreatureRoleSecElite"},
-	"solo": {label: "DND4E.CreatureRoleSecSolo"},
-	"minion": {label: "DND4E.CreatureRoleSecMinion"},
-	"other": {label: "DND4E.CreatureRoleSecOther"},
+	"standard": {label: "DND4E.Role.Standard"},
+	"elite": {label: "DND4E.Role.Elite"},
+	"solo": {label: "DND4E.Role.Solo"},
+	"minion": {label: "DND4E.Role.Minion"},
+	"companion": {label: "DND4E.Role.Companion"},
+	"other": {label: "DND4E.Role.Other"},
 }
-preLocalize("creatureRoleSecond", { keys: ["label"], sort: true });
+preLocalize("creatureRoleSecond", { keys: ["label"], sort: false });
+
+DND4E.companionType = {
+	"companion": {label: "DND4E.Role.Companion"},
+	"summon": {label: "DND4E.Role.Summon"},
+	"familiar": {label: "DND4E.Role.Familiar"},
+	"beast": {label: "DND4E.Role.Beast"},
+	"animal": {label: "DND4E.Role.Animal"},
+	"elemental": {label: "DND4E.Role.Elemental"},
+	"feybeast": {label: "DND4E.Role.FeyBeast"},
+	"hireling": {label: "DND4E.Role.Hireling"},
+	"mount": {label: "DND4E.Role.Mount"},
+	"pet": {label: "DND4E.Role.Pet"},
+	"other": {label: "DND4E.Role.Other"},
+}
+preLocalize("companionType", { keys: ["label"], sort: false });
 
 /* -------------------------------------------- */
 
 DND4E.hazardRole = {
-	"trap": {label: "DND4E.Role.Hazard.Trap"},
-	"hazard": {label: "DND4E.Role.Hazard.Hazard"},
-	"other": {label: "DND4E.Role.Hazard.Other"}
+	"trap": {label: "DND4E.Role.Trap"},
+	"hazard": {label: "DND4E.Role.Hazard"},
+	"other": {label: "DND4E.Role.Other"}
 }
-preLocalize("hazardRole", { keys: ["label"], sort: true });
+preLocalize("hazardRole", { keys: ["label"], sort: false });
 
 DND4E.hazardRoleSecond = {
-	"blaster": {label: "DND4E.Role.Hazard.Blaster"},
-	"lurker": {label: "DND4E.Role.Hazard.Lurker"},
-	"obstacle": {label: "DND4E.Role.Hazard.Obstacle"},
-	"warder": {label: "DND4E.Role.Hazard.Warder"},
-	"other": {label: "DND4E.Role.Hazard.Other"},
+	"blaster": {label: "DND4E.Role.Blaster"},
+	"lurker": {label: "DND4E.Role.Lurker"},
+	"obstacle": {label: "DND4E.Role.Obstacle"},
+	"warder": {label: "DND4E.Role.Warder"},
+	"other": {label: "DND4E.Role.Other"},
 }
-preLocalize("hazardRoleSecond", { keys: ["label"], sort: true });
+preLocalize("hazardRoleSecond", { keys: ["label"], sort: false });
 
 /* -------------------------------------------- */
 
 DND4E.creatureType = {
 	animate: {
-		label: "DND4E.CreatureTypeAnimate",
+		label: "DND4E.CreatureType.Animate",
 	},
 	beast: {
-		label: "DND4E.CreatureTypeBeast",
+		label: "DND4E.CreatureType.Beast",
 	},
 	humanoid: {
-		label: "DND4E.CreatureTypeHumanoid",
+		label: "DND4E.CreatureType.Humanoid",
 	},
 	magical: {
-		label: "DND4E.CreatureTypeMagicalBeaste",
+		label: "DND4E.CreatureType.MagicalBeast",
 	},
-	// "animate": "DND4E.CreatureTypeAnimate",
-	// "beast": "DND4E.CreatureTypeBeast",
-	// "humanoid": "DND4E.CreatureTypeHumanoid",
-	// "magical": "DND4E.CreatureTypeMagicalBeaste",
 }
 preLocalize("creatureType", { keys: ["label"], sort: true });
 
@@ -577,7 +575,7 @@ DND4E.consumableTypes = {
 	"wondrous": {label: "DND4E.EquipmentWondrousItem"},
 	"other": {label: "DND4E.EquipmentTypeOther"}
 };
-preLocalize("consumableTypes", { keys: ["label"], sort: true });
+preLocalize("consumableTypes", { keys: ["label"], sort: false });
 
 /* -------------------------------------------- */
 DND4E.commonAttackBonuses = {

--- a/module/data/actor/npc.js
+++ b/module/data/actor/npc.js
@@ -29,7 +29,9 @@ export default class NPCData extends foundry.abstract.TypeDataModel {
           primary: new StringField({initial: "brute"}),
           secondary: new StringField({initial: "standard"}),
           leader: new BooleanField({initial: false})
-        })
+        }),
+        source: new StringField({initial: ""}),
+        controller: new StringField({initial: ""})
       }),
       advancedCals: new BooleanField({initial: false}),
       attributes: new SchemaField({

--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -161,6 +161,11 @@
 		--checkbox-checked-color:var(--override-checkbox-checked-color);
 		--checkbox-checkmark-color:var(--override-checkbox-checkmark-color);
 	}
+	hr{
+		height:0;
+		margin:0.5em 0;
+		border-bottom:var(--border-normal);
+	}
 }
 .sheet.standard-form{
 	gap:0;
@@ -2351,8 +2356,13 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 		.npc-upper label.def-base{
 			margin-left:6px;
 		}
+		.npc-upper .basics .alignment{
+			display:flex;
+		}
 		.npc-upper .basics .alignment input{
-			max-width:120px;
+			flex:fit-content 5 5;
+			font-weight:normal;
+			max-width:unset;
 		}
 		.npc-upper .movement-dialog span{
 			font-weight:normal;
@@ -2372,6 +2382,33 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 			margin-left:1em;
 			padding-left:1em;
 			max-width:8em;
+		}
+		.tab.biography{
+			& prose-mirror[name='system.biography']{
+				height:calc(100% - 2em);
+			}
+			& .npc-details{
+				height:2em;
+				justify-content:space-between;
+				align-items:center;
+				
+				& label,input[type="text"]{
+                    flex-basis:fit-content;
+                    flex-grow:0;
+                    padding:0 1em;
+				}
+				& label{
+					font-weight:bold;
+				}
+				& .npc-source{
+					justify-content:flex-end;
+					align-items:center;
+				}
+				& .npc-controller{
+					justify-content:flex-start;
+					align-items:center;
+				}
+			}
 		}
 	}
 	

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -12,22 +12,29 @@
 						<input name="name" type="text" value="{{actor.name}}" data-tooltip="{{localize 'DND4E.NameNPC'}}" placeholder="{{localize 'DND4E.NameNPC'}}" onClick="this.select();"/>
 					</li>
 					<li class="summary-role-second">
-						<select class="actor-role-second" name="system.details.role.secondary">
+						<select class="actor-role-second" name="system.details.role.secondary" data-tooltip="{{localize 'DND4E.ThingType' thing=(localize 'TYPES.Actor.NPC')}}">
 							{{selectOptions config.creatureRoleSecond selected=system.details.role.secondary labelAttr="label"}}
 						</select>
 					</li>
 					
-					<li class="summary-role">
-						<select class="actor-role-prim" name="system.details.role.primary">
-							{{#if (eq system.details.role.secondary 'minion')}}<option value=""{{#unless system.details.role}} selected{{/unless}}></option>{{/if}}
-							{{#if (eq system.details.role.secondary 'other')}}<option value=""{{#unless system.details.role}} selected{{/unless}}></option>{{/if}}
-							{{selectOptions config.creatureRole selected=system.details.role.primary labelAttr="label"}}
+					<li class="summary-role">				
+						<select class="actor-role-prim" name="system.details.role.primary" data-tooltip="{{#if (eq system.details.role.secondary 'companion')}}{{localize 'DND4E.Role.ThingRole' thing=(localize 'DND4E.Role.Companion')}}{{else}}{{localize 'DND4E.Role.ThingRole' thing=(localize 'DND4E.Creature')}}{{/if}}">
+							<option value=""{{#unless system.details.role}} selected{{/unless}}></option>
+							{{#if (eq system.details.role.secondary "companion")}}
+								{{selectOptions config.companionType selected=system.details.role.primary labelAttr="label"}}					
+							{{else}}
+								{{selectOptions config.creatureRole selected=system.details.role.primary labelAttr="label"}}
+							{{/if}}
 						</select>
 					</li>
+					
+					{{#unless (eq system.details.role.secondary 'companion')}}
 					<li class="summary-leader">
-						<label>{{localize 'DND4E.CreatureRoleLeader'}}</label> 
-						<input type="checkbox" name="system.details.role.leader" data-dtype="Boolean" {{checked system.details.role.leader}} data-tooltip="{{localize 'DND4E.CreatureRoleLeader'}}"/>
+						<label>{{localize 'DND4E.Role.Leader'}}</label> 
+						<input type="checkbox" name="system.details.role.leader" data-dtype="Boolean" {{checked system.details.role.leader}} data-tooltip="{{localize 'DND4E.Role.Leader'}}"/>
 					</li>
+					{{/unless}}
+					
 					<li class="summary-level">
 						<label>{{localize 'DND4E.Level'}}</label>
 						<input type="text" name="system.details.level" value="{{system.details.level}}" data-tooltip="{{localize 'DND4E.Level'}}" data-dtype="Number" onClick="this.select();"/>
@@ -41,24 +48,24 @@
 				</ul>
 	
 				<ul class="summary flexrow">
-					<li class="summary-size">
+					<li class="summary-size" data-tooltip="{{localize 'DND4E.Size'}}">
 						<select class="actor-size" name="system.details.size">
 							{{selectOptions config.actorSizes selected=system.details.size labelAttr="label"}}
 						</select>
 					</li>
-					<li class="summary-origin">
-						<select class="actor-size" name="system.details.origin">
+					<li class="summary-origin" data-tooltip="{{localize 'DND4E.Origin.ThingOrigin' thing=(localize 'DND4E.Creature')}}">
+						<select class="actor-origin" name="system.details.origin">
 							{{selectOptions config.creatureOrigin selected=system.details.origin labelAttr="label"}}
 
 						</select>
 					</li>
-					<li class="summary-type">
-						<select class="actor-size" name="system.details.type">
+					<li class="summary-type"data-tooltip="{{localize 'DND4E.ThingType' thing=(localize 'DND4E.Creature')}}">
+						<select class="actor-type" name="system.details.type">
 							{{selectOptions config.creatureType selected=system.details.type labelAttr="label"}}
 						</select>
 					</li>
 					<li class="summary-typeother">
-						<input name="system.details.other" type="text" value="{{system.details.other}}" data-tooltip="{{localize 'DND4E.CreatureSubtypes'}}" placeholder="{{localize 'DND4E.CreatureSubtypes'}}" onClick="this.select();"/>
+						<input name="system.details.other" type="text" value="{{system.details.other}}" data-tooltip="{{localize 'DND4E.ThingSubtypes' thing=(localize 'DND4E.Creature')}}" placeholder="{{localize 'DND4E.ThingSubtypes' thing=(localize 'DND4E.Creature')}}" onClick="this.select();" />
 					</li>
 				
 					<li class="summary-exp">

--- a/templates/actors/tabs/biography.hbs
+++ b/templates/actors/tabs/biography.hbs
@@ -2,4 +2,17 @@
   <prose-mirror class="{{#if system.biography}}has-content{{/if}}" toggled name="system.biography" {{disabled (not editable)}} value="{{system.biography}}">
     {{{biographyHTML}}}
   </prose-mirror>
+  
+  {{#if isNPC}}
+  <div class="npc-details flexrow">
+	{{#if (eq system.details.role.secondary 'companion')}}
+	<div class="npc-controller flexrow">
+		<label>{{localize 'DND4E.ControllingActor'}}:</label> <input name="system.details.controller" type="text" value="{{system.details.controller}}" placeholder="{{localize 'DND4E.ControllingActor'}}" data-tooltip="{{localize 'DND4E.ControllingActor'}}" />
+	</div>
+	{{/if}}
+	<div class="npc-source flexrow">
+		<label>{{localize 'DND4E.Source'}}:</label> <input name="system.details.source" type="text" value="{{system.details.source}}" data-tooltip="{{localize 'DND4E.Source'}}" placeholder="{{localize 'DND4E.Source'}}" />
+	</div>
+  </div>
+  {{/if}}
 </section>

--- a/templates/actors/tabs/details.hbs
+++ b/templates/actors/tabs/details.hbs
@@ -59,20 +59,20 @@
 			</select>
 		  </div>
 		  <div class="detail form-group origin">
-			<label>{{localize 'DND4E.CreatureOrigin'}}:</label>
+			<label>{{localize 'DND4E.Origin.ThingOrigin' thing=(localize 'DND4E.Creature')}}:</label>
 			<select class="actor-origin" name="system.details.origin">
 			  {{selectOptions config.creatureOrigin selected=system.details.origin labelAttr="label"}}
 			</select>
 		  </div>
 		  <div class="detail form-group creature-type">
-			<label>{{localize 'DND4E.CreatureType'}}:</label>
+			<label>{{localize 'DND4E.ThingType' thing=(localize 'DND4E.Creature')}}:</label>
 			<select class="actor-type" name="system.details.type">
 			  {{selectOptions config.creatureType selected=system.details.type labelAttr="label"}}
 			</select>
 		  </div>
 		  <div class="detail subtypes">
-			<label for="subtypes">{{localize 'DND4E.CreatureSubtypes'}}:</label>
-			<input id="other" type="text" name="system.details.other" value="{{system.details.other}}" data-tooltip="{{localize 'DND4E.CreatureSubtypes'}}"  placeholder="{{localize 'DND4E.CreatureSubtypes'}}" onClick="this.select();"/>
+			<label for="subtypes">{{localize 'DND4E.ThingSubtypes' thing=(localize 'DND4E.Creature')}}:</label>
+			<input id="other" type="text" name="system.details.other" value="{{system.details.other}}" data-tooltip="{{localize 'DND4E.ThingSubtypes' thing=(localize 'DND4E.Creature')}}"  placeholder="{{localize 'DND4E.ThingSubtypes' thing=(localize 'DND4E.Creature')}}" onClick="this.select();"/>
 		  </div>
 		</div>
 		


### PR DESCRIPTION
This update lays groundwork to better facilitate companion NPCs like familiars, beast companions, summons etc. I thought better of creating a whole new actor type, since the needed attributes vary wildly depending on the companion type, and instead just added some new fields to the NPC definition that can be used to customise a sheet if desired.
- Added companion types to the config lists and "Companion" to the category (roleSec) selection for NPCs. If "Companion" is selected from this list, the role selector lists companion types instead of monster/henchman roles.
- Added "controller" field to NPCs. which only displays when the Companion is the category choice, which should contain an actor ID.
  -  The intention is that this can be used to fetch data from the summoner/master/etc for use in derived stats etc, and to reference in macros. Just an ID for now, while I think about the best way to implement it. I think just working it into the companion's `@` variables might be the right choice?
  - I'd like to add selection behaviour to the controller field at a later stage, but for now you can paste in an ID copied from the PC sheet so it's usable.

I also added a "source" field to NPCs (in the Biography tab), since they typically have a singular book source like an item/power/etc.