### PR TITLE
Tweak sustain action to use short labels

### DIFF
--- a/module/helper.js
+++ b/module/helper.js
@@ -796,7 +796,7 @@ export class Helper {
 		}
 
 		if ((chatData.sustain?.actionType !== "none") && chatData.sustain?.actionType) {
-			powerDetail += `<p class="sustain alt-highlight"><strong>${_loc("DND4E.Sustain")} ${CONFIG.DND4E.abilityActivationTypes[chatData.sustain.actionType].label}:</strong> ${chatData.sustain.detail}</p>`;
+			powerDetail += `<p class="sustain alt-highlight"><strong>${_loc("DND4E.Sustain")} ${CONFIG.DND4E.abilityActivationTypes[chatData.sustain.actionType].labelShort}:</strong> ${chatData.sustain.detail}</p>`;
 		}
 		
 		return powerDetail;


### PR DESCRIPTION
This better aligns powers' sustain lines with printed books (e.g. "Sustain Minor" instead of "Sustain Minor Action").