### PR TITLE
Don't consume perRound or perTurn uses outside of combat

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -2332,8 +2332,9 @@ export class Actor4e extends Actor {
 			const uses = parseInt(itemData.uses.value || 0);
 			if (uses <= 0) ui.notifications.warn(_loc("DND4E.ItemNoUses", { name: item.name }));
 			
-			await item.update({ "system.uses.value": Math.max(parseInt(item.system.uses.value || 0) - 1, 0) });
-			// item.update({"system.uses.value": Math.max(parseInt(item.system.uses.value || 0) - 1, 0)})
+			if (!!game.combat || !["round", "turn"].includes(item.system.uses.per)) {
+				await item.update({ "system.uses.value": Math.max(parseInt(item.system.uses.value || 0) - 1, 0) });
+			}
 		}
 
 		if (fastForward) {


### PR DESCRIPTION
It just seems inconvenient to decrement uses for per round and per turn features when not in a rounds and turns context.