### PR TITLE
Adjust how we handle bonuses sourced from Helper.applyEffects

### DIFF
--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -3,6 +3,7 @@ import { DND4E } from "../config.js";
 import { Helper } from "../helper.js";
 import { RollWithOriginalExpression } from "../roll/roll-with-expression.js";
 import { SaveThrowDialog } from "../apps/save-throw.js";
+import Roll4e from "../dice/Roll.js";
 
 /**
  * Extend the base Actor entity by defining a custom roll data structure which is ideal for the Simple system.
@@ -1947,7 +1948,7 @@ export class Actor4e extends Actor {
 
 	async rollSave(event, options) {
 		//let message = `${_loc("DND4E.RollSave")} ${options.dc || 10}`;
-		options.bonuses = foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses);
+		options.bonuses = foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses);
 		
 		let message = `(${_loc("DND4E.AbbreviationDC")} ${options.dc || 10})`;
 		if (options.effectSave) {

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1,6 +1,7 @@
 import { d20Roll, damageRoll } from "../dice.js";
 import { DND4E } from "../config.js";
 import { Helper } from "../helper.js";
+import { RollWithOriginalExpression } from "../roll/roll-with-expression.js";
 import { SaveThrowDialog } from "../apps/save-throw.js";
 
 /**
@@ -1946,6 +1947,7 @@ export class Actor4e extends Actor {
 
 	async rollSave(event, options) {
 		//let message = `${_loc("DND4E.RollSave")} ${options.dc || 10}`;
+		options.bonuses = foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses);
 		
 		let message = `(${_loc("DND4E.AbbreviationDC")} ${options.dc || 10})`;
 		if (options.effectSave) {
@@ -1977,6 +1979,7 @@ export class Actor4e extends Actor {
 			messageData: { "flags.dnd4e.roll": { type: "save", itemId: this.id } },
 			fastForward: true,
 			messageMode: options.messageMode,
+			options,
 		});
 		rollConfig.event = event;
 		

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1966,7 +1966,7 @@ export class Actor4e extends Actor {
 			options.formulaInnerData = Roll.replaceFormulaData(options.save, rollData);
 		}
 		
-		await Helper.applySaveEffects([parts], rollData, this, this.effects.get(options.effectId), "save", options);
+		await Helper.applySaveEffects(rollData, this, this.effects.get(options.effectId), "save", options);
 
 		const rollConfig = foundry.utils.mergeObject({
 			parts,

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -1964,7 +1964,7 @@ export class Actor4e extends Actor {
 			options.formulaInnerData = Roll.replaceFormulaData(options.save, rollData);
 		}
 		
-		await Helper.applySaveEffects([parts], rollData, this, this.effects.get(options.effectId), "save");
+		await Helper.applySaveEffects([parts], rollData, this, this.effects.get(options.effectId), "save", options);
 
 		const rollConfig = foundry.utils.mergeObject({
 			parts,

--- a/module/dice.js
+++ b/module/dice.js
@@ -199,10 +199,12 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			if (game.settings.get("dnd4e", "collapseSituationalBonus")) {
 				let total = 0;
 				targetBonuses.forEach(bonus => total += data.commonAttackBonuses[bonus.substring(1)].value);
-				allRollsParts.push(parts.concat([total]));
+				const partsToPush = total ? parts.concat([total]) : parts;
+				allRollsParts.push(partsToPush);
 			}
 			else {
-				allRollsParts.push(parts.concat(targetBonuses));
+				const partsToPush = targetBonuses.length ? parts.concat(targetBonuses) : parts;
+				allRollsParts.push(partsToPush);
 			}
 		}
 		

--- a/module/dice.js
+++ b/module/dice.js
@@ -137,7 +137,7 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 
 // Get the bonus for an attack roll 
 export function getAttackRollBonus({ parts = [], partsExpressionReplacements = [], data = {}, options = {} }) {
-	const roll = new MultiAttackRoll(parts.filterJoin(" + "), data, {});
+	const roll = new MultiAttackRoll(parts.filterJoin(" + "), data, options);
 	if (roll.isDeterministic) {
 		roll.evaluateSync();
 		return roll.total;

--- a/module/dice/Roll.js
+++ b/module/dice/Roll.js
@@ -20,9 +20,6 @@ export default class Roll4e extends Roll {
 			race: [],
 			untyped: [],
 		},
-		expressionArr: [],
-		formulaInnerData: {},
-		parts: [],
 	});
 
 	/* -------------------------------------------- */

