### PR TITLE
Improve compatibility with Aura Effects

### DIFF
--- a/module/applications/sheets/active-effect-config.mjs
+++ b/module/applications/sheets/active-effect-config.mjs
@@ -246,9 +246,9 @@ export default class ActiveEffectConfig4e extends foundry.applications.sheets.Ac
 	* Handle adding a new status to the statuses array - adapted from _addEffectChange
 	*/
 	async _addEffectStatus() {
-		const i = this.document.statuses.size;
+		const i = this.document._source.statuses.size;
 		return this.submit({ preventClose: true, updateData: {
-			statuses: [...this.document.statuses, "none"],
+			statuses: [...this.document._source.statuses, "none"],
 		} });
 	}
 

--- a/templates/sheets/active-effect/changes.hbs
+++ b/templates/sheets/active-effect/changes.hbs
@@ -28,7 +28,7 @@
       </div>
     </header>
     <ol class="statuses-list{{#if cltEnabled}} clt-enabled{{/if}}">
-      {{#each document.statuses as |status i|}}
+      {{#each source.statuses as |status i|}}
       <li class="effect-status flexrow" data-status-id="{{status}}" data-index="{{i}}">
         <div class="status-select">
           <select class="refreshes" name="statuses.{{i}}" {{#unless (eq status "none")}} data-tooltip="{{status}}{{#unless (contains status ../config.statusEffects 'id')}}: {{localize 'DND4EUI.UnknownCondition.Tip'}}{{/unless}}" {{/unless}} >


### PR DESCRIPTION
This change will let the statuses section of the Active Effect sheet function with the Aura Effects module. Ongoing damage will not work, pending some potential additional work on the module side (we'll cross that bridge when we come to it).