### PR TITLE
Fix Feature item creation failure

### DIFF
--- a/module/item/item.js
+++ b/module/item/item.js
@@ -261,7 +261,11 @@ export default class Item4e extends Item {
 	 */
 	/** @inheritdoc */
 	static getDefaultArtwork(itemData) {
-		return { img: CONFIG.DND4E.defaultArtwork.Item[itemData.type] ?? super.getDefaultArtwork(itemData) };
+		const defaultArtwork = CONFIG.DND4E.defaultArtwork.Item[itemData.type];
+		if (defaultArtwork) {
+			return { img: defaultArtwork };
+		}
+		return super.getDefaultArtwork(itemData);
 	}
 
 	/* -------------------------------------------- */


### PR DESCRIPTION
Nesting the parent call inside the returned object accidentally created a doubly nested object that would break things when we DON'T have an image in the CONFIG.