### PR TITLE
Add Source data and configfuration

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -572,6 +572,7 @@
 "DND4E.HPTotalAuto": "Total Hit Points (Auto Calculated)",
 "DND4E.HTwo": "Two Handed",
 "DND4E.Identified": "Identified",
+"DND4E.IdentifierError": "An identifier can only contain letters (a-z), numbers (0-9), dashes (-), and underscores (_).",
 "DND4E.IgnoredDifficultTerrain": "Terrain Walk",
 "DND4E.Illusion": "Illusion",
 "DND4E.Immune": "Immune",

--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -572,6 +572,7 @@
 "DND4E.HPTotalAuto": "Total Hit Points (Auto Calculated)",
 "DND4E.HTwo": "Two Handed",
 "DND4E.Identified": "Identified",
+"DND4E.Identifier": "Identifier",
 "DND4E.IdentifierError": "An identifier can only contain letters (a-z), numbers (0-9), dashes (-), and underscores (_).",
 "DND4E.IgnoredDifficultTerrain": "Terrain Walk",
 "DND4E.Illusion": "Illusion",
@@ -1556,6 +1557,36 @@
 	"Skills": "Skills"
 },
 
+"DND4E.SOURCE": {
+	"FIELDS": {
+		"source": {
+			"label": "Source",
+			"book": {
+				"label": "Book"
+			},
+			"custom": {
+				"label": "Custom Label"
+			},
+			"page": {
+				"label": "Page/Section"
+			},
+			"revision": {
+				"label": "Revision"
+			},
+			"uuid": {
+				"label": "Original Source"
+			}
+		}
+	},
+	"Action": {
+		"Configure": "Configure Source"
+	},
+	"Display": {
+		"Full": "{book} {page}",
+		"Page": "pg. {page}"
+	}
+},
+
 "DND4E.Tier": {
 	"Epic": "Epic",
 	"EpicDestiny": "Epic Destiny",
@@ -1582,12 +1613,12 @@
 	"CheckShort": "{check}",
 	"CheckLong": "{check} check",
 	"DC": "DC {dc} {check}",
-    "DCFlavor": "{check} check (DC {dc})",
+	"DCFlavor": "{check} check (DC {dc})",
 	"RequestRoll": "Request Roll",
 	"RollRequest": "Roll Request",
 	"Warning": {
 		"NoActor": "No selected or assigned actor could be found to execute this roll.",
-        "TooManyActors": "Only a single selected or assigned actor is valid for executing this roll."
+		"TooManyActors": "Only a single selected or assigned actor is valid for executing this roll."
 	}
 },
 
@@ -1718,7 +1749,7 @@
 	"AttackDetailsTextHint": "Only required for powers with special attack text. If provided, the power card's attack field will use this string instead of the normal pattern (e.g. \"Str vs AC\" or \"+12 vs AC\") selected in system config.",
 	"AttackVersus": "Attack versus",
 	"AttributeKey": "Attribute Key",
-    "Auto": "Auto",
+	"Auto": "Auto",
 	"AutoCardTip": "<strong>ON:</strong> The chat card will be generated from the provided Details, with styling applied automatically. If no flavour text is provided, the Description text will be used in its place.<br /><strong>OFF:</strong> The chat card will only use the Description text. Styling is up to the user.",
 	"AutoFromConfig": "Automatic (from Config)",
 	"AutoFromConfigTip": "These keywords have been inferred from the power's settings. If something looks wrong, the config may need updating!",

--- a/lang/en.json
+++ b/lang/en.json
@@ -572,6 +572,7 @@
 "DND4E.HPTotalAuto": "Total Hit Points (Auto Calculated)",
 "DND4E.HTwo": "Two Handed",
 "DND4E.Identified": "Identified",
+"DND4E.Identifier": "Identifier",
 "DND4E.IdentifierError": "An identifier can only contain letters (a-z), numbers (0-9), dashes (-), and underscores (_).",
 "DND4E.IgnoredDifficultTerrain": "Terrain Walk",
 "DND4E.Illusion": "Illusion",
@@ -1556,6 +1557,36 @@
 	"Skills": "Skills"
 },
 
