### PR TITLE
Correct attribute consumption

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -906,7 +906,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 			let quantity = 0;
 			switch (consume.type) {
 				case "attribute":
-					consumed = foundry.utils.getProperty(actor.system, consume.target);
+					consumed = foundry.utils.getProperty(actor, consume.target);
 					quantity = consumed || 0;
 					break;
 				case "resource":


### PR DESCRIPTION
All these attributes have `system` as part of their path, so they're _all_ getting missed 'cause we're looking in `system.system`.