### PR TITLE
Add lookup enricher and enrich active effect descriptions upon application

### DIFF
--- a/module/dnd4e.js
+++ b/module/dnd4e.js
@@ -31,6 +31,8 @@ import { default as DifficultTerrainRegionBehaviorType } from "./regionBehaviors
 import { default as TerrainData4e } from "./regionBehaviors/terrain-data.js";
 import { default as DifficultTerrainConfig } from "./apps/regionBehaviors/difficult-terrain-config.js";
 
+import * as lookup from "./enrichers/lookup.js";
+
 import { Helper, handleApplyEffectToToken, handleAutoDoTs, handleDeleteEffectToToken, handlePromptEoTSaves, performPreLocalization } from "./helper.js";
 
 // Import Helpers
@@ -261,6 +263,12 @@ Hooks.once("init", async function() {
 	CONFIG.Token.movement.costAggregator = (results, distance, segment) => {
 		return Math.max(...results.map(i => i.cost));
 	};
+
+	// Enrichers
+	// Register enrichers
+	CONFIG.TextEditor.enrichers = [
+		lookup,
+	];
 });
 
 /* --------------------------------------------- */

--- a/module/enrichers/lookup.js
+++ b/module/enrichers/lookup.js
@@ -1,0 +1,79 @@
+// Adapted from the Foundry Virtual Tabletop - Draw Steel Game System licensed under the MIT license
+
+import { Helper } from "../helper.js";
+import { parseConfig } from "./utils.js";
+
+/**
+ * @import { TextEditorEnricher, TextEditorEnricherConfig } from "@client/config.mjs";
+ * @import HTMLEnrichedContentElement from "@client/applications/elements/enriched-content.mjs";
+ * @import { ParsedConfig } from "./utils.js";
+ */
+
+/** @type {TextEditorEnricherConfig["id"]} */
+export const id = "DND4E.lookup";
+
+/* -------------------------------------------------- */
+
+/** @type {TextEditorEnricherConfig["pattern"]} */
+export const pattern = new RegExp("\\[\\[(?<type>lookup)(?<config> .*?)?]](?!])(?:{(?<label>[^}]+)})?", "gi");
+
+/**
+ * Enricher function.
+ * @type {TextEditorEnricher}
+ */
+export async function enricher(match, options) {
+	let { config, label: fallback } = match.groups;
+
+	/** @type {ParsedConfig} */
+	const parsedConfig = parseConfig(config);
+	parsedConfig._input = match[0];
+
+	for (const val of parsedConfig.values) {
+		const normalizedValue = val.toLowerCase();
+		if (["capitalize", "lowercase", "uppercase"].includes(normalizedValue)) parsedConfig.style ??= normalizedValue;
+		else if (normalizedValue === "evaluate") parsedConfig.evaluate = true;
+		else parsedConfig.formula ??= val;
+	}
+
+	if (!parsedConfig.formula) {
+		console.warn(`Lookup path must be defined to enrich ${config._input}.`);
+		return null;
+	}
+
+	const data = options.rollData ?? options.relativeTo?.getRollData?.() ?? {};
+
+	/** @type {string | number} */
+	let value;
+	if (parsedConfig.evaluate) {
+		const replacedFormula = Roll.replaceFormulaData(parsedConfig.formula, data);
+		value = (replacedFormula.includes("@")) ? fallback : Helper.evaluateFormula(replacedFormula, data, { contextName: "lookup" });
+	} else {
+		value = foundry.utils.getProperty(data, parsedConfig.formula.substring(1)) ?? fallback;
+
+		switch (parsedConfig.style) {
+			case "capitalize":
+				value = value.capitalize();
+				break;
+			case "lowercase":
+				value = value.toLowerCase();
+				break;
+			case "uppercase":
+				value = value.toUpperCase();
+				break;
+		}
+	}
+
+	const span = document.createElement("span");
+	span.classList.add("lookup-value");
+	if (!value && (options.documents === false)) return null;
+	else if (!value) span.classList.add("not-found");
+	span.innerText = value ?? parsedConfig.formula;
+	if (!options.noTooltip) span.dataset.tooltip = (!fallback || (value === fallback)) ? parsedConfig.formula : fallback;
+	return span;
+}
+
+/**
+ * Called when the enriched content is added to the DOM.
+ * @param {HTMLEnrichedContentElement} element
+ */
+export async function onRender(element) {}

