### PR TITLE
Fix RollWithOriginalExpression not getting the bonuses object

### DIFF
--- a/module/roll/roll-with-expression.js
+++ b/module/roll/roll-with-expression.js
@@ -53,6 +53,7 @@ export class RollWithOriginalExpression extends Roll4e {
 	/* -------------------------------------------------- */
 
 	static DEFAULT_OPTIONS = Object.freeze({
+		...Roll4e.DEFAULT_OPTIONS,
 		expressionArr: [],
 		formulaInnerData: {},
 		parts: [],


### PR DESCRIPTION
In contrast to the previous PR, this one definitely should be merged before a release so that rolls actually work (juggling like five different branches at the same time is rough 😔).