### PR TITLE
Add new "Use Source Actor Data" option to active effects.

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1020,6 +1020,8 @@
 "DND4E.Sleep": "Sleep",
 "DND4E.Slots": "Slots",
 "DND4E.Source": "Source",
+"DND4E.SourceActorData": "Use Source Actor Data",
+"DND4E.SourceActorDataHint": "If checked, the source actor's roll data will be used for change values instead of the target's.",
 "DND4E.SourceName": "Source Name",
 "DND4E.Special": "Special",
 "DND4E.SpecialRequirements": "Special Requirements",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1020,6 +1020,8 @@
 "DND4E.Sleep": "Sleep",
 "DND4E.Slots": "Slots",
 "DND4E.Source": "Source",
+"DND4E.SourceActorData": "Use Source Actor Data",
+"DND4E.SourceActorDataHint": "If checked, the source actor's roll data will be used for change values instead of the target's.",
 "DND4E.SourceName": "Source Name",
 "DND4E.Special": "Special",
 "DND4E.SpecialRequirements": "Special Requirements",

--- a/module/data/active-effect/active-effect.js
+++ b/module/data/active-effect/active-effect.js
@@ -1,4 +1,4 @@
-const { ArrayField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, NumberField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 /**
  * Data structure for a standard actor trait.
@@ -47,11 +47,14 @@ export default class ActiveEffectData extends foundry.data.ActiveEffectTypeDataM
       durationType: new StringField({initial: ""}),
       powerEffectType: new StringField({initial: "misc"}),
       dots: new ArrayField(new SchemaField({
+        // TODO: Make FormulaField when "$solidify()" is fully deprecated.
         amount: new StringField({initial: "0"}),
         types: new SetField(new StringField({initial: ""}))
       })),
+      equippedRec: new BooleanField({initial: false}),
       keywords: new SetField(new StringField({ choices: keywords })),
       keywordsCustom: new StringField({initial: ""}),
+      useSourceActorData: new BooleanField({initial: true}),
       saveDC: new NumberField()
     };
   }

--- a/module/effects/effects-config.js
+++ b/module/effects/effects-config.js
@@ -153,6 +153,16 @@ export default class ActiveEffectConfig4e extends foundry.applications.sheets.Ac
 
 	/* ----------------------------------------- */
 
+	/** @inheritDoc */
+	_onChangeForm(formConfig, event) {
+		super._onChangeForm(formConfig, event);
+		if(event.target?.name === "transfer") {
+			this._refresh(event);
+		}
+	}
+
+	/* ----------------------------------------- */
+
 	/**
 	* Handling for mouse clicks on DOT control buttons - adapted from _onEffectControl
 	* Delegate responsibility out to action-specific handlers depending on the button action.

--- a/module/effects/effects.js
+++ b/module/effects/effects.js
@@ -26,7 +26,7 @@
 				if(context.parent.system?.keywordsCustom) data.system.keywordsCustom = context.parent.system?.keywordsCustom;
 
 				if(['equipment','weapon'].includes(context?.parent?.type)){
-					foundry.utils.setProperty(data, "flags.dnd4e.effectData.equippedRec", true);
+					data.system.equippedRec = true;
 				}
 			}
 		} catch(e){
@@ -164,7 +164,6 @@
 			}
 			
 			updates.transfer = false;
-			updates.equippedRec = false;
 		}
 
 		if(data.statuses?.length && data.description){
@@ -249,7 +248,7 @@
 			//types of items that can be equipped
 			const validTypes = ["weapon", "equipment", "tool", "loot", "backpack"];
 			if(validTypes.includes(this.parent.type) && this.parent.system.equipped === false){
-				return this.flags.dnd4e?.effectData?.equippedRec || false;
+				return this.system.equippedRec || false;
 			}
 			return this.areEffectsSuppressed;
 		}
@@ -371,12 +370,19 @@
 		}
 		delete flags.effectData?.durationType;
 
-        if (flags.effectData?.powerEffectTypes) {
-            source.system.powerEffectType = flags.effectData.powerEffectTypes;
-        }
-        delete flags.effectData?.durationType;
+		if (flags.effectData?.powerEffectTypes) {
+			source.system.powerEffectType = flags.effectData.powerEffectTypes;
+		}
+		delete flags.effectData?.powerEffectType;
+		
 
-        if (flags.effectData != null && !flags.effectData) delete flags.effectData;
+		if (flags.effectData?.equippedRec) {
+			source.system.equippedRec = flags.effectData.equippedRec;
+		}
+		delete flags.effectData?.equippedRec;
+
+
+		if (("effectData" in flags) && !flags.effectData) delete flags.effectData;
 
 		if (flags.keywords?.length) {
 			let keywords = []

--- a/module/helper.js
+++ b/module/helper.js
@@ -928,22 +928,33 @@ export class Helper {
 	static async solidifyEffectActorData(effect, parentActor){
 		Helper.debugLog(effect)
 		Helper.debugLog(parentActor)
+		const regex = /\$solidify\((.*?)\)/g
 
 		//dots
 		for(const dot of effect.system.dots){
-			// dot.amount = await this.parseSolidify(dot.amount, parentActor);
-			dot.amount = dot.amount.toString().replace(/\$solidify\((.*?)\)/g, (match, value) => {
-				return Roll.replaceFormulaData(value, parentActor.getRollData());
-			});
+			if(regex.test(dot.amount)) {    
+				foundry.utils.logCompatibilityWarning("Use of $solidify() in Active Effect values is deprecated since 0.8.0; manage this behavior via the \"Use Source Actor Data\" setting on the Active Effect.")
+				// dot.amount = await this.parseSolidify(dot.amount, parentActor);
+				dot.amount = dot.amount.toString().replace(/\$solidify\((.*?)\)/g, (match, value) => {
+					return Roll.replaceFormulaData(value, parentActor.getRollData());
+				});
+			} else if (typeof dot.amount === "string" && effect.system.useSourceActorData) {
+				dot.amount = Roll.replaceFormulaData(dot.amount, parentActor.getRollData());
+			}
 		}
 
 		//changes
 		for(const change of effect.system.changes){
-			// change.value = this.parseSolidify(change.value, parentActor);
-			change.value = change.value.replace(/\$solidify\((.*?)\)/g, (match, value) => {
-                return Roll.replaceFormulaData(value, parentActor.getRollData());
-			});
-			Helper.debugLog(change.value);
+			if(regex.test(change.value)) {
+				foundry.utils.logCompatibilityWarning("Use of $solidify() in Active Effect values is deprecated since 0.8.0; manage this behavior via the \"Use Source Actor Data\" setting on the Active Effect.")
+				// change.value = this.parseSolidify(change.value, parentActor);
+				change.value = change.value.replace(/\$solidify\((.*?)\)/g, (match, value) => {
+					return Roll.replaceFormulaData(value, parentActor.getRollData());
+				});
+				Helper.debugLog(change.value);
+			} else if (typeof change.value === "string" && effect.system.useSourceActorData) {
+				change.value = Roll.replaceFormulaData(change.value, parentActor.getRollData());
+			}
 		}
 
 	}
@@ -980,7 +991,7 @@ export class Helper {
 						tint: e.tint,
 						"flags": flags,
 						changesID: e.uuid,
-                        showIcon: e.showIcon
+						showIcon: e.showIcon
 					};
 
 					if(parent && newEffectData.system.saveDC) {
@@ -1211,17 +1222,17 @@ export class Helper {
 		return `${result}`;
 	}
 
-    /**
+	/**
 	 * Wrapper for findKeyScale(level, CONFIG.DND4E.SCALE.basic) for use in dice formulas.
 	 *
-     * @param {number} level Level to scale from, as we don't have access to any rollData in here. Default 1.
+	 * @param {number} level Level to scale from, as we don't have access to any rollData in here. Default 1.
 	 * @param {number} offset Offset value to increase the input to adjust the scale. Default 0.
 	 * @returns {result} New set of matching disposition
 	 */
 
-    static scaleFn(level = 1, offset = 1) {
-        return Helper.findKeyScale(level, CONFIG.DND4E.SCALE.basic, offset - 1)
-    }
+	static scaleFn(level = 1, offset = 1) {
+		return Helper.findKeyScale(level, CONFIG.DND4E.SCALE.basic, offset - 1)
+	}
 	
 	/**
 	 * Helper function to convert an initiative with decimal points to a human-friendly round number with tooltip.
@@ -1637,17 +1648,17 @@ export class Helper {
 		return false;
 	}
 
-    /* -------------------------------------------- */
+	/* -------------------------------------------- */
 
-    /** 
-     * @param {String} msg  Text to print to the console
-    */
+	/** 
+	 * @param {String} msg  Text to print to the console
+	*/
 
-    static debugLog(msg) {
-        if (game.settings.get("dnd4e", "debugLogging")) {
-            console.log(msg);
-        }
-    }
+	static debugLog(msg) {
+		if (game.settings.get("dnd4e", "debugLogging")) {
+			console.log(msg);
+		}
+	}
 }
 
 export async function handleApplyEffectToToken(data){

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -2062,7 +2062,8 @@ export default class Item4e extends Item {
 			ownership: { [game.user.id]: CONST.DOCUMENT_OWNERSHIP_LEVELS.OWNER },
 			flags: {
 				["dnd4e"]: {
-					origin: this.uuid,
+					item: this,
+                    origin: this.uuid
 				},
 			},
 		};

--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -351,7 +351,7 @@ export class RollWithOriginalExpression extends Roll {
                             }
                         }
                         // replace the expression variable with the span and mouseover tags