--- a/module/enrichers/utils.js
+++ b/module/enrichers/utils.js
@@ -1,0 +1,28 @@
+/**
+ * @typedef ParsedConfig
+ * @property {string} _config
+ * @property {string[]} values
+ */
+
+/**
+ * Parse an enricher string into a configuration object.
+ * @param {string} match  Matched configuration string.
+ * @param {object} [options={}]
+ * @param {boolean} [options.multiple=false]  Support splitting configuration by "&" into multiple sub-configurations.
+ *                                            If set to `true` then an array of configs will be returned.
+ * @returns {ParsedConfig[] | ParsedConfig} Array if Multiple is true, else object.
+ */
+export function parseConfig(match = "", { multiple = false } = {}) {
+	if (multiple) return match.split("&").map(s => parseConfig(s));
+	const config = { _config: match, values: [] };
+	for (const part of match.match(/(?:[^\s"]+|"[^"]*")+/g) ?? []) {
+		if (!part) continue;
+		const [key, value] = part.split("=");
+		const valueLower = value?.toLowerCase();
+		if (value === undefined) config.values.push(key.replace(/(^"|"$)/g, ""));
+		else if (["true", "false"].includes(valueLower)) config[key] = valueLower === "true";
+		else if (Number.isNumeric(value)) config[key] = Number(value);
+		else config[key] = value.replace(/(^"|"$)/g, "");
+	}
+	return config;
+}

--- a/module/helper.js
+++ b/module/helper.js
@@ -964,6 +964,7 @@ export class Helper {
 						const rollData = parent?.getRollData();
 						const targetData = t.actor?.getRollData();
 						if (rollData && targetData) rollData.target = targetData;
+						rollData.effect = { name: e.name };
 						description = await foundry.applications.ux.TextEditor.implementation.enrichHTML(description, { rollData: rollData });
 					}
 

--- a/module/helper.js
+++ b/module/helper.js
@@ -15,6 +15,29 @@ export class Helper {
 	}
 
 	/**
+     * Helper function to perform synchronous evaluation of a user-input formula
+     * User-input formulas may throw if blank or otherwise contain invalid terms.
+     * @param {string} formula                      The roll formula. May be blank or otherwise invalid.
+     * @param {object} [rollData]                   The roll data for parsing.
+     * @param {object} [options]                    Options for this method to forward.
+     * @param {boolean} [options.strict=false]      Forwarded to {@linkcode Roll.evaluateSync}.
+     * @param {boolean} [options.allowStrings=true] Forwarded to {@linkcode Roll.evaluateSync}.
+     * @param {string} [options.contextName]        Helpful string put into the error message.
+     * @returns {number} Returns the total, or 0 if it failed to evaluate.
+     */
+	static evaluateFormula(formula, rollData = {}, { strict = false, allowStrings = true, contextName = "unknown" } = {}) {
+		let result = 0;
+		try {
+			const evaluatedResult = new Roll(formula || "0", rollData).evaluateSync({ strict, allowStrings }).total;
+			result = evaluatedResult;
+		}
+		catch (e) {
+			console.error(`Failed to evaluate formula ${formula} in ${contextName}`, e);
+		}
+		return result;
+	}
+
+	/**
 	 * Returns true if the variable is defined and is not an empty string.
 	 * @param str the object to check, could be a string, could be any other object
 	 * @returns {boolean} if the object is defined (non null) and is not the empty string.
@@ -941,7 +964,7 @@ export class Helper {
 						const rollData = parent?.getRollData();
 						const targetData = t.actor?.getRollData();
 						if (rollData && targetData) rollData.target = targetData;
-						description = Roll.replaceFormulaData(description, rollData);
+						description = await foundry.applications.ux.TextEditor.implementation.enrichHTML(description, { rollData: rollData });
 					}
 
 					e.origin = parent.uuid;

--- a/module/helper.js
+++ b/module/helper.js
@@ -961,7 +961,8 @@ export class Helper {
 					// Perform data replacement on effect description; target values can be accessed with @target.[normal property path].
 					let description = e.description ? e.description : "";
 					if (typeof description === "string") {
-						const rollData = parent?.getRollData();
+						const sourceItem = fromUuidSync(e.origin);
+						const rollData = sourceItem?.getRollData() ?? parent?.getRollData();
 						const targetData = t.actor?.getRollData();
 						if (rollData && targetData) rollData.target = targetData;
 						rollData.effect = { name: e.name };

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -1093,7 +1093,7 @@ export default class Item4e extends Item {
 		if (this.effects.size) {
 			for (const e of this.effects) {
 				if (e.description) {
-					const enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(e.description, { rollData: this.getRollData() });
+					const enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(e.description, { rollData: { ...this.getRollData(), ...{ effect: { name: e.name } } } });
 					e.descriptionToolTip = `<div class="effect-tooltip" >${enrichedDescription}</div>`;
 				}
 			}

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -1093,7 +1093,8 @@ export default class Item4e extends Item {
 		if (this.effects.size) {
 			for (const e of this.effects) {
 				if (e.description) {
-					e.descriptionToolTip = `<div class="effect-tooltip" >${e.description}</div>`;
+					const enrichedDescription = await foundry.applications.ux.TextEditor.implementation.enrichHTML(e.description, { rollData: this.getRollData() });
+					e.descriptionToolTip = `<div class="effect-tooltip" >${enrichedDescription}</div>`;
 				}
 			}
 		}


### PR DESCRIPTION
Took this enricher from Draw Steel, here's how it works (ever so slightly adapted from their wiki):

> The [[lookup]] enricher allows dynamic display of actor, item, and effect data as plain text. It supports both text and numerical values, and uses roll data syntax.
> 
> Examples:
> 
> - [​[lookup `@name`]] Prints the actor's name.
> - [​[lookup `@item.name`]] Prints the item's name (Requires the context of an item or an effect on an item, e.g. the description)
> - [​[lookup `@effect.name`]] Prints the effect's name (Requires the context of an Active Effect, e.g. the description)
> - [​[lookup `@name` lowercase]] Prints the actor's name but lowercase. Valid options are capitalize, lowercase, and uppercase.
> - [​[lookup `@name` style=uppercase]] The style property can be defined explicitly.
> - [​[lookup `@dexMod`+3 evaluate]] Evaluates the lookup value as a formula. Non-deterministic values like dice are treated as 0.
> - [​[lookup formula=`@dexMod`+3 evaluate=true]] The formula and evaluate parameters can be defined explicitly.
> - [​[lookup formula="`@dexMod` + 3" evaluate=true]] You must use quotes for formulas with spaces