### PR TITLE
Add ability for Active Effects to grant typed bonuses to attack rolls targeting the affected actor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ packs/*
 dnd4e.lock
 
 foundry-config.yaml
-foundry
+foundry/*

--- a/module/dice.js
+++ b/module/dice.js
@@ -1,5 +1,6 @@
 import { Helper } from "./helper.js";
 import { MultiAttackRoll } from "./roll/multi-attack-roll.js";
+import Roll4e from "./dice/Roll.js";
 import RollDialog from "./apps/dice/roll-dialog.js";
 import { RollWithOriginalExpression } from "./roll/roll-with-expression.js";
 
@@ -348,7 +349,11 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 		const rollExpression = allRollsParts[rollExpressionIdx];
 		let subroll;
 		try {
-			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, options);
+			let targetOptions = foundry.utils.deepClone(options);
+			const targetActor = targets[rollExpressionIdx]?.document.actor;
+			const IS_TARGET = true;
+			if (targetActor) await Helper.applyEffects(data, targetActor, item, weaponUse, "attack", null, IS_TARGET, targetOptions);
+			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}
 		catch(err) {
 			// let the user know what is going on if the roll doesn't evaluate.
@@ -362,20 +367,24 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const attackedDef = targetData.targDefArray[rollExpressionIdx];
 			let targName = targets[rollExpressionIdx].name;
 			let targDefVal = targets[rollExpressionIdx].document.actor.system.defences[attackedDef]?.value;
-			const defParts = [];
-			await Helper.applyEffects([defParts], data, targets[rollExpressionIdx].actor, item, weaponUse, "defence");
-			for (let i = 0; i < defParts.length; i++) {
-				const key = defParts[i].slice(1);
-				const undecoratedKey = key.slice(0, -11);
-				// Any global typed bonus to this defence is already accounted for.
-				let currentBonus = 0;
-				if (undecoratedKey !== "untyped") {
-					const thisDefenceBonus = targets[rollExpressionIdx].document.actor.system.defences[attackedDef][undecoratedKey];
-					const globalDefenceBonus = targets[rollExpressionIdx].document.actor.system.modifiers.defences[undecoratedKey];
-					currentBonus = Math.max(thisDefenceBonus, globalDefenceBonus);
+			let defOptions = { bonuses: foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses) };
+			await Helper.applyEffects(data, targets[rollExpressionIdx].actor, item, weaponUse, "defence", null, null, defOptions);
+
+			let bonusesTotal = 0;
+			for (const [type, bonuses] of Object.entries(defOptions.bonuses)) {
+				if (bonuses.length) {
+					bonuses.push(actor.system.defences[attackedDef][type]);
+					const bonus = type == "untyped" ? bonuses.reduce((acc, curr) => acc + parseInt(curr), 0) : bonuses.reduce((max, curr) => Math.max(max, parseInt(curr)), -Infinity);
+					let currentBonus = 0;
+					if (type !== "untyped") {
+						const thisDefenceBonus = targets[rollExpressionIdx].document.actor.system.defences[attackedDef][type];
+						const globalDefenceBonus = targets[rollExpressionIdx].document.actor.system.modifiers.defences[type];
+						currentBonus = Math.max(thisDefenceBonus, globalDefenceBonus);
+					}
+					bonusesTotal += Math.max((bonus - currentBonus), 0);
 				}
-				targDefVal += Math.max(data[key] - currentBonus, 0);
 			}
+			targDefVal += bonusesTotal;
 			const meleeRange = weaponUse?.system.properties.rch ? 2 : 1;
 			const dist = Helper.computeDistance(actor, targets[rollExpressionIdx]);
 			const isThrown = (weaponUse?.system.properties.thv || weaponUse?.system.properties.tlg) && (dist > meleeRange);

--- a/module/dice/Roll.js
+++ b/module/dice/Roll.js
@@ -47,7 +47,9 @@ export default class Roll4e extends Roll {
 				const bonusString = String(bonus);
 				this._formula += ` + (${bonus})`;
 				const operatorTerm = new foundry.dice.terms.OperatorTerm({ operator: "+" });
-				const parentheticalTerm = new foundry.dice.terms.ParentheticalTerm({ term: bonusString });
+				const options = {};
+				if (this.terms[0]?.flavor) options.flavor = this.terms[0].flavor;
+				const parentheticalTerm = new foundry.dice.terms.ParentheticalTerm({ term: bonusString, options });
 				this.terms.push(operatorTerm);
 				this.terms.push(parentheticalTerm);
 			}

--- a/module/helper.js
+++ b/module/helper.js
@@ -168,39 +168,49 @@ export class Helper {
 		return new RegExp(/@([a-z.0-9_-]+)/gi);
 	}
 
-	static async applyEffects(arrayOfParts, rollData, actorData, powerData, weaponData = null, effectType, extraDamage = [], options = {}) {
+	static async applyEffects(rollData, actor, power, weapon = null, effectType, extraDamage = [], target = false, options = {}) {
 		const debug = game.settings.get("dnd4e", "debugEffectBonus") ? "D&D4e |" : "";
-		if (actorData.effects) {
-			const powerInnerData = powerData.system;
-			const weaponInnerData = weaponData?.system;
+		const actorEffects = [...actor.allApplicableEffects()];
+		if (actorEffects.length) {
+			const powerInnerData = power.system;
+			const weaponInnerData = weapon?.system;
 			let enhValue = weaponInnerData?.enhance || 0;
 			if (debug) {
-				console.log(`${debug} Debugging ${effectType} effects for ${powerData.name}.	Supplied Weapon: ${weaponData?.name}`);
+				console.log(`${debug} Debugging ${effectType} effects for ${power.name}.	Supplied Weapon: ${weapon?.name}`);
 			}
 			
 			//Using inherent enhancements?
 			if (game.settings.get("dnd4e", "inhEnh")) {
 				//If our enhancement is lower than the inherent level, adjust it upward
-				enhValue = Math.max(weaponInnerData?.enhance || 0, Helper.findKeyScale(actorData.system.details.level, CONFIG.DND4E.SCALE.basic, 1));
-				Helper.debugLog(`Checked inherent atk/dmg enhancement of +'${Helper.findKeyScale(actorData.system.details.level, CONFIG.DND4E.SCALE.basic, 1)}' for this level against weapon value of +${weaponInnerData?.enhance})`);
+				enhValue = Math.max(weaponInnerData?.enhance || 0, Helper.findKeyScale(actor.system.details.level, CONFIG.DND4E.SCALE.basic, 1));
+				Helper.debugLog(`Checked inherent atk/dmg enhancement of +'${Helper.findKeyScale(actor.system.details.level, CONFIG.DND4E.SCALE.basic, 1)}' for this level against weapon value of +${weaponInnerData?.enhance})`);
 			}
 
 			const effectsToProcess = [];
-			const effects = actorData.getActiveEffects().filter((effect) => effect.disabled === false);
-			effects.forEach((effect) => {
+			const effectTargets = [];
+			if (target) {
+				effectTargets.push("grants");
+			} else {
+				effectTargets.push("power");
+				if (weaponInnerData) effectTargets.push("weapon");
+			}
+			actorEffects.forEach((effect) => {
 				effect.changes.forEach((change => {
-					if (change.key.startsWith(`power.${effectType}`) || (weaponInnerData && change.key.startsWith(`weapon.${effectType}`))) {
-						effectsToProcess.push({
-							name: effect.name,
-							key: change.key,
-							value: change.value,
-						});
+					for (const effectTarget of effectTargets) {
+						if (change.key.startsWith(`${effectTarget}.${effectType}`)) {
+							effectsToProcess.push({
+								name: effect.name,
+								key: change.key,
+								value: change.value,
+							});
+							break;
+						}
 					}
 				}));
 			});
 			
 			//Dummy up some extra effects to represent global atk/damage bonuses
-			const globalMods = actorData.system.modifiers;
+			const globalMods = actor.system.modifiers;
 			if (globalMods[effectType]?.value) {
 				for (const [key, value] of Object.entries(globalMods[effectType])) {
 					//No way to sort bonus array types, so we'll combine them with untyped before checks.
@@ -392,22 +402,22 @@ export class Helper {
 					console.debug(`${debug} ${suitableKeywords.join(", ")}`);
 				}
 
-				await this._applyEffectsInternal(effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage, options);
+				await this._applyEffectsInternal(effectsToProcess, suitableKeywords, actor, effectType, debug, extraDamage, options);
 			}
 		}
 	}
 
 	// A pared down version of applyEffects suitable for determining bonuses to saving throws against effects or the DCs of effects. Only needs to know
 	// about effect keywords and statuses inflicted by the effect. effectType can be `save` or `saveDC`.
-	static async applySaveEffects(rollData, actorData, effectData, effectType, options = {}) {
+	static async applySaveEffects(rollData, actor, effectData, effectType, options = {}) {
 		const debug = game.settings.get("dnd4e", "debugEffectBonus") ? "D&D4e |" : "";
-		if (actorData.effects) {
+		if (actor.effects) {
 			if (debug) {
 				Helper.debugLog(`${debug} Debugging ${effectType} effects for ${effectData?.name}.`);
 			}
 
 			const effectsToProcess = [];
-			const effects = actorData.getActiveEffects().filter((effect) => effect.disabled === false);
+			const effects = actor.getActiveEffects().filter((effect) => effect.disabled === false);
 			effects.forEach((effect) => {
 				effect.changes.forEach((change => {
 					if (change.key.startsWith(`effect.${effectType}`)) {
@@ -423,7 +433,7 @@ export class Helper {
 			// No global bonuses to save DCs
 			if (effectType === "save") {
 				//Dummy up some extra effects to represent global save bonuses
-				const globalMods = actorData.system.details.saves;
+				const globalMods = actor.system.details.saves;
 				if (globalMods.value) {
 					for (const [key, value] of Object.entries(globalMods)) {
 						//No way to sort bonus array types, so we'll combine them with untyped before checks.
@@ -480,12 +490,12 @@ export class Helper {
 					console.debug(`${debug} ${suitableKeywords.join(", ")}`);
 				}
 
-				await this._applyEffectsInternal(effectsToProcess, suitableKeywords, actorData, effectType, debug, null, options);
+				await this._applyEffectsInternal(effectsToProcess, suitableKeywords, actor, effectType, debug, null, options);
 			}
 		}
 	}
 
-	static async _applyEffectsInternal(effectsToProcess, suitableKeywords, actorData, effectType, debug, extraDamage = [], options = {}) {
+	static async _applyEffectsInternal(effectsToProcess, suitableKeywords, actor, effectType, debug, extraDamage = [], options = {}) {
 		// filter out to just the relevant effects by keyword
 		const matchingEffects = effectsToProcess.filter((effect) => {
 			const keyParts = effect.key.split(".");
@@ -509,7 +519,7 @@ export class Helper {
 			const keyParts = effect.key.split(".");
 			if (keyParts.length >= 4) {
 				const bonusType = keyParts[keyParts.length - 1];
-				const effectValueString = Roll.replaceFormulaData(String(effect.value), actorData.getRollData());
+				const effectValueString = Roll.replaceFormulaData(String(effect.value), actor.getRollData());
 				const effectDice = await this.rollWithErrorHandling(effectValueString, { context: effect.key });
 				const effectValue = effectDice.total;
 				if (bonusType === "roll") {

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -1684,7 +1684,7 @@ export default class Item4e extends Item {
 			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponUse.system.consume, "weapon used by the power");
 		}
 		
-		await Helper.applyEffects([parts], rollData, actorData, this, weaponUse, "attack", null, options);
+		await Helper.applyEffects(rollData, actorData, this, weaponUse, "attack", null, null, options);
 
 		// Compose roll options
 		const rollConfig = {
@@ -1805,7 +1805,7 @@ export default class Item4e extends Item {
 			};
 			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponUse.system.consume, "weapon used by the power");
 		}
-		await Helper.applyEffects([parts], rollData, actorData, this, weaponUse, "attack", null, options);
+		await Helper.applyEffects(rollData, actorData, this, weaponUse, "attack", null, null, options);
 
 		// Compose roll options
 		const rollConfig = {
@@ -2218,22 +2218,9 @@ export default class Item4e extends Item {
 			}
 		}
 
-		// Originally these were a separate part, but then they were not part of the primary damage type
-		// which they should be.  So now appending them to the main expression.
-		const effectDamageParts = [];
 		const extraDamageParts = [];
 		if (!this.system?.hit?.damageBonusNull) {
-			await Helper.applyEffects([effectDamageParts], rollData, actorData, this, weaponUse, "damage", extraDamageParts, options);
-			effectDamageParts.forEach(part => {
-				const value = rollData[part.substring(1)];
-				damageFormula += `+ ${value}`;
-				missDamageFormula += `+ ${value}`;
-				critDamageFormula += `+ ${value}`;
-				damageFormulaExpression += `+ ${part}`;
-				missDamageFormulaExpression += `+ ${part}`;
-				critDamageFormulaExpression += `+ ${part}`;
-				options.formulaInnerData[part.substring(1)] = value;
-			});
+			await Helper.applyEffects(rollData, actorData, this, weaponUse, "damage", extraDamageParts, null, options);
 		}
 
 		// Ammunition Damage from power


### PR DESCRIPTION
The relevant keys take the form `grants.attack.[key.terms].[type]`. For example, `grants.attack.global.power` would grant a power bonus to attack rolls made against the creature subject to the effect, which correctly obeys stacking rules with other bonuses on the attacking actor. I expect `global` will be the most common term used here, but technically it could automate effects like "attack rolls from fire powers get a +x bonus against this target" if they're, idunno, on fire or something.

Examples of _actual_ powers this could be used for:
https://iws.mx/dnd/?view=power7196
https://iws.mx/dnd/?view=power11239