+"DND4E.SOURCE": {
+	"FIELDS": {
+		"source": {
+			"label": "Source",
+			"book": {
+				"label": "Book"
+			},
+			"custom": {
+				"label": "Custom Label"
+			},
+			"page": {
+				"label": "Page/Section"
+			},
+			"revision": {
+				"label": "Revision"
+			},
+			"uuid": {
+				"label": "Original Source"
+			}
+		}
+	},
+	"Action": {
+		"Configure": "Configure Source"
+	},
+	"Display": {
+		"Full": "{book} {page}",
+		"Page": "pg. {page}"
+	}
+},
+
 "DND4E.Tier": {
 	"Epic": "Epic",
 	"EpicDestiny": "Epic Destiny",
@@ -1582,12 +1613,12 @@
 	"CheckShort": "{check}",
 	"CheckLong": "{check} check",
 	"DC": "DC {dc} {check}",
-    "DCFlavor": "{check} check (DC {dc})",
+	"DCFlavor": "{check} check (DC {dc})",
 	"RequestRoll": "Request Roll",
 	"RollRequest": "Roll Request",
 	"Warning": {
 		"NoActor": "No selected or assigned actor could be found to execute this roll.",
-        "TooManyActors": "Only a single selected or assigned actor is valid for executing this roll."
+		"TooManyActors": "Only a single selected or assigned actor is valid for executing this roll."
 	}
 },
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -572,6 +572,7 @@
 "DND4E.HPTotalAuto": "Total Hit Points (Auto Calculated)",
 "DND4E.HTwo": "Two Handed",
 "DND4E.Identified": "Identified",
+"DND4E.IdentifierError": "An identifier can only contain letters (a-z), numbers (0-9), dashes (-), and underscores (_).",
 "DND4E.IgnoredDifficultTerrain": "Terrain Walk",
 "DND4E.Illusion": "Illusion",
 "DND4E.Immune": "Immune",

--- a/module/applications/apps/_module.mjs
+++ b/module/applications/apps/_module.mjs
@@ -16,5 +16,6 @@ export { default as MovementDialog } from "./movement-dialog.mjs";
 export { default as SaveThrowDialog } from "./save-throw.mjs";
 export { default as SecondWindDialog } from "./second-wind.mjs";
 export { default as ShortRestDialog } from "./short-rest.mjs";
+export { default as SourceConfig } from "./source-config.mjs";
 export { default as TraitSelectorValues } from "./trait-selector-sense.mjs";
 export { default as TraitSelector } from "./trait-selector.mjs";

--- a/module/applications/apps/source-config.mjs
+++ b/module/applications/apps/source-config.mjs
@@ -1,0 +1,62 @@
+import DocumentSheet4e from "../sheets/DocumentSheet4e.mjs";
+
+/**
+ * Application for configuring the source data on actors and items.
+ */
+export default class SourceConfig extends DocumentSheet4e {
+	/** @override */
+	static DEFAULT_OPTIONS = {
+		classes: ["dnd4e", "source-config", "standard-form", "default"],
+		sheetConfig: false,
+		position: {
+			width: 400,
+		},
+		form: {
+			closeOnSubmit: true,
+		},
+	};
+
+	/* -------------------------------------------- */
+
+	/** @override */
+	static PARTS = {
+		source: {
+			template: "systems/dnd4e/templates/apps/source-config.hbs",
+		},
+		footer: {
+			template: "templates/generic/form-footer.hbs",
+		},
+	};
+
+	/* -------------------------------------------- */
+	/*  Properties                                  */
+	/* -------------------------------------------- */
+
+	/** @override */
+	get title() {
+		return _loc("DND4E.SOURCE.Action.Configure");
+	}
+
+	/* -------------------------------------------- */
+	/*  Rendering                                   */
+	/* -------------------------------------------- */
+
+	/** @inheritDoc */
+	async _prepareContext(options) {
+		const context = await super._prepareContext(options);
+		const source = this.document.system._source;
+		context.buttons = [{ icon: "fa-regular fa-save", label: "Save", type: "Save" }];
+		context.data = foundry.utils.getProperty(this.document, this.options.keyPath);
+		context.fields = this.document.system.schema.getField("source").fields;
+		context.keyPath = this.options.keyPath;
+		context.source = source.source;
+		context.sourceUuid = this.document._stats.compendiumSource;
+		context.sourceAnchor = (await fromUuid(context.sourceUuid))?.toAnchor().outerHTML;
+		if ("identifier" in this.document.system) context.identifier = {
+			field: this.document.system.schema.getField("identifier"),
+			placeholder: this.document.identifier,
+			value: source.identifier,
+		};
+		return context;
+	}
+}

--- a/module/applications/sheets/item-sheet.mjs
+++ b/module/applications/sheets/item-sheet.mjs
@@ -2,6 +2,7 @@
 import ActiveEffect4e from "../../documents/active-effect.mjs";
 import * as utils from "../../utils/utils.mjs";
 import * as macros from "../../helpers/macros.mjs";
