### PR TITLE
Add new "self" keyword for use in custom modifiers

### DIFF
--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -193,6 +193,7 @@ export async function applyEffects(rollData, actor, powerData = {}, weaponData =
 							name: effect.name,
 							key: change.key,
 							value: change.value,
+							itemUuid: effect.item.uuid,
 						});
 						break;
 					}
@@ -233,6 +234,7 @@ export async function applyEffects(rollData, actor, powerData = {}, weaponData =
 				if (weaponData.weaponBaseType) {
 					suitableKeywords.push(weaponData.weaponBaseType);
 				}
+				options.weaponUuid = weaponData.uuid;
 			}
 
 			if (powerData.powersource) {
@@ -500,6 +502,13 @@ async function _applyEffectsInternal(effectsToProcess, suitableKeywords, actor, 
 		if ((keyParts.length >= 4) && (keyParts[1] === effectType)) {
 			const keywords = keyParts.slice(2, -1);
 			for (const keyword of keywords) {
+				if (keyword === "self") {
+					if (options.weaponUuid === effect.itemUuid) {
+						continue;
+					} else {
+						return false;
+					}
+				} 
 				if (!suitableKeywords.includes(keyword)) {
 					return false;
 				}

--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -193,7 +193,7 @@ export async function applyEffects(rollData, actor, powerData = {}, weaponData =
 							name: effect.name,
 							key: change.key,
 							value: change.value,
-							itemUuid: effect.item.uuid,
+							itemUuid: effect.item?.uuid,
 						});
 						break;
 					}


### PR DESCRIPTION
This keyword applies to the `weapon` scope in `attack` and `damage` effects. It indicates that a bonus should only apply when a power is used with the weapon the active effect originates from. This is admittedly of limited use; most of the item, if you have a weapon equipped, you are attacking with it. But it could be useful for character who dual-wield weapons when one or both grants some bonus "when you attack with this weapon" or similar.