### PR TITLE
Normalise status sections on weapons/equipment

### DIFF
--- a/templates/items/parts/details-equipment.hbs
+++ b/templates/items/parts/details-equipment.hbs
@@ -1,4 +1,26 @@
-<h3 class="form-header">{{ localize "DND4E.ItemEquipmentDetails" }}</h3>
+{{!-- Equipment Status --}}
+<fieldset name="equipment-status" class="equipment-status form-group stacked">
+  <legend>{{ localize "DND4E.ItemEquipmentStatus" }}</legend>  
+  <div class="form-group">
+    <label>{{localize "DND4E.Proficient"}} </label>
+    <select name="system.proficient">
+      {{selectOptions config.proficiency selected=system.proficient}}
+    </select>
+  </div>
+  <label class="checkbox small">
+    <input type="checkbox" name="system.equipped" {{checked system.equipped}}>
+    {{ localize "DND4E.Equipped" }}
+  </label>
+  <label class="checkbox small">
+    <input type="checkbox" name="system.identified" {{checked system.identified}}>
+    {{ localize "DND4E.Identified" }}
+  </label>
+  <label class="checkbox small">
+    <input type="checkbox" name="system.attuned" {{checked system.attuned}}>
+    {{ localize "DND4E.Attuned" }}
+  </label>
+</fieldset>
+
 {{!-- Equipment Type --}}
 <div class="form-group uses-per">
   <label>{{ localize "DND4E.ItemEquipmentType" }}</label>
@@ -45,29 +67,6 @@
 </div>
 {{/if}}
 {{/if}}
-
-{{!-- Equipment Status --}}
-<div class="form-group stacked">
-  <label>{{ localize "DND4E.ItemEquipmentStatus" }}</label>
-  <div class="form-group">
-    <label>{{localize "DND4E.Proficient"}} </label>
-    <select name="system.proficient">
-      {{selectOptions config.proficiency selected=system.proficient}}
-    </select>
-  </div>
-  <label class="checkbox">
-    <input type="checkbox" name="system.equipped" {{checked system.equipped}}>
-    {{ localize "DND4E.Equipped" }}
-  </label>
-  <label class="checkbox">
-    <input type="checkbox" name="system.identified" {{checked system.identified}}>
-    {{ localize "DND4E.Identified" }}
-  </label>
-  <label class="checkbox">
-    <input type="checkbox" name="system.attuned" {{checked system.attuned}}>
-    {{ localize "DND4E.Attuned" }}
-  </label>
-</div>
 
 {{#if hasBaseProps}}
 {{!-- Base Properties --}}

--- a/templates/items/parts/details-weapon.hbs
+++ b/templates/items/parts/details-weapon.hbs
@@ -1,23 +1,22 @@
 {{!-- Weapon Status --}}
 <fieldset name="weapon-status" class="weapon-status form-group stacked">
-  <legend>{{ localize "DND4E.ItemWeaponStatus" }}</legend>  
+  <legend>{{ localize "DND4E.ItemWeaponStatus" }}</legend>
   <div class="form-group">
     <label>{{localize "DND4E.Proficient"}} </label>
-    <select name="system.proficient">
-      {{selectOptions config.proficiency selected=system.proficient}}
+    <select name="system.proficient{{#if (eq system.weaponType 'implement')}}I{{/if}}">
+	  {{#if (eq system.weaponType 'implement')}}
+        {{selectOptions config.proficiency selected=system.proficientI}}
+	  {{else}}
+	    {{selectOptions config.proficiency selected=system.proficient}}
+	  {{/if}}
     </select>
   </div>
-  {{#if (eq system.weaponType 'implement')}}
-  <label class="checkbox small">
-    <input type="checkbox" name="system.proficientI" {{checked system.proficientI}}>
-    {{ localize "DND4E.Proficient" }}
-  </label>
-  {{else if system.properties.imp}}
+  {{#unless (eq system.weaponType 'implement')}}{{#if system.properties.imp}}
   <label class="checkbox small">
     <input type="checkbox" name="system.proficientI" {{checked system.proficientI}}>
     {{ localize "DND4E.ProficiencyI" }}
   </label>
-  {{/if}}
+  {{/if}}{{/unless}}
   <label class="checkbox small">
     <input type="checkbox" name="system.equipped" {{checked system.equipped}}>
     {{ localize "DND4E.Equipped" }}


### PR DESCRIPTION
- Makes the status section match for both item types
- Restores implement proficiency behaviour to previous state (replaces main "proficiency" setting for implement-only weapons, displays separately for weapliments).