-                        activeExpression = activeExpression.replace(variable, `<span class="roll-expression" id="exp${spanId}"</span>`)
+                        activeExpression = activeExpression.replace(variable, `<span class="roll-expression" id="exp${spanId}">${variable}</span>`)
 
                         // find the value
                         const indexOfReplacement = activeFormula.indexOf(replacementStr)

--- a/templates/items/parts/target-effects.hbs
+++ b/templates/items/parts/target-effects.hbs
@@ -36,7 +36,7 @@
 		{{#each section.effects as |effect|}}
 			<li class="item effect flexrow" data-effect-id="{{effect.id}}">
 				<div class="item-name effect-name flexrow">
-					<img class="item-image" src="{{effect.icon}}"/>
+					<img class="item-image" src="{{effect.img}}"/>
 					<h4>{{effect.name}}</h4>
 				</div>
 				<div class="effect-source">{{effect.sourceName}}</div>

--- a/templates/sheets/active-effect/activation.hbs
+++ b/templates/sheets/active-effect/activation.hbs
@@ -87,9 +87,18 @@
   <div class="form-group">
     <label>{{localize 'DND4E.EffectWhenEquipped'}}?</label>
     <div class="form-fields">
-      <input type="checkbox" name="flags.dnd4e.effectData.equippedRec" data-dtype="Boolean" {{checked document.flags.dnd4e.effectData.equippedRec}}/>
+      <input type="checkbox" name="system.equippedRec" data-dtype="Boolean" {{checked document.system.equippedRec}}/>
     </div>
   </div>
   {{formGroup fields.transfer value=source.transfer rootId=rootId}}
+  {{#unless source.transfer}}
+  <div class="form-group">
+    <label>{{localize 'DND4E.SourceActorData'}}?</label>
+    <div class="form-fields">
+      <input type="checkbox" name="system.useSourceActorData" data-dtype="Boolean" {{checked document.system.useSourceActorData}}/>
+    </div>
+    <p class="hint">{{localize 'DND4E.SourceActorDataHint'}}</p>
+  </div>
+  {{/unless}}
   {{/if}}
 </section>


### PR DESCRIPTION
This new option defaults to true and will automatically replace `@properties` when we create the effect on the target. Logs a deprecation warning when `$solidify()` is found (but it's still functional for now).

Also added back the "only when equipped" option that I missed when setting up the AE data model.

Also also stores the item that created a region on the region as we did with MeasuredTemplates (Automated Animations seems to be relying on this, and our own hook for template auto-targeting does as well, in the case that the item no longer exists because it was synthetic).