### PR TITLE
Add explicit error message when trying to place a template without a token

### DIFF
--- a/module/item/item.js
+++ b/module/item/item.js
@@ -1954,6 +1954,11 @@ export default class Item4e extends Item {
 
 		/** @type {TokenDocument4e} */
 		const tokenInfo = this.actor?.token ?? this.actor?.getActiveTokens(true, true)[0];
+		if (!tokenInfo) {
+			const msg = "This item's actor does not have a token on the scene.";
+			ui.notifications.error(msg, { console: false });
+			throw new Error(msg);
+		}
 		const isAura = this.system.effectType.aura;
 		const areaType = isAura ? "aura" : this.system.rangeType;
 


### PR DESCRIPTION
A token is only strictly required for auras and close bursts, but I don't think coding for that nuance is very user-friendly. Much easier to explain and to remember that a lot of things require tokens. This message handles the tokenless case more gracefully than is currently done.