+import SourceConfig from "../apps/source-config.mjs";
 import Item4e from "../../documents/item.mjs";
 
 /**
@@ -66,6 +67,7 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			editItem: ItemSheet4e.#onItemControl,
 			deleteItem: ItemSheet4e.#onItemControl,
 			convertCurrency: ItemSheet4e.#onConvertCurrency,
+			configureSource: ItemSheet4e.#onConfigureSource,
 		},
 	};
 
@@ -202,6 +204,22 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 
 	/* -------------------------------------------- */
 
+	/**
+     * Render an application in the same workspace as this one.
+     * @param {ApplicationV2} app        The application to render.
+     * @param {RenderOptions} [options]  Options passed to render.
+     * @returns {Promise<ApplicationV2>}
+     */
+	_renderChild(app, options = {}) {
+		if (this.parent) return this.parent.renderChild(app, options);
+		if (this.window?.windowId) return app.render({
+			force: true, window: { detached: true, windowId: this.window.windowId }, ...options,
+		});
+		return app.render({ force: true, ...options });
+	}
+
+	/* -------------------------------------------- */
+
 	async _onFirstRender(context, options) {
 		await super._onFirstRender(context, options);
 		if (!this.tabGroups.sheet) {
@@ -215,6 +233,7 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 	/** @override */
 	async _onRender(context, options) {
 		await super._onRender(context, options);
+		this._renderSource();
 
 		this.#dragDrop.forEach((d) => d.bind(this.element));
 
@@ -251,6 +270,7 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 
 		context.showLevel = true;
 		context.showRarity = true;
+		context.sourceLabel = this.document.system.source.label;
 
 		// Potential consumption targets
 		context.abilityConsumptionTargets = this._getItemConsumptionTargets(itemData);
@@ -616,6 +636,19 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			content: `<p>${_loc("DND4E.CurrencyConvertHint")}</p>`,
 		});
 		if (shouldConvert) return this.convertCurrency();
+	}
+
+	/* -------------------------------------------- */
+
+	/**
+   * Handle opening a configuration application.
+   * @this {ItemSheet4e}
+   * @param {Event} event         Triggering click event.
+   * @param {HTMLElement} target  Button that was clicked.
+   * @returns {any}
+   */
+	static #onConfigureSource(event, target) {
+		return this._renderChild(new SourceConfig({ document: this.item, keyPath: "system.source" }));
 	}
 
 	async shareItem() {

--- a/module/applications/sheets/item-sheet.mjs
+++ b/module/applications/sheets/item-sheet.mjs
@@ -233,7 +233,6 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 	/** @override */
 	async _onRender(context, options) {
 		await super._onRender(context, options);
-		this._renderSource();
 
 		this.#dragDrop.forEach((d) => d.bind(this.element));
 

--- a/module/data/fields/_module.mjs
+++ b/module/data/fields/_module.mjs
@@ -1,2 +1,3 @@
 export { default as FormulaField } from "./formula-field.mjs";
+export { default as IdentifierField } from "./identifier-field.mjs";
 export { default as MappingField } from "./mapping-field.mjs";

--- a/module/data/fields/_types.mjs
+++ b/module/data/fields/_types.mjs
@@ -1,0 +1,26 @@
+/**
+ * @typedef {StringFieldOptions} FormulaFieldOptions
+ * @property {boolean} [deterministic=false]  Is this formula not allowed to have dice values?
+ */
+
+/**
+ * @typedef {StringFieldOptions} IdentifierFieldOptions
+ * @property {string[]} [allowType=false]  Allow identifiers that are prefixed by type (e.g. `spell:mage-hand`).
+ * @property {string[]} [types=null]       Item types that can be represented by this identifier.
+ */
+
+/**
+ * @callback MappingFieldInitialValueBuilder
+ * @param {string} key       The key within the object where this new value is being generated.
+ * @param {*} initial        The generic initial data provided by the contained model.
+ * @param {object} existing  Any existing mapping data.
+ * @returns {object}         Value to use as default for this key.
+ */
+
+/**
+ * @typedef {DataFieldOptions} MappingFieldOptions
+ * @property {string[]} [initialKeys]       Keys that will be created if no data is provided.
+ * @property {MappingFieldInitialValueBuilder} [initialValue]  Function to calculate the initial value for a key.
+ * @property {boolean} [initialKeysOnly=false]  Should the keys in the initialized data be limited to the keys provided
+ *                                              by `options.initialKeys`?
+ */

--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -1,6 +1,5 @@
 /**
- * @typedef {StringFieldOptions} FormulaFieldOptions
- * @property {boolean} [deterministic=false]  Is this formula not allowed to have dice values?
+ * @import { FormulaFieldOptions } from "./_types.mjs";
  */
 
 /**

--- a/module/data/fields/identifier-field.mjs
+++ b/module/data/fields/identifier-field.mjs
@@ -32,20 +32,4 @@ export default class IdentifierField extends foundry.data.fields.StringField {
 			throw new Error(_loc("DND4E.IdentifierError"));
 		}
 	}
-
-	/* -------------------------------------------- */
-	/*  Form Field Integration                      */
-	/* -------------------------------------------- */
-
-	/** @override */
-	_toInput(config) {
-		if (this.types?.length) config.types ??= this.types;
-		if (foundry.utils.getType(config.types) === "string") config.types = config.types.split(",");
-		const input = document.createElement("identifier-input");
-		input.name = config.name;
-		foundry.applications.fields.setInputAttributes(input, config);
-		input.setAttribute("value", config.value ?? "");
-		if (config.types?.length) input.setAttribute("types", config.types.join(","));
-		return input;
-	}
 }

--- a/module/data/fields/identifier-field.mjs
+++ b/module/data/fields/identifier-field.mjs
@@ -1,0 +1,51 @@
+/**
+ * @import { IdentifierFieldOptions } from "./_types.mjs";
+ */
+
+/**
+ * Special case StringField that includes automatic validation for identifiers.
+ *
+ * @param {IdentifierFieldOptions} options  Options which configure the behavior of the field.
+ */
+export default class IdentifierField extends foundry.data.fields.StringField {
+	/** @inheritDoc */
+	static get _defaults() {
+		return foundry.utils.mergeObject(super._defaults, {
+			allowType: false,
+			types: null,
+		});
+	}
+
+	/* -------------------------------------------- */
+	/*  Field Validation                            */
+	/* -------------------------------------------- */
+
+	/** @override */
+	_validateType(value) {
+		const IDENTIFIER_REGEX = /^([a-zA-Z0-9_-]+)$/i;
+		if (this.allowType) {
+			const split = value.split(":");
+			if (split.length > 2) return false;
+			value = split[1];
+		}
+		if (!IDENTIFIER_REGEX.test(value)) {
+			throw new Error(_loc("DND4E.IdentifierError"));
+		}
+	}
+
+	/* -------------------------------------------- */
+	/*  Form Field Integration                      */
+	/* -------------------------------------------- */
+
+	/** @override */
+	_toInput(config) {
+		if (this.types?.length) config.types ??= this.types;
+		if (foundry.utils.getType(config.types) === "string") config.types = config.types.split(",");
+		const input = document.createElement("identifier-input");
+		input.name = config.name;
+		foundry.applications.fields.setInputAttributes(input, config);
+		input.setAttribute("value", config.value ?? "");
+		if (config.types?.length) input.setAttribute("types", config.types.join(","));
+		return input;
+	}
+}

--- a/module/data/fields/mapping-field.mjs
+++ b/module/data/fields/mapping-field.mjs
@@ -1,19 +1,7 @@
 // Adapted from the Foundry Virtual Tabletop - Dungeons & Dragons Fifth Edition Game System licensed under the MIT license
 
 /**
- * @callback MappingFieldInitialValueBuilder
- * @param {string} key       The key within the object where this new value is being generated.
- * @param {*} initial        The generic initial data provided by the contained model.
- * @param {object} existing  Any existing mapping data.
- * @returns {object}         Value to use as default for this key.
- */
-
-/**
- * @typedef {DataFieldOptions} MappingFieldOptions
- * @property {string[]} [initialKeys]       Keys that will be created if no data is provided.
- * @property {MappingFieldInitialValueBuilder} [initialValue]  Function to calculate the initial value for a key.
- * @property {boolean} [initialKeysOnly=false]  Should the keys in the initialized data be limited to the keys provided
- *                                              by `options.initialKeys`?
+ * @import { MappingFieldInitialValueBuilder, MappingFieldOptions } from "./_types.mjs";
  */
 
 /**

--- a/module/data/item/backpack.mjs
+++ b/module/data/item/backpack.mjs
@@ -4,6 +4,10 @@ import { ActivatedEffectTemplate, ItemDescriptionTemplate, ItemMacroTemplate, Ph
 const { BooleanField, NumberField, StringField, SchemaField } = foundry.data.fields;
 
 export default class BackpackData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		return {
 			...ItemDescriptionTemplate.defineSchema(),
@@ -19,5 +23,15 @@ export default class BackpackData extends foundry.abstract.TypeDataModel {
 			}),
       
 		};
+	}
+
+	/* -------------------------------------------- */
+	/*  Data Migration                              */
+	/* -------------------------------------------- */
+
+	/** @inheritdoc */
+	static migrateData(source) {
+		ItemDescriptionTemplate.migrateSource(source);
+		return super.migrateData(source);
 	}
 }

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -5,6 +5,10 @@ import { processPart } from "./_utils.mjs";
 const { BooleanField, NumberField, StringField, SchemaField } = foundry.data.fields;
 
 export default class ConsumableData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		const { attack, hit, ...attackAndDamageSchema } = AttackAndDamageTemplate.defineSchema();
 		return {
@@ -75,6 +79,7 @@ export default class ConsumableData extends foundry.abstract.TypeDataModel {
 				source.damageCritImp.parts[partIndex] = processPart(source.damageCritImp.parts[partIndex]);
 			}
 		}
