### PR TITLE
Include temphp as healing roll for damage enrichers

### DIFF
--- a/module/enrichers/roll.js
+++ b/module/enrichers/roll.js
@@ -561,7 +561,7 @@ async function rollDamageHealing(config, event) {
 			left: window.innerWidth - 710,
 		},
 		messageData: { "flags.dnd4e.roll": { type: "damage" } },
-		healingRoll: type === "healing",
+		healingRoll: ["healing", "temphp"].includes(type),
 		options,
 		allowCritical: !!partsCrit?.length,
 	};


### PR DESCRIPTION
Not the biggest deal since the system expectation for temp HP is that you use a normal healing roll and then apply as temp from the card. BUT, still should be "correct."