### PR TITLE
Adjust `alt-highlight` class

### DIFF
--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -3516,7 +3516,7 @@ input[type="text"].dice-count{
 	}
 	.item-description,
 	.item-details .alt,
-	.item-details .alt-highlight:nth-child(even) {
+	.item-details .alt-highlight:nth-child(odd of .alt-highlight) {
 		background:var(--gradient-4e);
 	}
 }


### PR DESCRIPTION
This resolves an issue where some lines in item cards would fail to get the correct background.