--- a/module/dice/Roll.js
+++ b/module/dice/Roll.js
@@ -1,8 +1,59 @@
 import { Helper } from "../helper.js";
 
 export default class Roll4e extends Roll {
-	static parse(formula = "", data = {}) {
-		if (data.isActor) formula = Roll.replaceFormulaData(formula, data);
-		return super.parse(formula, data);
+	constructor (formula, data = {}, options = {}) {
+		super(formula, data, options);
+		foundry.utils.mergeObject(this.options, this.constructor.DEFAULT_OPTIONS, {
+			insertKeys: true,
+			insertValues: true,
+			overwrite: false,
+		});
+	}
+
+	/* -------------------------------------------------- */
+
+	static DEFAULT_OPTIONS = Object.freeze({
+		bonuses: {
+			feat: [],
+			item: [],
+			power: [],
+			race: [],
+			untyped: [],
+		},
+		expressionArr: [],
+		formulaInnerData: {},
+		parts: [],
+	});
+
+	/* -------------------------------------------- */
+
+	/** @override */
+	async evaluate(options = {}) {
+		this.processBonuses();
+		return super.evaluate(options);
+	}
+
+	/* -------------------------------------------- */
+
+	/** @override */
+	evaluateSync(options = {}) {
+		this.processBonuses();
+		return super.evaluateSync(options);
+	}
+
+	/* -------------------------------------------- */
+
+	processBonuses() {
+		for (const [type, bonuses] of Object.entries(this.options.bonuses)) {
+			if (bonuses.length) {
+				const bonus = type == "untyped" ? bonuses.reduce((acc, curr) => acc + parseInt(curr), 0) : bonuses.reduce((max, curr) => Math.max(max, parseInt(curr)), -Infinity);
+				const bonusString = String(bonus);
+				this._formula += ` + (${bonus})`;
+				const operatorTerm = new foundry.dice.terms.OperatorTerm({ operator: "+" });
+				const parentheticalTerm = new foundry.dice.terms.ParentheticalTerm({ term: bonusString });
+				this.terms.push(operatorTerm);
+				this.terms.push(parentheticalTerm);
+			}
+		}
 	}
 }

--- a/module/helper.js
+++ b/module/helper.js
@@ -953,7 +953,7 @@ export class Helper {
 						const rollData = parent.getRollData();
 						let options = { bonuses: foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses) };
 						await Helper.applySaveEffects(rollData, parent, newEffectData, "saveDC", options);
-						const bonusRoll = await new RollWithOriginalExpression("0", null, options).evaluate();
+						const bonusRoll = await new Roll4e("0", null, options).evaluate();
 						dcBonus += bonusRoll?.total;
 						newEffectData.system.saveDC = String(Number(newEffectData.system.saveDC) + dcBonus);
 					}

--- a/module/helper.js
+++ b/module/helper.js
@@ -1,4 +1,5 @@
 import { RollWithOriginalExpression } from "./roll/roll-with-expression.js";
+import Roll4e from "./dice/Roll.js";
 
 export class Helper {
 
@@ -950,7 +951,7 @@ export class Helper {
 					if (parent && newEffectData.system.saveDC) {
 						let dcBonus = 0;
 						const rollData = parent.getRollData();
-						let options = { bonuses: foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses) };
+						let options = { bonuses: foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses) };
 						await Helper.applySaveEffects(rollData, parent, newEffectData, "saveDC", options);
 						const bonusRoll = await new RollWithOriginalExpression("0", null, options).evaluate();
 						dcBonus += bonusRoll?.total;

--- a/module/helper.js
+++ b/module/helper.js
@@ -387,15 +387,14 @@ export class Helper {
 					console.debug(`${debug} ${suitableKeywords.join(", ")}`);
 				}
 
-				//await this._applyEffectsInternal(arrayOfParts, rollData, powerData, effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage);
-				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage, options);
+				await this._applyEffectsInternal(effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage, options);
 			}
 		}
 	}
 
 	// A pared down version of applyEffects suitable for determining bonuses to saving throws against effects or the DCs of effects. Only needs to know
 	// about effect keywords and statuses inflicted by the effect. effectType can be `save` or `saveDC`.
