### PR TITLE
Add ability to OR keywords in custom modifier change values

### DIFF
--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -509,7 +509,7 @@ async function _applyEffectsInternal(effectsToProcess, suitableKeywords, actor, 
 						return false;
 					}
 				} 
-				if (!suitableKeywords.includes(keyword)) {
+				if (!(new Set(suitableKeywords).intersection(new Set(keyword.split(",")))).size) {
 					return false;
 				}
 			}


### PR DESCRIPTION
Keywords separated by commas, rather than periods, will be evaluated as a group, and if any of them matches, the whole set is considered to match.

I was looking at the Silvery Glow feat, which grants a damage bonus to cold powers and radiant powers. Currently this requires two separate changes on the AE, and while this specific feat confers a feat bonus, so they wouldn't stack, any similar bonus without a type isn't currently possible to handle correctly. With this change, such effects are easily handled. Silvery Glow for example looks like: `power.damage.cold,radiant.feat`