### PR TITLE
Ensure we don't display a crit damage button if there's no crit damage

### DIFF
--- a/module/dice.js
+++ b/module/dice.js
@@ -555,14 +555,14 @@ export async function damageRoll({ parts, partsCrit, partsMiss, partsExpressionR
 		buttons.push({
 			action: "normal",
 			// icon: "fa-solid fa-dice-d20",
-			label: _loc(allowCritical ? "DND4E.Normal" : "DND4E.Roll"),
+			label: _loc((partsCrit?.length || partsMiss?.length) ? "DND4E.Normal" : "DND4E.Roll"),
 			type: "submit",
 		});
-		if (data?.item?.miss?.halfDamage || data?.item?.miss?.formula) {
+		if (partsMiss?.length) {
 			buttons.push({
 				action: "miss",
 				// icon: "fa-solid fa-dice-d20",
-				label: _loc(allowCritical ? "DND4E.Miss" : "DND4E.Roll"),
+				label: _loc("DND4E.Miss"),
 				type: "submit",
 			});
 		}

--- a/module/dice.js
+++ b/module/dice.js
@@ -544,7 +544,7 @@ export async function damageRoll({ parts, partsCrit, partsMiss, partsExpressionR
 		});
 	}
 	else {
-		if (allowCritical) {
+		if (allowCritical && partsCrit?.length) {
 			buttons.push({
 				action: "crit",
 				// icon: "fa-solid fa-dice-d20",

--- a/module/enrichers/roll.js
+++ b/module/enrichers/roll.js
@@ -563,6 +563,7 @@ async function rollDamageHealing(config, event) {
 		messageData: { "flags.dnd4e.roll": { type: "damage" } },
 		healingRoll: type === "healing",
 		options,
+		allowCritical: !!partsCrit?.length,
 	};
 
 	return damageRoll(rollConfig);

--- a/module/item/item.js
+++ b/module/item/item.js
@@ -2214,12 +2214,12 @@ export default class Item4e extends Item {
 				// parts.push("@dmg");
 				// partsCrit.push("@dmg");
 				// rollData["dmg"] = actorBonus.damage;
-				damageFormula += `+ ${actorBonus.damage}`;
-				missDamageFormula += `+ ${actorBonus.damage}`;
-				critDamageFormula += `+ ${actorBonus.damage}`;
-				damageFormulaExpression += "+ @actorBonusDamage";
-				missDamageFormulaExpression += "+ @actorBonusDamage";
-				critDamageFormulaExpression += "+ @actorBonusDamage";
+				if (damageFormula) damageFormula += `+ ${actorBonus.damage}`;
+				if (missDamageFormula) missDamageFormula += `+ ${actorBonus.damage}`;
+				if (critDamageFormula) critDamageFormula += `+ ${actorBonus.damage}`;
+				if (damageFormulaExpression) damageFormulaExpression += "+ @actorBonusDamage";
+				if (missDamageFormulaExpression) missDamageFormulaExpression += "+ @actorBonusDamage";
+				if (critDamageFormulaExpression) critDamageFormulaExpression += "+ @actorBonusDamage";
 				options.formulaInnerData.actorBonusDamage = actorBonus.damage;
 			}
 		}
@@ -2312,12 +2312,12 @@ export default class Item4e extends Item {
 
 		const primaryDamageStr = primaryDamage ? `[${primaryDamage}]` : "";
 		if (primaryDamage) options.flavor = primaryDamage;
-		parts.unshift(`(${damageFormula})${primaryDamageStr}`);
-		partsCrit.unshift(`(${critDamageFormula})${primaryDamageStr}`);
-		partsMiss.unshift(`(${missDamageFormula})${primaryDamageStr}`);
-		partsExpressionReplacement.unshift({ target: parts[0], value: damageFormulaExpression });
-		partsCritExpressionReplacement.unshift({ target: partsCrit[0], value: critDamageFormulaExpression });
-		partsMissExpressionReplacement.unshift({ target: partsMiss[0], value: missDamageFormulaExpression });
+		if (damageFormula) parts.unshift(`(${damageFormula})${primaryDamageStr}`);
+		if (critDamageFormula) partsCrit.unshift(`(${critDamageFormula})${primaryDamageStr}`);
+		if (missDamageFormula) partsMiss.unshift(`(${missDamageFormula})${primaryDamageStr}`);
+		if (damageFormulaExpression) partsExpressionReplacement.unshift({ target: parts[0], value: damageFormulaExpression });
+		if (critDamageFormulaExpression) partsCritExpressionReplacement.unshift({ target: partsCrit[0], value: critDamageFormulaExpression });
+		if (missDamageFormulaExpression) partsMissExpressionReplacement.unshift({ target: partsMiss[0], value: missDamageFormulaExpression });
 		
 		const speaker = ChatMessage.getSpeaker({ actor: this.actor });
 
@@ -2346,6 +2346,7 @@ export default class Item4e extends Item {
 			fastForward,
 			isCharge: variance?.isCharge || false,
 			isOpp: variance?.isOpp || false,
+			allowCritical: !!partsCrit?.length,
 		});
 	}
 


### PR DESCRIPTION
Trying to roll critical damage in such a case can cause an error, so we'll hide the button if there's no crit damage to be had.