### PR TITLE
Make powers inherit weapon damage types

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -983,7 +983,7 @@ export default class Item4e extends Item {
 	getDamageType() {
 		if ((this.type == "power") && this.actor) {
 			const weapon = utils.getWeaponUse(this.system, this.actor);
-			if (weapon && weapon.system.damageTypeOverride) {
+			if (weapon && this.system.weaponDamageType && (!Array.from(Object.entries(this.system.damageType)).filter((d) => d[1]).length || weapon.system.damageTypeOverride)) {
 				this.system.damageTypeOverride = true;
 				this.system.weaponDamageType = weapon.system.damageType;
 				this.system.weaponSourceName = weapon.name;


### PR DESCRIPTION
Specifically if a power deals _untyped_ damage, it will inherit the damage type of the weapon being used with the power. Powers explicitly marked as dealing physical damage will not have that damage type replaced.

The "override damage type" checkbox and its functionality is unchanged; I'm not sure if there's anything in the game that does it, but it will completely override power damage typing with weapon damage typing, regardless of what type the power does originally, just as it always has.