### PR TITLE
Remove duplicate "other" from Power type/subtype

### DIFF
--- a/templates/items/parts/details-power.hbs
+++ b/templates/items/parts/details-power.hbs
@@ -27,11 +27,9 @@
   <label>{{ localize 'DND4E.PowerType' }}</label>
   <select name="system.powerType">
     {{selectOptions config.powerType selected=system.powerType labelAttr="label"}}
-    <option value="other" {{#if (eq system.powerType "other")}}selected{{/if}}>{{localize "DND4E.Other"}}</option>
   </select> 
   <select name="system.powerSubtype">
     {{selectOptions config.powerSubtype selected=system.powerSubtype labelAttr="label"}}
-    <option value="other" {{#if (eq system.powerSubtype "other")}}selected{{/if}}>{{localize "DND4E.Other"}}</option>
   </select>
 </div>
 <div class="form-group select">


### PR DESCRIPTION
We were manually adding the "other" option when it's already included in `CONFIG.DND4E.powerType`/`powerSubtype`.