-	static async applySaveEffects(arrayOfParts, rollData, actorData, effectData, effectType, options = {}) {
+	static async applySaveEffects(rollData, actorData, effectData, effectType, options = {}) {
 		const debug = game.settings.get("dnd4e", "debugEffectBonus") ? "D&D4e |" : "";
 		if (actorData.effects) {
 			if (debug) {
@@ -476,12 +475,12 @@ export class Helper {
 					console.debug(`${debug} ${suitableKeywords.join(", ")}`);
 				}
 
-				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug, null, options);
+				await this._applyEffectsInternal(effectsToProcess, suitableKeywords, actorData, effectType, debug, null, options);
 			}
 		}
 	}
 
-	static async _applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage = [], options = {}) {
+	static async _applyEffectsInternal(effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage = [], options = {}) {
 		// filter out to just the relevant effects by keyword
 		const matchingEffects = effectsToProcess.filter((effect) => {
 			const keyParts = effect.key.split(".");
@@ -522,12 +521,8 @@ export class Helper {
 						}
 					});
 				}
-				else if (bonusType === "untyped") {
-					if ("untyped" in options.bonuses) options.bonuses.untyped += effectValue;
-				}
 				else {
-					const key = `${bonusType}EffectBonus`;
-					if (options.bonuses?.typed[bonusType]) options.bonuses.typed[bonusType].push(effectValue);
+					if (("bonuses" in options) && (bonusType in options.bonuses)) options.bonuses[bonusType].push(effectValue);
 				}
 			}
 			else {
@@ -954,10 +949,9 @@ export class Helper {
 
 					if (parent && newEffectData.system.saveDC) {
 						let dcBonus = 0;
-						const dcParts = [];
 						const rollData = parent.getRollData();
 						let options = { bonuses: foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses) };
-						await Helper.applySaveEffects([dcParts], rollData, parent, newEffectData, "saveDC", options);
+						await Helper.applySaveEffects(rollData, parent, newEffectData, "saveDC", options);
 						const bonusRoll = await new RollWithOriginalExpression("0", null, options).evaluate();
 						dcBonus += bonusRoll?.total;
 						newEffectData.system.saveDC = String(Number(newEffectData.system.saveDC) + dcBonus);

--- a/module/helper.js
+++ b/module/helper.js
@@ -1,3 +1,5 @@
+import { RollWithOriginalExpression } from "./roll/roll-with-expression.js";
+
 export class Helper {
 
 	static async executeMacro(item) {
@@ -161,7 +163,7 @@ export class Helper {
 		return new RegExp(/@([a-z.0-9_-]+)/gi);
 	}
 
-	static async applyEffects(arrayOfParts, rollData, actorData, powerData, weaponData = null, effectType, extraDamage = []) {
+	static async applyEffects(arrayOfParts, rollData, actorData, powerData, weaponData = null, effectType, extraDamage = [], options = {}) {
 		const debug = game.settings.get("dnd4e", "debugEffectBonus") ? "D&D4e |" : "";
 		if (actorData.effects) {
 			const powerInnerData = powerData.system;
@@ -386,14 +388,14 @@ export class Helper {
 				}
 
 				//await this._applyEffectsInternal(arrayOfParts, rollData, powerData, effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage);
-				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage);
+				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage, options);
 			}
 		}
 	}
 
 	// A pared down version of applyEffects suitable for determining bonuses to saving throws against effects or the DCs of effects. Only needs to know
 	// about effect keywords and statuses inflicted by the effect. effectType can be `save` or `saveDC`.
-	static async applySaveEffects(arrayOfParts, rollData, actorData, effectData, effectType) {
+	static async applySaveEffects(arrayOfParts, rollData, actorData, effectData, effectType, options = {}) {
 		const debug = game.settings.get("dnd4e", "debugEffectBonus") ? "D&D4e |" : "";
 		if (actorData.effects) {
 			if (debug) {
@@ -416,7 +418,7 @@ export class Helper {
 			
 			// No global bonuses to save DCs
 			if (effectType === "save") {
-				//Dummy up some extra effects to represent global atk/damage bonuses
+				//Dummy up some extra effects to represent global save bonuses
 				const globalMods = actorData.system.details.saves;
 				if (globalMods.value) {
 					for (const [key, value] of Object.entries(globalMods)) {
@@ -459,7 +461,7 @@ export class Helper {
 				if (effectData?.system.dots.length) {
 					suitableKeywords.push("ongoing");
 					effectData.system.dots.forEach((d) => {
-						d.typesArray.forEach((t) => {
+						d.types.forEach((t) => {
 							suitableKeywords.push(t);
 							// Since game text describes this as "untyped" let's allow users to use that language in effect keys.
 							if (t === "physical") suitableKeywords.push("untyped");
@@ -474,13 +476,12 @@ export class Helper {
 					console.debug(`${debug} ${suitableKeywords.join(", ")}`);
 				}
 
-				//await this._applyEffectsInternal(arrayOfParts, rollData, powerData, effectsToProcess, suitableKeywords, actorData, effectType, debug);
-				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug);
+				await this._applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug, null, options);
 			}
 		}
 	}
 
-	static async _applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage = []) {
+	static async _applyEffectsInternal(arrayOfParts, rollData, effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage = [], options = {}) {
 		// filter out to just the relevant effects by keyword
 		const matchingEffects = effectsToProcess.filter((effect) => {
 			const keyParts = effect.key.split(".");
@@ -500,7 +501,6 @@ export class Helper {
 			matchingEffects.forEach((effect) => console.log(`${debug} ${effect.name} : ${effect.key} = ${effect.value}`));
 		}
 
-		const newParts = {};
 		for (const effect of matchingEffects) {
 			const keyParts = effect.key.split(".");
 			if (keyParts.length >= 4) {
@@ -523,53 +523,17 @@ export class Helper {
 					});
 				}
 				else if (bonusType === "untyped") {
-					if (newParts["untypedEffectBonus"]) {
-						newParts["untypedEffectBonus"] = newParts["untypedEffectBonus"] + effectValue;
-						if (debug) {
-							console.log(`${debug} ${effect.name} : ${effect.key} => ${effect.value} = ${effectValue}: Additional untyped Bonus.	They Stack.`);
-						}
-					}
-					else {
-						newParts["untypedEffectBonus"] = effectValue;
-						if (debug) {
-							console.log(`${debug} ${effect.name} : ${effect.key} => ${effect.value} = ${effectValue}: First untyped Bonus`);
-						}
-					}
+					if ("untyped" in options.bonuses) options.bonuses.untyped += effectValue;
 				}
 				else {
 					const key = `${bonusType}EffectBonus`;
-					if (newParts[key]) {
-						if (newParts[key] < effectValue) {
-							newParts[key] = effectValue;
-							if (debug) {
-								console.log(`${debug} ${effect.name} : ${effect.key} => ${effect.value} = ${effectValue}: Is greater than existing ${bonusType}, replacing`);
-							}
-						}
-						else {
-							if (debug) {
-								console.log(`${debug} ${effect.name} : ${effect.key} => ${effect.value} = ${effectValue} : Is not greater than existing ${bonusType}, discarding`);
-							}
-						}
-					}
-					else {
-						newParts[key] = effectValue;
-						if (debug) {
-							console.log(`${debug} ${effect.name} : ${effect.key} => ${effect.value} = ${effectValue} : First ${bonusType} Bonus`);
-						}
-					}
+					if (options.bonuses?.typed[bonusType]) options.bonuses.typed[bonusType].push(effectValue);
 				}
 			}
 			else {
 				ui.notifications.warn(`Tried to process a bonus effect that had too few .'s in it: ${effect.key}: ${effect.value}`);
 				Helper.debugLog(`Tried to process a bonus effect that had too few .'s in it: ${effect.key}: ${effect.value}`);
 			}
-		}
-		
-		for (const [key, value] of Object.entries(newParts)) {
-			for (const parts of arrayOfParts) {
-				parts.push("@" + key);
-			}
-			rollData[key] = value;
 		}
 	}
 
@@ -992,11 +956,10 @@ export class Helper {
 						let dcBonus = 0;
 						const dcParts = [];
 						const rollData = parent.getRollData();
-						await Helper.applySaveEffects([dcParts], rollData, parent, newEffectData, "saveDC");
-						for (let i = 0; i < dcParts.length; i++) {
-							const key = dcParts[i].slice(1);
-							dcBonus += rollData[key];
-						}
+						let options = { bonuses: foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses) };
+						await Helper.applySaveEffects([dcParts], rollData, parent, newEffectData, "saveDC", options);
+						const bonusRoll = await new RollWithOriginalExpression("0", null, options).evaluate();
+						dcBonus += bonusRoll?.total;
 						newEffectData.system.saveDC = String(Number(newEffectData.system.saveDC) + dcBonus);
 					}
 

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -2,6 +2,7 @@ import { d20Roll, damageRoll, getAttackRollBonus } from "../dice.js";
 import AbilityUseDialog from "../apps/ability-use-dialog.js";
 import { DND4E } from "../config.js";
 import { Helper } from "../helper.js";
+import { RollWithOriginalExpression } from "../roll/roll-with-expression.js";
 
 /**
  * Override and extend the basic :class:`Item` implementation
@@ -1589,6 +1590,7 @@ export default class Item4e extends Item {
 	async rollAttack(options = {}) {
 		const itemData = this.system;
 		const actorData = this.actor;
+		options.bonuses = foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses);
 		// itemData.weaponUse = 2nd dropdown - default/none/weapon
 		// itemData.weaponType = first dropdown: melee/ranged/implement/none etc...
 		// find details on the weapon being used, if any.   This is null if no weapon is being used.
@@ -1700,7 +1702,7 @@ export default class Item4e extends Item {
 			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponUse.system.consume, "weapon used by the power");
 		}
 		
-		await Helper.applyEffects([parts], rollData, actorData, this, weaponUse, "attack");
+		await Helper.applyEffects([parts], rollData, actorData, this, weaponUse, "attack", null, options);
 
 		// Compose roll options
 		const rollConfig = {
@@ -1819,7 +1821,7 @@ export default class Item4e extends Item {
 			};
 			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponUse.system.consume, "weapon used by the power");
 		}
-		await Helper.applyEffects([parts], rollData, actorData, this, weaponUse, "attack");
+		await Helper.applyEffects([parts], rollData, actorData, this, weaponUse, "attack", null, options);
 
 		// Compose roll options
 		const rollConfig = {
@@ -2104,7 +2106,7 @@ export default class Item4e extends Item {
 			}
 
 		};
-		const options = { formulaInnerData: {}, divisors: { normal: { value: 1, reason: [] }, miss: { value: 1, reason: [] }, crit: { value: 1, reason: [] } } };
+		const options = { formulaInnerData: {}, divisors: { normal: { value: 1, reason: [] }, miss: { value: 1, reason: [] }, crit: { value: 1, reason: [] } }, bonuses: foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses) };
 		const secondaryPartsHelper = (formula, damageType) => {
 			// store the values that were used to sub in any formulas
 			options.formulaInnerData = foundry.utils.mergeObject(options.formulaInnerData, Helper.getDataObject(formula, rollData));
@@ -2240,7 +2242,7 @@ export default class Item4e extends Item {
 		const effectDamageParts = [];
 		const extraDamageParts = [];
 		if (!this.system?.hit?.damageBonusNull) {
-			await Helper.applyEffects([effectDamageParts], rollData, actorData, this, weaponUse, "damage", extraDamageParts);
+			await Helper.applyEffects([effectDamageParts], rollData, actorData, this, weaponUse, "damage", extraDamageParts, options);
 			effectDamageParts.forEach(part => {
 				const value = rollData[part.substring(1)];
 				damageFormula += `+ ${value}`;

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -1,8 +1,8 @@
 import { d20Roll, damageRoll, getAttackRollBonus } from "../dice.js";
-import AbilityUseDialog from "../apps/ability-use-dialog.js";
 import { DND4E } from "../config.js";
 import { Helper } from "../helper.js";
-import { RollWithOriginalExpression } from "../roll/roll-with-expression.js";
+import AbilityUseDialog from "../apps/ability-use-dialog.js";
+import Roll4e from "../dice/Roll.js";
 
 /**
  * Override and extend the basic :class:`Item` implementation
@@ -1590,7 +1590,7 @@ export default class Item4e extends Item {
 	async rollAttack(options = {}) {
 		const itemData = this.system;
 		const actorData = this.actor;
-		options.bonuses = foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses);
+		options.bonuses = foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses);
 		// itemData.weaponUse = 2nd dropdown - default/none/weapon
 		// itemData.weaponType = first dropdown: melee/ranged/implement/none etc...
 		// find details on the weapon being used, if any.   This is null if no weapon is being used.
@@ -1758,6 +1758,8 @@ export default class Item4e extends Item {
 
 	async getAttackBonus(options = {}) {
 		if (!this.hasAttack) return;
+
+		options.bonuses = foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses);
 
 		const itemData = this.system;
 		const actorData = this.actor;
@@ -2106,7 +2108,7 @@ export default class Item4e extends Item {
 			}
 
 		};
-		const options = { formulaInnerData: {}, divisors: { normal: { value: 1, reason: [] }, miss: { value: 1, reason: [] }, crit: { value: 1, reason: [] } }, bonuses: foundry.utils.deepClone(RollWithOriginalExpression.DEFAULT_OPTIONS.bonuses) };
+		const options = { formulaInnerData: {}, divisors: { normal: { value: 1, reason: [] }, miss: { value: 1, reason: [] }, crit: { value: 1, reason: [] } }, bonuses: foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses) };
 		const secondaryPartsHelper = (formula, damageType) => {
 			// store the values that were used to sub in any formulas
 			options.formulaInnerData = foundry.utils.mergeObject(options.formulaInnerData, Helper.getDataObject(formula, rollData));

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -2410,7 +2410,7 @@ export default class Item4e extends Item {
 		const parts = itemData.damage.parts.map(d => d[0]);
 		const partsExpressionReplacement = itemData.damage.parts.map(part => { return { target: part[0], value: "@wep2ndryDamage" };});
 
-		const options = { formulaInnerData: {} };
+		const options = { formulaInnerData: {}, bonuses: foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses) };
 		const formulaHelper = (formula) => {
 			// store the values that were used to sub in any formulas
 			options.formulaInnerData = foundry.utils.mergeObject(options.formulaInnerData, Helper.getDataObject(formula, actorData.getRollData(), this.getRollData()));

--- a/module/roll/multi-attack-roll.js
+++ b/module/roll/multi-attack-roll.js
@@ -1,11 +1,12 @@
 import { DND4E } from "../config.js";
+import Roll4e from "../dice/Roll.js";
 
 /**
  * An extension of the default Foundry Roll class for handling multiattack rolls and displaying them in a single chat message
  */
 import { RollWithOriginalExpression } from "./roll-with-expression.js";
 
-export class MultiAttackRoll extends Roll {
+export class MultiAttackRoll extends Roll4e {
 	constructor (formula, data = {}, options = {}) {
 		super(formula, data, options);
 		this.rollArray = [];

--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -41,7 +41,69 @@ export class RollWithOriginalExpression extends Roll {
      */
 	constructor (formula, data = {}, options = {}) {
 		super(formula, data, foundry.utils.mergeObject({ expression: formula, originalFormula: formula }, options));
+		foundry.utils.mergeObject(this.options, this.constructor.DEFAULT_OPTIONS, {
+			insertKeys: true,
+			insertValues: true,
+			overwrite: false,
+		});
 		this.expression = options.expression ? options.expression : formula;
+	}
+
+	/* -------------------------------------------------- */
+
+	static DEFAULT_OPTIONS = Object.freeze({
+		bonuses: {
+			typed: {
+				feat: [],
+				item: [],
+				power: [],
+				race: [],
+			},
+			untyped: 0,
+		},
+	});
+
+	/* -------------------------------------------- */
+
+	/** @override */
+	async evaluate(options = {}) {
+		this.processBonuses();
+		return super.evaluate(options);
+	}
+
+	/* -------------------------------------------- */
+
+	processBonuses() {
+		for (const [type, bonuses] of Object.entries(this.options.bonuses.typed)) {
+			if (bonuses.length) {
+				const bonus = bonuses.reduce((acc, curr) => acc + parseInt(curr), 0);
+				const bonusString = String(bonus);
+				const bonusPath = `${type}EffectBonus`;
+				this._formula += ` + (${bonus})`;
+				this.expression += ` + @${bonusPath}`;
+				this.options.expressionArr?.push(`@${bonusPath}`);
+				this.options.parts?.push(bonusString);
+				if (this.options?.formulaInnerData) this.options.formulaInnerData[bonusPath] = bonusString;
+				const operatorTerm = new foundry.dice.terms.OperatorTerm({ operator: "+" });
+				const parentheticalTerm = new foundry.dice.terms.ParentheticalTerm({ term: bonusString });
+				this.terms.push(operatorTerm);
+				this.terms.push(parentheticalTerm);
+			}
+		}
+		if (this.options.bonuses.untyped) {
+			const bonus = this.options.bonuses.untyped;
+			const bonusString = String(bonus);
+			this._formula += ` + (${bonus})`;
+			this.expression += " + @untypedEffectBonus";
+			this.options.expressionArr?.push("@untypedEffectBonus");
+			this.options.parts?.push(bonusString);
+			if (this.options?.formulaInnerData) this.options.formulaInnerData.untypedEffectBonus = bonusString;
+			const operatorTerm = new foundry.dice.terms.OperatorTerm({ operator: "+" });
+			const parentheticalTerm = new foundry.dice.terms.ParentheticalTerm({ term: bonusString });
+			this.terms.push(operatorTerm);
+			this.terms.push(parentheticalTerm);
+		}
+		this.options.expression = this.expression;
 	}
 
 	/**

--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -53,14 +53,15 @@ export class RollWithOriginalExpression extends Roll {
 
 	static DEFAULT_OPTIONS = Object.freeze({
 		bonuses: {
-			typed: {
-				feat: [],
-				item: [],
-				power: [],
-				race: [],
-			},
-			untyped: 0,
+			feat: [],
+			item: [],
+			power: [],
+			race: [],
+			untyped: [],
 		},
+		expressionArr: [],
+		formulaInnerData: {},
+		parts: [],
 	});
 
 	/* -------------------------------------------- */
@@ -74,34 +75,21 @@ export class RollWithOriginalExpression extends Roll {
 	/* -------------------------------------------- */
 
 	processBonuses() {
-		for (const [type, bonuses] of Object.entries(this.options.bonuses.typed)) {
+		for (const [type, bonuses] of Object.entries(this.options.bonuses)) {
 			if (bonuses.length) {
-				const bonus = bonuses.reduce((acc, curr) => acc + parseInt(curr), 0);
+				const bonus = type == "untyped" ? bonuses.reduce((acc, curr) => acc + parseInt(curr), 0) : bonuses.reduce((max, curr) => Math.max(max, parseInt(curr)), -Infinity);
 				const bonusString = String(bonus);
 				const bonusPath = `${type}EffectBonus`;
 				this._formula += ` + (${bonus})`;
 				this.expression += ` + @${bonusPath}`;
-				this.options.expressionArr?.push(`@${bonusPath}`);
-				this.options.parts?.push(bonusString);
-				if (this.options?.formulaInnerData) this.options.formulaInnerData[bonusPath] = bonusString;
+				this.options.expressionArr.push(`@${bonusPath}`);
+				this.options.parts.push(bonusString);
+				this.options.formulaInnerData[bonusPath] = bonusString;
 				const operatorTerm = new foundry.dice.terms.OperatorTerm({ operator: "+" });
 				const parentheticalTerm = new foundry.dice.terms.ParentheticalTerm({ term: bonusString });
 				this.terms.push(operatorTerm);
 				this.terms.push(parentheticalTerm);
 			}
-		}
-		if (this.options.bonuses.untyped) {
-			const bonus = this.options.bonuses.untyped;
-			const bonusString = String(bonus);
-			this._formula += ` + (${bonus})`;
-			this.expression += " + @untypedEffectBonus";
-			this.options.expressionArr?.push("@untypedEffectBonus");
-			this.options.parts?.push(bonusString);
-			if (this.options?.formulaInnerData) this.options.formulaInnerData.untypedEffectBonus = bonusString;
-			const operatorTerm = new foundry.dice.terms.OperatorTerm({ operator: "+" });
-			const parentheticalTerm = new foundry.dice.terms.ParentheticalTerm({ term: bonusString });
-			this.terms.push(operatorTerm);
-			this.terms.push(parentheticalTerm);
 		}
 		this.options.expression = this.expression;
 	}

--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -62,20 +62,16 @@ export class RollWithOriginalExpression extends Roll4e {
 
 	/** @override */
 	processBonuses() {
+		super.processBonuses();
 		for (const [type, bonuses] of Object.entries(this.options.bonuses)) {
 			if (bonuses.length) {
 				const bonus = type == "untyped" ? bonuses.reduce((acc, curr) => acc + parseInt(curr), 0) : bonuses.reduce((max, curr) => Math.max(max, parseInt(curr)), -Infinity);
 				const bonusString = String(bonus);
 				const bonusPath = `${type}EffectBonus`;
-				this._formula += ` + (${bonus})`;
 				this.expression += ` + @${bonusPath}`;
 				this.options.expressionArr.push(`@${bonusPath}`);
 				this.options.parts.push(bonusString);
 				this.options.formulaInnerData[bonusPath] = bonusString;
-				const operatorTerm = new foundry.dice.terms.OperatorTerm({ operator: "+" });
-				const parentheticalTerm = new foundry.dice.terms.ParentheticalTerm({ term: bonusString });
-				this.terms.push(operatorTerm);
-				this.terms.push(parentheticalTerm);
 			}
 		}
 		this.options.expression = this.expression;

--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -1,4 +1,5 @@
 import { Helper } from "../helper.js";
+import Roll4e from "../dice/Roll.js";
 
 /**
  * Roll that will also have a roll for the expression used to build the row, and highlighting for how elements correspond to formula numbers.
@@ -14,7 +15,7 @@ import { Helper } from "../helper.js";
  *
  * It is highly recommended to use the static member {@link createRoll} method to create new instances of this class as that manages a lot of the constructor arguments for you.
  */
-export class RollWithOriginalExpression extends Roll {
+export class RollWithOriginalExpression extends Roll4e {
 
 	/**
      * Has an enhanced Options object with 2 additional properties:
@@ -52,13 +53,6 @@ export class RollWithOriginalExpression extends Roll {
 	/* -------------------------------------------------- */
 
 	static DEFAULT_OPTIONS = Object.freeze({
-		bonuses: {
-			feat: [],
-			item: [],
-			power: [],
-			race: [],
-			untyped: [],
-		},
 		expressionArr: [],
 		formulaInnerData: {},
 		parts: [],
@@ -67,13 +61,6 @@ export class RollWithOriginalExpression extends Roll {
 	/* -------------------------------------------- */
 
 	/** @override */
-	async evaluate(options = {}) {
-		this.processBonuses();
-		return super.evaluate(options);
-	}
-
-	/* -------------------------------------------- */
-
 	processBonuses() {
 		for (const [type, bonuses] of Object.entries(this.options.bonuses)) {
 			if (bonuses.length) {


### PR DESCRIPTION
I was thinking about how best to handle effects wherein a target grants a bonus to attack rolls made against it, and the issue was that we're basically wholly constructing the roll, evaluating typed bonuses and all, long before we have any targets. With this PR, we instead pass those bonuses down to the roll via `options` and then let the roll sort out its own bonuses when it comes time to evaluate. In this way, once we _do_ have targets, we can iterate over their effects for `grants` type bonuses and just push them into the bonus arrays in `options` before we evaluate the roll (`grants` type bonuses not in this PR; that's a future endeavor).

I will add that I am kind of viewing this as a stopgap to, relatively quickly, allow us to provide the means to implement more of what can be done in the D&D4e game. But I find our whole roll process, with the RollWithOriginalExpression stuff, terribly difficult to wrap my head around, and I would very much like to do a big ol' refactor of the entire procedure. Of course that would be a significant undertaking, so it's kind of a backburner idea for the moment. But, in that future, I think streamlining all of this is going to make target-aware damage rolls a whole lot easier.