+		ItemDescriptionTemplate.migrateSource(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -3,6 +3,10 @@ import { ActivatedEffectTemplate, ItemDescriptionTemplate, ItemMacroTemplate, Ph
 const { ArrayField, BooleanField, NumberField, StringField, SchemaField } = foundry.data.fields;
 
 export default class EquipmentData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		return {
 			...ItemDescriptionTemplate.defineSchema(),
@@ -58,6 +62,7 @@ export default class EquipmentData extends foundry.abstract.TypeDataModel {
 			delete source.armour.subType;
 		}
 		if (source.armour?.subtype === "cloth") source.armour.subtype = "light";
+		ItemDescriptionTemplate.migrateSource(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -4,6 +4,10 @@ import { ItemDescriptionTemplate, ItemMacroTemplate } from "./templates/_module.
 const { BooleanField, StringField } = foundry.data.fields;
 
 export default class FeatureData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		return {
 			...ItemDescriptionTemplate.defineSchema(),
@@ -24,5 +28,15 @@ export default class FeatureData extends foundry.abstract.TypeDataModel {
 			}),
 			keywordsCustom: new StringField({ initial: "" }),
 		};
+	}
+
+	/* -------------------------------------------- */
+	/*  Data Migration                              */
+	/* -------------------------------------------- */
+
+	/** @inheritdoc */
+	static migrateData(source) {
+		ItemDescriptionTemplate.migrateSource(source);
+		return super.migrateData(source);
 	}
 }

--- a/module/data/item/fields/_module.mjs
+++ b/module/data/item/fields/_module.mjs
@@ -1,1 +1,2 @@
 export { default as DamagePartsField } from "./damage-parts-field.mjs";
+export { default as SourceField } from "./source-field.mjs";

--- a/module/data/item/fields/_types.mjs
+++ b/module/data/item/fields/_types.mjs
@@ -1,0 +1,13 @@
+/**
+ * @typedef DamagePartsData
+ * @property {string} formula   Damage formula.
+ * @property {Set<string>} page      Damage types.
+ */
+
+/**
+ * @typedef SourceData
+ * @property {string} book      Book/publication where the item originated.
+ * @property {string} page      Page or section where the item can be found.
+ * @property {string} custom    Fully custom source label.
+ * @property {number} revision  Revision count for this item.
+ */

--- a/module/data/item/fields/damage-parts-field.mjs
+++ b/module/data/item/fields/damage-parts-field.mjs
@@ -1,6 +1,10 @@
 const { SchemaField, SetField, StringField } = foundry.data.fields;
 import FormulaField from "../../fields/formula-field.mjs";
 
+/**
+ * @import { DamagePartsData } from "./_types.mjs";
+ */
+
 export default class DamagePartsField extends SchemaField {
 	constructor(fields = {}, { initialValue = [], ...options } = {}) {
 		const damageTypes = Object.fromEntries(Object.entries(CONFIG.DND4E.damageTypes).filter(([key, value]) => !["damage", "ongoing"].includes(key)));

--- a/module/data/item/fields/source-field.mjs
+++ b/module/data/item/fields/source-field.mjs
@@ -1,0 +1,53 @@
+import { formatIdentifier } from "../../../utils/utils.mjs";
+
+const { NumberField, SchemaField, StringField } = foundry.data.fields;
+
+/**
+ * @import { SourceData } from "./_types.mjs";
+ */
+
+/**
+ * Data fields that stores information on the sourcebook where this document originated.
+ */
+export default class SourceField extends SchemaField {
+	constructor(fields = {}, options = {}) {
+		fields = {
+			book: new StringField(),
+			page: new StringField(),
+			custom: new StringField(),
+			revision: new NumberField({ initial: 1 }),
+			...fields,
+		};
+		Object.entries(fields).forEach(([k, v]) => !v ? delete fields[k] : null);
+		super(fields, { label: "DND4E.SOURCE.FIELDS.source.label", ...options });
+	}
+
+	/* -------------------------------------------- */
+	/*  Data Preparation                            */
+	/* -------------------------------------------- */
+
+	/**
+   * Prepare the source label.
+   * @this {SourceData}
+   */
+	static prepareData() {
+		this.bookPlaceholder = "";
+		if (!this.book) this.book = this.bookPlaceholder;
+
+		if (this.custom) this.label = this.custom;
+		else {
+			const page = Number.isNumeric(this.page)
+				? _loc("DND4E.SOURCE.Display.Page", { page: this.page }) : (this.page ?? "");
+			this.label = _loc("DND4E.SOURCE.Display.Full", { book: this.book, page }).trim();
+		}
+
+		this.value = this.book;
+		this.slug = formatIdentifier(this.value);
+
+		Object.defineProperty(this, "directlyEditable", {
+			value: (this.custom ?? "") === this.label,
+			configurable: true,
+			enumerable: false,
+		});
+	}
+}

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -3,6 +3,10 @@ import { ActivatedEffectTemplate, ItemDescriptionTemplate, ItemMacroTemplate, Ph
 const { StringField } = foundry.data.fields;
 
 export default class LootData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		return {
 			...ItemDescriptionTemplate.defineSchema(),
@@ -11,5 +15,15 @@ export default class LootData extends foundry.abstract.TypeDataModel {
 			...ItemMacroTemplate.defineSchema(),
 			level: new StringField({ initial: "" }),
 		};
+	}
+
+	/* -------------------------------------------- */
+	/*  Data Migration                              */
+	/* -------------------------------------------- */
+
+	/** @inheritdoc */
+	static migrateData(source) {
+		ItemDescriptionTemplate.migrateSource(source);
+		return super.migrateData(source);
 	}
 }

--- a/module/data/item/power.mjs
+++ b/module/data/item/power.mjs
@@ -1,10 +1,15 @@
 import { FormulaField, MappingField } from "../fields/_module.mjs";
+import SourceField from "./fields/source-field.mjs";
 import { ActivatedEffectTemplate, AttackAndDamageTemplate, ItemDescriptionTemplate, ItemMacroTemplate } from "./templates/_module.mjs";
 import { processPart } from "./_utils.mjs";
 
 const { ArrayField, BooleanField, SchemaField, SetField, StringField } = foundry.data.fields;
 
 export default class PowerData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		return {
 			...ItemDescriptionTemplate.defineSchema(),
@@ -83,6 +88,7 @@ export default class PowerData extends foundry.abstract.TypeDataModel {
 				source.damageCritImp.parts[partIndex] = processPart(source.damageCritImp.parts[partIndex]);
 			}
 		}
+		ItemDescriptionTemplate.migrateSource(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/ritual.mjs
+++ b/module/data/item/ritual.mjs
@@ -3,6 +3,10 @@ import { ActivatedEffectTemplate, ItemDescriptionTemplate, ItemMacroTemplate } f
 const { SchemaField, StringField, BooleanField } = foundry.data.fields;
 
 export default class RitualData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		return {
 			...ItemDescriptionTemplate.defineSchema(),
@@ -20,5 +24,15 @@ export default class RitualData extends foundry.abstract.TypeDataModel {
 			formula: new StringField({ initial: "" }),
 			category: new StringField({ initial: "other" }),
 		};
+	}
+
+	/* -------------------------------------------- */
+	/*  Data Migration                              */
+	/* -------------------------------------------- */
+
+	/** @inheritdoc */
+	static migrateData(source) {
+		ItemDescriptionTemplate.migrateSource(source);
+		return super.migrateData(source);
 	}
 }

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -1,6 +1,9 @@
-const { SchemaField, StringField } = foundry.data.fields;
+import IdentifierField from "../../fields/identifier-field.mjs";
+import SourceField from "../fields/source-field.mjs";
+const { NumberField, SchemaField, StringField } = foundry.data.fields;
 
 export default class ItemDescriptionTemplate extends foundry.abstract.DataModel {
+	/** @inheritdoc */
 	static defineSchema() {
 		return {
 			description: new SchemaField({
@@ -12,7 +15,22 @@ export default class ItemDescriptionTemplate extends foundry.abstract.DataModel 
 			descriptionGM: new SchemaField({
 				value: new StringField({ initial: "" }),
 			}),
-			source: new StringField({ initial: "" }),
+			identifier: new IdentifierField({ required: true, label: "DND4E.Identifier" }),
+			source: new SourceField(),
 		};
+	}
+
+	/* -------------------------------------------- */
+	/*  Data Migration                              */
+	/* -------------------------------------------- */
+
+	/**
+	 * Convert source string into custom object.
+	 * @param {object} source  The candidate source data from which the model will be constructed.
+	 */
+	static migrateSource(source) {
+		if (("source" in source) && (foundry.utils.getType(source.source) !== "Object")) {
+			source.source = { custom: source.source };
+		}
 	}
 }

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -3,6 +3,10 @@ import { ActivatedEffectTemplate, ItemDescriptionTemplate, ItemMacroTemplate, Ph
 const { StringField } = foundry.data.fields;
 
 export default class ToolData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		return {
 			...ItemDescriptionTemplate.defineSchema(),
@@ -15,5 +19,15 @@ export default class ToolData extends foundry.abstract.TypeDataModel {
 			formula: new StringField({ initial: "" }),
 			bonus: new StringField({ initial: "2" }),
 		};
+	}
+
+	/* -------------------------------------------- */
+	/*  Data Migration                              */
+	/* -------------------------------------------- */
+
+	/** @inheritdoc */
+	static migrateData(source) {
+		ItemDescriptionTemplate.migrateSource(source);
+		return super.migrateData(source);
 	}
 }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -6,6 +6,10 @@ import { processPart } from "./_utils.mjs";
 const { ArrayField, BooleanField, NumberField, SchemaField, StringField } = foundry.data.fields;
 
 export default class WeaponData extends foundry.abstract.TypeDataModel {
+	/* -------------------------------------------- */
+	/** @override */
+	static LOCALIZATION_PREFIXES = ["DND4E.SOURCE"];
+
 	static defineSchema() {
 		return {
 			...ItemDescriptionTemplate.defineSchema(),
@@ -127,6 +131,7 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
 				};
 			}
 		}
+		ItemDescriptionTemplate.migrateSource(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -235,7 +235,7 @@ export default class Item4e extends Item {
 	 * @param {object} data	The source data from which to migrate, mutated here
 	 */
 	static #migrateIdentifier(data) {
-		if (!("identifier" in data.system)) {
+		if (data.name && !("identifier" in data.system)) {
 			data.system.identifier = utils.formatIdentifier(data.name);
 		}
 	}

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -4,6 +4,7 @@ import * as utils from "../utils/utils.mjs";
 import * as macros from "../helpers/macros.mjs";
 import AbilityUseDialog from "../applications/apps/ability-use-dialog.mjs";
 import Roll4e from "../rolls/roll.mjs";
+import SourceField from "../data/item/fields/source-field.mjs";
 
 /**
  * @import Actor4e from "../documents/actor.mjs";
@@ -142,6 +143,7 @@ export default class Item4e extends Item {
 		await super._preCreate(data, options, user);
 		
 		this._onCreationName(data);
+		this.updateSource({ "system.identifier": utils.createIdentifier(this) });
 
 		if (!this.isEmbedded) return;
 		const isNPC = this.parent.isNPC;
@@ -165,6 +167,7 @@ export default class Item4e extends Item {
 	static migrateData(data) {
 		super.migrateData(data);
 		this.#migrateOldFeatures(data);
+		this.#migrateIdentifier(data);
 		return data;
 	}
 
@@ -228,6 +231,18 @@ export default class Item4e extends Item {
 	/* -------------------------------------------- */
 
 	/**
+	 * Add an identifer if one doesn't already exist
+	 * @param {object} data	The source data from which to migrate, mutated here
+	 */
+	static #migrateIdentifier(data) {
+		if (!("identifier" in data.system)) {
+			data.system.identifier = utils.formatIdentifier(data.name);
+		}
+	}
+
+	/* -------------------------------------------- */
+
+	/**
 	 * Pre-creation logic for setting up name of Items.
 	 *
 	 * @param {object} data       Data for the newly created item.
@@ -252,7 +267,6 @@ export default class Item4e extends Item {
 		if (count) newName += ` (${count + 1})`;
 		updates["name"] = newName;
 		this.updateSource(updates);
-		
 	}
 
 	/**
@@ -570,6 +584,10 @@ export default class Item4e extends Item {
 		} catch(e) {
 			console.error("System or item error: Failed to gather keywords correctly."); return { system: {}, custom: {}, string: "" };		
 		}
+	}
+
+	get identifier() {
+		return this.system.identifier || utils.createIdentifier(this);
 	}
 
 	/* -------------------------------------------- */
@@ -970,13 +988,12 @@ export default class Item4e extends Item {
 		}
 
 		itemData.system.isOnCooldown = this.isOnCooldown();
-		
 	}
 
-	// /** @inheritdoc */
-	// prepareDerivedData() {
-
-	// }
+	/** @inheritdoc */
+	prepareDerivedData() {
+		SourceField.prepareData.call(this.system.source);
+	}
 
 	/* -------------------------------------------- */
 

--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -208,9 +208,11 @@ export async function applyEffects(rollData, actor, powerData = {}, weaponData =
 				effectsToProcess.forEach((effect) => console.log(`${debug} ${effect.name} : ${effect.key} = ${effect.value}`));
 			}
 
+			suitableKeywords.push(powerData.identifier);
 			_addKeywords(suitableKeywords, powerData.damageType);
 			_addKeywords(suitableKeywords, powerData.effectType);
 			if (weaponData) {
+				suitableKeywords.push(weaponData.identifier);
 				_addKeywords(suitableKeywords, weaponData.weaponGroup);
 				_addKeywords(suitableKeywords, weaponData.properties);
 				_addKeywords(suitableKeywords, weaponData.damageType);
@@ -1953,7 +1955,31 @@ export function formatNumber(value, options) {
 export function formatText(value) {
 	return new Handlebars.SafeString(value?.replaceAll("\n", "<br>") ?? "");
 }
-	
+
+/* -------------------------------------------- */
+
+/**
+ * Create a valid identifier from the provided string.
+ * @param {string} input
+ * @returns {string}
+ */
+export function formatIdentifier(input) {
+	input = input.replaceAll(/(\w+)([\\|/])(\w+)/g, "$1-$3");
+	return input.slugify({ strict: true });
+}
+
+/* -------------------------------------------- */
+
+/**
+ * Returns an item's identifier, or creates one if one doesn't exist.
+ * @param {Item4e} item 
+ * @returns {string}
+ */
+export function createIdentifier(item) {
+	if (item.system?.identifier) return item.system.identifier;
+	return formatIdentifier(item.name);
+}
+
 /* -------------------------------------------- */
 
 /**

--- a/templates/apps/source-config.hbs
+++ b/templates/apps/source-config.hbs
@@ -1,0 +1,25 @@
+<fieldset>
+  <legend>{{ localize "DND4E.SOURCE.FIELDS.source.label" }}</legend>
+  <div class="form-group">
+    <label>{{ localize "DND4E.SOURCE.FIELDS.source.book.label" }}</label>
+    <div class="form-fields">
+      <input type="text" name="system.source.book" value="{{ source.book }}"
+        placeholder="{{ data.bookPlaceholder }}">
+    </div>
+  </div>
+  {{ formField fields.page value=source.page }}
+  {{ formField fields.custom value=source.custom }}
+  <hr>
+  {{#if identifier}}
+  {{ formField identifier.field value=identifier.value placeholder=identifier.placeholder localize=true }}
+  {{/if}}
+  {{ formField fields.revision value=source.revision }}
+  {{#if sourceAnchor}}
+  <div class="form-group">
+    <label>{{ localize "DND4E.SOURCE.FIELDS.source.uuid.label" }}</label>
+    <div class="source-uuid form-fields">
+      {{{ sourceAnchor }}}
+    </div>
+  </div>
+  {{/if}}
+</fieldset>

--- a/templates/items/parts/header.hbs
+++ b/templates/items/parts/header.hbs
@@ -42,7 +42,12 @@
       </li>
       {{/if}}
       <li>
-        <input type="text" name="system.source" value="{{system.source}}" placeholder="{{ localize 'DND4E.Source' }}">
+        <div class="source-book">
+          <button type="button" class="icon fa-solid fa-cog" data-action="configureSource"
+            data-config="source" data-tooltip aria-label="{{ localize 'DND4E.SOURCE.Action.Configure' }}">
+          </button>
+        </div>
+        <label>{{sourceLabel}}</label>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Adds a config menu to input source data. This includes a book source, which accepts a book and a page number and will format appropriately, or a custom label which will be displayed as-is. Data migration takes whatever source currently exists on an item and puts it into the custom label. If the item was pulled from a compendium, it will also include a link to the original compendium item.

Additionally, this config menu contains a new field for an identifier. By default, this is the item's name, but slugified, and it will only accept slugs as valid input. I can imagine a few neat things that could be done with this (effect stacking, for example), but for the moment, the only real functionality here is that 4e custom modifiers can apply bonuses based on power or weapon identifiers. In this way, divine domain feats that add a damage bonus to a select set of powers can have their bonuses implemented in a portable way. For example, the key for the Power of Winter feat, assuming default identifiers, would look like:
`power.damage.bond-of-censure,enfeebling-strike,hand-of-radiance,lance-of-faith.untyped`

<img width="502" height="397" alt="image" src="https://github.com/user-attachments/assets/1d6eb173-6714-44f8-b89f-01c146d87680" />