### PR TITLE
Fix issue preventing some roll expressions from displaying in chat cards

### DIFF
--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -351,7 +351,7 @@ export class RollWithOriginalExpression extends Roll {
                             }
                         }
                         // replace the expression variable with the span and mouseover tags
-                        activeExpression = activeExpression.replace(variable, `<span class="roll-expression" id="exp${spanId}"</span>`)
+                        activeExpression = activeExpression.replace(variable, `<span class="roll-expression" id="exp${spanId}">${variable}</span>`)
 
                         // find the value
                         const indexOfReplacement = activeFormula.indexOf(replacementStr)


### PR DESCRIPTION
A dumb thing I did during the V13 update that I proceeded to never notice (and apparently neither did anyone else). PRing it here 'cause it's super safe and easy and I'd rather leave V13 in as good a shape as possible ('cause I do not want to look back once we get V14 out).