### PR TITLE
Effect tweaks

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1859,6 +1859,7 @@
 "MIGRATION.4eComplete": "DnD4E System Migration to version {version} completed!",
 "MIGRATION.4eVersionTooOldWarning": "Your DnD4e system data is from too old a Foundry version and cannot be reliably migrated to the latest version. The process will be attempted, but errors may occur.",
 
+"SHEET.ActiveEffect": "Active Effect 4e Sheet",
 "SHEET.Character.Basic": "Basic Character Sheet",
 "SHEET.NPC": "NPC Sheet",
 "SHEET.Hazard": "Trap/Hazard Sheet",

--- a/lang/en.json
+++ b/lang/en.json
@@ -1859,6 +1859,7 @@
 "MIGRATION.4eComplete": "DnD4E System Migration to version {version} completed!",
 "MIGRATION.4eVersionTooOldWarning": "Your DnD4e system data is from too old a Foundry version and cannot be reliably migrated to the latest version. The process will be attempted, but errors may occur.",
 
+"SHEET.ActiveEffect": "Active Effect 4e Sheet",
 "SHEET.Character.Basic": "Basic Character Sheet",
 "SHEET.NPC": "NPC Sheet",
 "SHEET.Hazard": "Trap/Hazard Sheet",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -177,6 +177,9 @@ export class Actor4e extends Actor {
 	/** @inheritdoc */
 	getRollData() {
 		const data = super.getRollData();
+
+		data.name = this.name;
+
 		data.strMod = data?.abilities?.str.mod || 0;
 		data.conMod = data?.abilities?.con.mod || 0;
 		data.dexMod = data?.abilities?.dex.mod || 0;

--- a/module/dnd4e.js
+++ b/module/dnd4e.js
@@ -87,8 +87,10 @@ Hooks.once("init", async function() {
 	// Define custom Entity classes
 	CONFIG.DND4E = DND4E;
 
-	foundry.applications.apps.DocumentSheetConfig.registerSheet(ActiveEffect, "dnd4e", ActiveEffectConfig4e, { makeDefault: true });
-	// DocumentSheetConfig.registerSheet(Actor4e, "dnd4e", ActiveEffectConfig4e, {makeDefault :true});
+	foundry.applications.apps.DocumentSheetConfig.registerSheet(ActiveEffect, "dnd4e", ActiveEffectConfig4e, {
+		makeDefault: true,
+		label: _loc("SHEET.ActiveEffect"),
+	});
 	CONFIG.ActiveEffect.documentClass = ActiveEffect4e;
 	CONFIG.ActiveEffect.legacyTransferral = false;
 	CONFIG.Item.collection = Items4e;

--- a/module/effects/effects.js
+++ b/module/effects/effects.js
@@ -54,19 +54,6 @@ export default class ActiveEffect4e extends ActiveEffect {
 
 	/* --------------------------------------------- */
 
-	/** @inheritdoc */
-	apply(actor, change) {
-
-		if (this.isSuppressed) return null;
-		
-		// this.otherActorLink(actor, change);
-		this.safeEvalEffectValue(actor, change);
-
-		return super.apply(actor, change);
-	}
-
-	/* --------------------------------------------- */
-
 	// Work in progress, evaluate from other actors given ID?
 	
 	/*otherActorLink(actor, change) {
@@ -83,45 +70,8 @@ export default class ActiveEffect4e extends ActiveEffect {
 		actor = targetActor;
 		
 	}*/
-	/* --------------------------------------------- */
 
-	/**
-	 * Before passing changes to the parent ActiveEffect class,
-	 * we want to make some modifications to make the effect
-	 * rolldata aware.
-	 * 
-	 * @param {Actor} actor     The Actor that is affected by the effect
-	 * @param {Object} change    The changeset to be applied with the Effect
-	 * @returns 
-	 */
-	safeEvalEffectValue(actor, change) {
-		const stringDiceFormat = /\d+d\d+/;
-	
-		// If the user wants to use the rolldata format
-		// for grabbing data keys, why stop them?
-		// This is purely syntactic sugar, and for folks
-		// who copy-paste values between the key and value
-		// fields.
-		if (change.key.indexOf("@") === 0)
-			change.key = change.key.replace("@", "");
-	  
-		// If the user entered a dice formula, I really doubt they're 
-		// looking to add a random number between X and Y every time
-		// the Effect is applied, so we treat dice formulas as normal
-		// strings.
-		// For anything else, we use Roll.replaceFormulaData to handle
-		// fetching of data fields from the actor, as well as math
-		// operations.  
-		if (!change.value.match(stringDiceFormat))
-			change.value = Roll.replaceFormulaData(change.value, actor.getRollData());
-	  
-		// If it'll evaluate, we'll send the evaluated result along 
-		// for the change.
-		// Otherwise we just send along the exact string we were given. 
-		try {
-			change.value = Roll.safeEval(change.value).toString();
-		} catch (e) { /* noop */ }
-	}
+	/* --------------------------------------------- */
 
 	/** @inheritdoc */
 	async _preCreate(data, options, user) {

--- a/module/helper.js
+++ b/module/helper.js
@@ -934,6 +934,16 @@ export class Helper {
 				for (let t of tokenTarget) {
 					// let effectData = e.data;
 					// e.sourceName = parent.name;
+
+					// Perform data replacement on effect description; target values can be accessed with @target.[normal property path].
+					let description = e.description ? e.description : "";
+					if (typeof description === "string") {
+						const rollData = parent?.getRollData();
+						const targetData = t.actor?.getRollData();
+						if (rollData && targetData) rollData.target = targetData;
+						description = Roll.replaceFormulaData(description, rollData);
+					}
+
 					e.origin = parent.uuid;
 					this.solidifyEffectActorData(e, parent);
 					const flags = e.flags;
@@ -941,7 +951,7 @@ export class Helper {
 					const newEffectData = {
 						name: e.name,
 						type: e.type,
-						description: e.description ? e.description : "",
+						description: description,
 						img: e.img,
 						origin: e.origin,
 						sourceName: parent.name,


### PR DESCRIPTION
Item name is alrady in item rollData as `@item.name` if in an item context, so we add actor name, which will simply be `@name` and will be the name of the item's owner in an item context. This can be used in Active Effect descriptions; now we manually do data replacement of Active Effect descriptions when we apply the effect. The target's data can be accessed at `@target.[normal data path]`. This feels _somewhat_ naïve, and perhaps a better solution will present itself in the future, but I think it's fine.

Additionally, localize the Active Effect sheet name.