### PR TITLE
Adjust hasAreaTarget to always return a boolean

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -523,7 +523,7 @@ export default class Item4e extends Item {
 	 * @type {boolean}
 	 */
 	get hasAreaTarget() {
-		return ["closeBurst", "closeBlast", "rangeBurst", "rangeBlast", "wall"].includes(this.system.rangeType) || (this.system.effectType?.aura && this.system.auraSize);
+		return ["closeBurst", "closeBlast", "rangeBurst", "rangeBlast", "wall"].includes(this.system.rangeType) || !!(this.system.effectType?.aura && this.system.auraSize);
 	}
 
 	/* -------------------------------------------- */


### PR DESCRIPTION
Not a bugfix per se, and low priority; what we currently have here didn't produce incorrect behavior, it works totally fine as-is (unless some joker is doing `if (item.hasAreaTarget === true/false)`), it's just _more_ correct for us to make sure this actually returns a bool.