### PR TITLE
Add common attack bonus evaluation hook

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -676,6 +676,7 @@
 "DND4E.LaunchOrderPre": "Pre-Item-Use",
 "DND4E.LaunchOrderPost": "Post-Item-Use",
 "DND4E.LaunchOrderSub": "Substitute-Item-Use",
+"DND4E.LaunchOrderHookComBon": "Hook: Evaluate Common Attack Bonuses",
 "DND4E.Level": "Level",
 "DND4E.LevelScaling": "Level Scaling",
 "DND4E.LimitedUses": "Limited Uses",

--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -677,6 +677,7 @@
 "DND4E.LaunchOrderPost": "Post-Item-Use",
 "DND4E.LaunchOrderSub": "Substitute-Item-Use",
 "DND4E.LaunchOrderHookComBon": "Hook: Evaluate Common Attack Bonuses",
+"DND4E.LaunchOrderHookPreAttack": "Hook: Pre Attack Roll",
 "DND4E.Level": "Level",
 "DND4E.LevelScaling": "Level Scaling",
 "DND4E.LimitedUses": "Limited Uses",

--- a/lang/en.json
+++ b/lang/en.json
@@ -676,6 +676,7 @@
 "DND4E.LaunchOrderPre": "Pre-Item-Use",
 "DND4E.LaunchOrderPost": "Post-Item-Use",
 "DND4E.LaunchOrderSub": "Substitute-Item-Use",
+"DND4E.LaunchOrderHookComBon": "Hook: Evaluate Common Attack Bonuses",
 "DND4E.Level": "Level",
 "DND4E.LevelScaling": "Level Scaling",
 "DND4E.LimitedUses": "Limited Uses",

--- a/lang/en.json
+++ b/lang/en.json
@@ -677,6 +677,7 @@
 "DND4E.LaunchOrderPost": "Post-Item-Use",
 "DND4E.LaunchOrderSub": "Substitute-Item-Use",
 "DND4E.LaunchOrderHookComBon": "Hook: Evaluate Common Attack Bonuses",
+"DND4E.LaunchOrderHookPreAttack": "Hook: Pre Attack Roll",
 "DND4E.Level": "Level",
 "DND4E.LevelScaling": "Level Scaling",
 "DND4E.LimitedUses": "Limited Uses",

--- a/module/applications/ux/enrichers/roll.mjs
+++ b/module/applications/ux/enrichers/roll.mjs
@@ -477,7 +477,7 @@ async function rollDamageHealing(config, event) {
 	if (!formula) throw new Error("Attack enricher must provide a formula");
 
 	const parts = [formula];
-	const partsExpressionReplacement = [{ value: formula, target: replacedFormula }];
+	const partsExpressionReplacements = [{ value: formula, target: replacedFormula }];
 	const partsCrit = critFormula ? [critFormula] : null;
 	const partsCritExpressionReplacement = critFormula ? [{ value: critFormula, target: replacedCritFormula }] : null;
 
@@ -515,7 +515,7 @@ async function rollDamageHealing(config, event) {
 	if (extraDamageParts.length) {
 		for (const part of extraDamageParts) {
 			parts.push(part);
-			partsExpressionReplacement.unshift({ target: part, value: "@extraDamage" });
+			partsExpressionReplacements.unshift({ target: part, value: "@extraDamage" });
 			if (partsCrit) {
 				let critDamage = new Roll("part").evaluateSync({ maximize: true });
 				partsCrit.push(critDamage.total);
@@ -546,7 +546,7 @@ async function rollDamageHealing(config, event) {
 	// Compose roll options
 	const rollConfig = {
 		parts,
-		partsExpressionReplacement,
+		partsExpressionReplacements,
 		partsCrit,
 		partsCritExpressionReplacement,
 		actor,

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -80,12 +80,12 @@ DND4E.macroType = {
 preLocalize("macroType", { keys: ["label"] });
 
 DND4E.macroLaunchOrder = {
-	both: { label: "DND4E.LaunchOrderBoth" },
 	off: { label: "DND4E.LaunchOrderOff" },
+	both: { label: "DND4E.LaunchOrderBoth" },
 	pre: { label: "DND4E.LaunchOrderPre" },
 	post: { label: "DND4E.LaunchOrderPost" },
 	sub: { label: "DND4E.LaunchOrderSub" },
-	comBon: { label: "dnd4e.evaluateCommonAttackBonuses" },
+	comBon: { label: "DND4E.LaunchOrderHookComBon" },
 };
 preLocalize("macroLaunchOrder", { keys: ["label"] });
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -85,6 +85,7 @@ DND4E.macroLaunchOrder = {
 	pre: { label: "DND4E.LaunchOrderPre" },
 	post: { label: "DND4E.LaunchOrderPost" },
 	sub: { label: "DND4E.LaunchOrderSub" },
+	comBon: { label: "dnd4e.evaluateCommonAttackBonuses" },
 };
 preLocalize("macroLaunchOrder", { keys: ["label"] });
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -86,6 +86,7 @@ DND4E.macroLaunchOrder = {
 	post: { label: "DND4E.LaunchOrderPost" },
 	sub: { label: "DND4E.LaunchOrderSub" },
 	comBon: { label: "DND4E.LaunchOrderHookComBon" },
+	preAttack: { label: "DND4E.LaunchOrderHookPreAttack" },
 };
 preLocalize("macroLaunchOrder", { keys: ["label"] });
 

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -2132,7 +2132,7 @@ export default class Item4e extends Item {
 		const partsCrit = itemData.damageCrit.parts.map(d => secondaryPartsHelper(d.formula, [...d.type].join(",")));
 
 		// store the original expression formula that produced those formula
-		const partsExpressionReplacement = parts.map(part => { return { target: part, value: "@pow2ndryDamage" };});
+		const partsExpressionReplacements = parts.map(part => { return { target: part, value: "@pow2ndryDamage" };});
 		const partsMissExpressionReplacement = partsMiss.map(part => { return { target: part, value: "@pow2ndryDamage" };});
 		const partsCritExpressionReplacement = partsCrit.map(part => { return { target: part, value: "@pow2ndryCritDamage" };});
 
@@ -2193,14 +2193,14 @@ export default class Item4e extends Item {
 			//I really want to factor this, but they are annoyingly different enough to make it too headache inducing
 			if (weaponUse) {
 				if (itemData.hit.formula.includes("@wepDamage") && weaponUse.system.damage.parts.length) {
-					secondaryDamageExpressionHelper(parts, partsExpressionReplacement, weaponUse.system.damage.parts);
+					secondaryDamageExpressionHelper(parts, partsExpressionReplacements, weaponUse.system.damage.parts);
 				}
 				if (itemData.hit.critFormula.includes("@wepCritBonus") && weaponUse.system.damageCrit.parts.length) {
 					secondaryDamageExpressionHelper(partsCrit, partsCritExpressionReplacement, weaponUse.system.damageCrit.parts);
 				}
 
 				if (itemData.hit.formula.includes("@impDamage") && weaponUse.isActorImplementProficient && weaponUse.system.damageImp.parts.length) {
-					secondaryDamageExpressionHelper(parts, partsExpressionReplacement, weaponUse.system.damageImp.parts);
+					secondaryDamageExpressionHelper(parts, partsExpressionReplacements, weaponUse.system.damageImp.parts);
 				}
 				if (itemData.hit.critFormula.includes("@impCritBonus") && weaponUse.isActorImplementProficient && weaponUse.system.damageCritImp.parts.length) {
 					secondaryDamageExpressionHelper(partsCrit, partsCritExpressionReplacement, weaponUse.system.damageCritImp.parts);
@@ -2292,7 +2292,7 @@ export default class Item4e extends Item {
 		if (extraDamageParts.length) {
 			for (const part of extraDamageParts) {
 				parts.push(part);
-				partsExpressionReplacement.unshift({ target: part, value: "@extraDamage" });
+				partsExpressionReplacements.unshift({ target: part, value: "@extraDamage" });
 
 				if (critDamageFormula) {
 					const maxRoll = await new Roll(part).evaluate({ maximize: true });
@@ -2342,7 +2342,7 @@ export default class Item4e extends Item {
 		if (damageFormula) parts.unshift(`(${damageFormula})${primaryDamageStr}`);
 		if (critDamageFormula) partsCrit.unshift(`(${critDamageFormula})${primaryDamageStr}`);
 		if (missDamageFormula) partsMiss.unshift(`(${missDamageFormula})${primaryDamageStr}`);
-		if (damageFormulaExpression) partsExpressionReplacement.unshift({ target: parts[0], value: damageFormulaExpression });
+		if (damageFormulaExpression) partsExpressionReplacements.unshift({ target: parts[0], value: damageFormulaExpression });
 		if (critDamageFormulaExpression) partsCritExpressionReplacement.unshift({ target: partsCrit[0], value: critDamageFormulaExpression });
 		if (missDamageFormulaExpression) partsMissExpressionReplacement.unshift({ target: partsMiss[0], value: missDamageFormulaExpression });
 		
@@ -2355,7 +2355,7 @@ export default class Item4e extends Item {
 			parts,
 			partsCrit,
 			partsMiss,
-			partsExpressionReplacement,
+			partsExpressionReplacements,
 			partsCritExpressionReplacement,
 			partsMissExpressionReplacement,
 			actor: this.actor,
@@ -2409,7 +2409,7 @@ export default class Item4e extends Item {
 
 		// Define Roll parts
 		const parts = itemData.damage.parts.map(d => d[0]);
-		const partsExpressionReplacement = itemData.damage.parts.map(part => { return { target: part[0], value: "@wep2ndryDamage" };});
+		const partsExpressionReplacements = itemData.damage.parts.map(part => { return { target: part[0], value: "@wep2ndryDamage" };});
 
 		const options = { formulaInnerData: {}, bonuses: foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses) };
 		const formulaHelper = (formula) => {
@@ -2429,12 +2429,12 @@ export default class Item4e extends Item {
 		if (weaponUse) {
 			if (itemData.hit.healFormula.includes("@wepDamage") && weaponUse.system.damage.parts.length) {
 				Array.prototype.push.apply(parts, weaponUse.system.damage.parts.map(d => formulaHelper(d[0])));
-				Array.prototype.push.apply(partsExpressionReplacement, weaponUse.system.damage.parts.map(part => { return { target: part[0], value: "@wep2ndryDamage" };}));
+				Array.prototype.push.apply(partsExpressionReplacements, weaponUse.system.damage.parts.map(part => { return { target: part[0], value: "@wep2ndryDamage" };}));
 			}
 			
 			if (itemData.hit.healFormula.includes("@impDamage") && weaponUse.isActorImplementProficient && weaponUse.system.damageImp.parts.length) {
 				Array.prototype.push.apply(parts, weaponUse.system.damageImp.parts.map(d => formulaHelper(d[0])));
-				Array.prototype.push.apply(partsExpressionReplacement, weaponUse.system.damageImp.parts.map(part => { return { target: part[0], value: "@wep2ndryDamage" };}));
+				Array.prototype.push.apply(partsExpressionReplacements, weaponUse.system.damageImp.parts.map(part => { return { target: part[0], value: "@wep2ndryDamage" };}));
 			}
 		}
 
@@ -2443,7 +2443,7 @@ export default class Item4e extends Item {
 			if (weaponUse.system.properties["ver"] && (weaponUse.system.weaponHand === "hTwo")) {
 				parts.push("1");
 				messageData["flags.dnd4e.roll"].versatile = true;
-				partsExpressionReplacement.push({ target: "1", value: "@versatile" });
+				partsExpressionReplacements.push({ target: "1", value: "@versatile" });
 			}
 		}
 	
@@ -2484,7 +2484,7 @@ export default class Item4e extends Item {
 		return damageRoll({
 			event,
 			parts,
-			partsExpressionReplacement,
+			partsExpressionReplacements,
 			actor: this.actor,
 			data: rollData,
 			title,

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -238,7 +238,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 	let allRollsParts = [];
 	const numberOfTargets = Math.max(1, game.user.targets.size);
 	//console.debug(data);
-	let targetDefArray = [], targetAtkModArray = [];
+	let targetDefArray = [], targetAtkModArray = [], targetBonusArray = [];
 	
 	if (isAttackRoll && (form !== null)) {
 		const individualAttack = (form.querySelector("#multibonus-toggle")?.value === "true");
@@ -368,10 +368,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			}
 			else {
 				allRollsParts.push(parts.concat(Object.entries(targetBonuses).filter((bon) => bon[1].shouldApply).map((bon) => `@${bon[0]}`)));
-				// populate the common attack bonuses into data
-				Object.keys(targetBonuses).forEach(function(key, index) {
-					data[key] = targetBonuses[key].value;
-				});
+				targetBonusArray.push(targetBonuses);
 			}
 		}
 		
@@ -424,12 +421,10 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const targetActor = targets[rollExpressionIdx]?.document.actor;
 			const IS_TARGET = true;
 			if (targetActor) await utils.applyEffects({ ...data, ...options.variance }, targetActor, itemData, weaponData, "attack", null, IS_TARGET, targetOptions);
-			if (!fastForward) {
-				// populate the common attack bonuses into data
-				Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
-					data[key] = targDataArray?.targets[rollExpressionIdx].targetBonuses[key].value;
-				});
-			}
+			// populate the common attack bonuses into data
+			Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
+				data[key] = targDataArray?.targets[rollExpressionIdx].targetBonuses[key].value || targetBonusArray[rollExpressionIdx][key].value;
+			});
 			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}
 		catch(err) {

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -422,18 +422,21 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const IS_TARGET = true;
 			if (targetActor) await utils.applyEffects({ ...data, ...options.variance }, targetActor, itemData, weaponData, "attack", null, IS_TARGET, targetOptions);
 			// populate the common attack bonuses into data
-			Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
-				data[key] = targDataArray ? targDataArray.targets[rollExpressionIdx].targetBonuses[key].value : (targetBonusArray ? targetBonusArray[rollExpressionIdx][key].value : null);
-			});
+			const commonAttackBonuses = targDataArray ? targDataArray.targets[rollExpressionIdx].targetBonuses : (targetBonusArray ? targetBonusArray[rollExpressionIdx] : null);
+			if (commonAttackBonuses) {
+				Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
+					data[key] = commonAttackBonuses[key].value;
+				});
+			}
 			const attacker = utils.tokenForActor(actor);
 			const target = targets[rollExpressionIdx];
 			for (const actorItem of [...actor.items]) {
 				if (actorItem.system.macro.launchOrder === "preAttack") {
 					const func = new Function("source", "item", "attacker", "target", "rollConfig", actorItem.system.macro.command);
-					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, targetOptions });
+					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, targetOptions, commonAttackBonuses });
 				}
 			}
-			Hooks.callAll("dnd4e.preAttackRoll", item, attacker, target, { rollExpression, partsExpressionReplacements, targetOptions });
+			Hooks.callAll("dnd4e.preAttackRoll", item, attacker, target, { rollExpression, partsExpressionReplacements, targetOptions, commonAttackBonuses });
 			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}
 		catch(err) {

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -423,7 +423,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			if (targetActor) await utils.applyEffects({ ...data, ...options.variance }, targetActor, itemData, weaponData, "attack", null, IS_TARGET, targetOptions);
 			// populate the common attack bonuses into data
 			Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
-				data[key] = targDataArray?.targets[rollExpressionIdx].targetBonuses[key].value || targetBonusArray[rollExpressionIdx][key].value;
+				data[key] = targDataArray ? targDataArray.targets[rollExpressionIdx].targetBonuses[key].value : (targetBonusArray ? targetBonusArray[rollExpressionIdx][key].value : null);
 			});
 			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -115,8 +115,8 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 			const target = targetArr[targ];
 			for (const actorItem of [...actor.items]) {
 				if (actorItem.system.macro.launchOrder === "comBon") {
-					const func = new Function("item", "attacker", "target", "bonuses", actorItem.system.macro.command);
-					func(item, attacker, target, targetBonuses);
+					const func = new Function("source", "item", "attacker", "target", "bonuses", actorItem.system.macro.command);
+					func(actorItem, item, attacker, target, targetBonuses);
 				}
 			}
 			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, targetBonuses);
@@ -357,8 +357,8 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const target = theTargets[targetIndex];
 			for (const actorItem of [...actor.items]) {
 				if (actorItem.system.macro.launchOrder === "comBon") {
-					const func = new Function("item", "attacker", "target", "bonuses", actorItem.system.macro.command);
-					func(item, attacker, target, targetBonuses);
+					const func = new Function("source", "item", "attacker", "target", "bonuses", actorItem.system.macro.command);
+					func(actorItem, item, attacker, target, targetBonuses);
 				}
 			}
 			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, targetBonuses);

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -433,10 +433,10 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			for (const actorItem of [...actor.items]) {
 				if (actorItem.system.macro.launchOrder === "preAttack") {
 					const func = new Function("source", "item", "attacker", "target", "rollConfig", actorItem.system.macro.command);
-					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, targetOptions, commonAttackBonuses });
+					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
 				}
 			}
-			Hooks.callAll("dnd4e.preAttackRoll", item, attacker, target, { rollExpression, partsExpressionReplacements, targetOptions, commonAttackBonuses });
+			Hooks.callAll("dnd4e.preAttackRoll", item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
 			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}
 		catch(err) {

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -57,8 +57,8 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 	if (actor && game.user.targets.size) {
 		const userBonuses = Object.keys(CONFIG.DND4E.commonAttackBonuses).reduce((bonuses, bonus) => {
 			bonuses[bonus] = {
-				value: false,
-				bonus: actor.system.commonAttackBonuses[bonus].value,
+				shouldApply: false,
+				value: actor.system.commonAttackBonuses[bonus].value,
 			};
 			return bonuses;
 		}, {});
@@ -67,15 +67,15 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 		targDataArray.hasTarget = true;
 		if (game.settings.get("dnd4e", "markAutomation") && actor.system?.marker) {
 			targDataArray.ignoringMark = !targetArr.some(t => (t.actor.uuid === data.marker));
-			userBonuses.ignoringMark.value = true;
+			userBonuses.ignoringMark.shouldApply = true;
 		}
 		// User conditions
-		if (userStatus.has("prone")) userBonuses.prone.value = true;
-		if (userStatus.has("restrained")) userBonuses.restrained.value = true;
-		if (userStatus.has("running")) userBonuses.running.value = true;
-		if (userStatus.has("squeezing")) userBonuses.squeez.value = true;
-		if (userStatus.has("comAdv")) userBonuses.comAdv.value = true;
-		if (isCharge) userBonuses.charge.value = true;
+		if (userStatus.has("prone")) userBonuses.prone.shouldApply = true;
+		if (userStatus.has("restrained")) userBonuses.restrained.shouldApply = true;
+		if (userStatus.has("running")) userBonuses.running.shouldApply = true;
+		if (userStatus.has("squeezing")) userBonuses.squeez.shouldApply = true;
+		if (userStatus.has("comAdv")) userBonuses.comAdv.shouldApply = true;
+		if (isCharge) userBonuses.charge.shouldApply = true;
 		for (let targ = 0; targ < numTargets; targ++) {
 			const targetBonuses = foundry.utils.deepClone(userBonuses);
 			const targName = targetArr[targ].name;
@@ -83,7 +83,7 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 			const targetStatus = Array.from(targetArr[targ].actor.statuses);
 				
 			//Target conditions
-			if (targetStatus.filter(element => ["blinded", "dazed", "dominated", "helpless", "restrained", "stunned", "surprised", "squeezing", "running", "grantingCA"].includes(element)).length) targetBonuses.comAdv.value = true;
+			if (targetStatus.filter(element => ["blinded", "dazed", "dominated", "helpless", "restrained", "stunned", "surprised", "squeezing", "running", "grantingCA"].includes(element)).length) targetBonuses.comAdv.shouldApply = true;
 			const targetDist = utils.computeDistance(actor, targetArr[targ]);
 			//console.debug(data);
 			if (targetArr[targ].actor.statuses.has("prone") && (["melee", "touch", "reach"].includes(item?.system.rangeType) || ((item?.system.rangeType === "weapon") && (weaponUse?.system.weaponType.slice(-1) === "M")))) {
@@ -97,19 +97,19 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 						}
 					}
 				}
-				if (meleeVsProne) targetBonuses.comAdv = true;
+				if (meleeVsProne) targetBonuses.comAdv.shouldApply = true;
 			}
 			if (((item?.system.rangeType === "range") && item?.system.range.long && (targetDist > item?.system.rangePower)) || ((item?.system.rangeType === "weapon") && weaponUse?.system.range.long && (targetDist > weaponUse?.system.range.value))) {
-				targetBonuses.longRange.value = true;
+				targetBonuses.longRange.shouldApply = true;
 			}
 			if (utils.computeFlankingStatus(utils.tokenForActor(actor), targetArr[targ])) {
-				targetBonuses.comAdv.value = true;
+				targetBonuses.comAdv.shouldApply = true;
 			}
-			if (targetStatus.includes("bloodied")) targetBonuses.bloodied.value = true;
-			if (targetStatus.includes("concealed")) targetBonuses.conceal.value = true;	
-			if (targetStatus.includes("concealedTotal")) targetBonuses.concealTotal.value = true;
-			if (targetStatus.includes("cover")) targetBonuses.cover.value = true;		
-			if (targetStatus.includes("coverSup")) targetBonuses.coverSup.value = true;
+			if (targetStatus.includes("bloodied")) targetBonuses.bloodied.shouldApply = true;
+			if (targetStatus.includes("concealed")) targetBonuses.conceal.shouldApply = true;	
+			if (targetStatus.includes("concealedTotal")) targetBonuses.concealTotal.shouldApply = true;
+			if (targetStatus.includes("cover")) targetBonuses.cover.shouldApply = true;		
+			if (targetStatus.includes("coverSup")) targetBonuses.coverSup.shouldApply = true;
             
 			const attacker = utils.tokenForActor(actor);
 			const target = targetArr[targ];
@@ -259,7 +259,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			}
 			if (game.settings.get("dnd4e", "collapseSituationalBonus")) {
 				let total = 0;
-				targetBonuses.forEach(bonus => total += targDataArray.targets[targetIndex].targetBonuses[bonus.substring(1)].bonus);
+				targetBonuses.forEach(bonus => total += targDataArray.targets[targetIndex].targetBonuses[bonus.substring(1)].value);
 				const partsToPush = total ? parts.concat([total]) : parts;
 				allRollsParts.push(partsToPush);
 			}
@@ -292,22 +292,22 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 		let hasComAdv = false;
 		const userStatBonuses = Object.keys(CONFIG.DND4E.commonAttackBonuses).reduce((bonuses, bonus) => {
 			bonuses[bonus] = {
-				value: false,
-				bonus: data.commonAttackBonuses[bonus].value,
+				shouldApply: false,
+				value: data.commonAttackBonuses[bonus].value,
 			};
 			return bonuses;
 		}, {});
 
 		// User conditions
-		if (userStatus.has("prone")) userStatBonuses.prone.value = true;
-		if (userStatus.has("restrained")) userStatBonuses.restrained.value = true;
-		if (userStatus.has("running")) userStatBonuses.running.value = true;
-		if (userStatus.has("squeezing")) userStatBonuses.squeez.value = true;
+		if (userStatus.has("prone")) userStatBonuses.prone.shouldApply = true;
+		if (userStatus.has("restrained")) userStatBonuses.restrained.shouldApply = true;
+		if (userStatus.has("running")) userStatBonuses.running.shouldApply = true;
+		if (userStatus.has("squeezing")) userStatBonuses.squeez.shouldApply = true;
 		if (userStatus.has("comAdv")) hasComAdv = true;
-		if (options?.variance?.isCharge) userStatBonuses.charge.value = true;
+		if (options?.variance?.isCharge) userStatBonuses.charge.shouldApply = true;
 		
 		if (game.settings.get("dnd4e", "markAutomation") && data?.marker) {
-			if (!theTargets.some(t => (t.actor.uuid === data.marker))) userStatBonuses.marked.value = true;
+			if (!theTargets.some(t => (t.actor.uuid === data.marker))) userStatBonuses.marked.shouldApply = true;
 		}
 				
 		for (let targetIndex = 0; targetIndex < numberOfTargets; targetIndex++) {
@@ -343,16 +343,16 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 				}
 
 				if (((item?.system.rangeType === "range") && item?.system.range.long && (targetDist > item?.system.rangePower)) || ((item?.system.rangeType === "weapon") && weaponUse?.system.range.long && (targetDist > weaponUse?.system.range.value))) {
-					targetBonuses.longRange.value = true;
+					targetBonuses.longRange.shouldApply = true;
 				}
 
-				if (targetStatus.includes("bloodied")) targetBonuses.bloodied.value = true;
-				if (targetStatus.includes("concealed")) targetBonuses.conceal.value = true;	
-				if (targetStatus.includes("concealedTotal")) targetBonuses.concealTotal.value = true;
-				if (targetStatus.includes("cover")) targetBonuses.cover.value = true;		
-				if (targetStatus.includes("coverSup")) targetBonuses.coverSup.value = true;
+				if (targetStatus.includes("bloodied")) targetBonuses.bloodied.shouldApply = true;
+				if (targetStatus.includes("concealed")) targetBonuses.conceal.shouldApply = true;	
+				if (targetStatus.includes("concealedTotal")) targetBonuses.concealTotal.shouldApply = true;
+				if (targetStatus.includes("cover")) targetBonuses.cover.shouldApply = true;		
+				if (targetStatus.includes("coverSup")) targetBonuses.coverSup.shouldApply = true;
 			}
-			if (hasComAdv) targetBonuses.comAdv.value = true;
+			if (hasComAdv) targetBonuses.comAdv.shouldApply = true;
 			const attacker = utils.tokenForActor(actor);
 			const target = theTargets[targetIndex];
 			for (const actorItem of [...actor.items]) {
@@ -363,14 +363,14 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			}
 			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, targetBonuses);
 			if (game.settings.get("dnd4e", "collapseSituationalBonus")) {
-				const total = Object.values(targetBonuses).filter((bon) => bon.value).map((bon) => bon.bonus).reduce((acc, curr) => acc + curr);
+				const total = Object.values(targetBonuses).filter((bon) => bon.shouldApply).map((bon) => bon.value).reduce((acc, curr) => acc + curr);
 				allRollsParts.push(parts.concat([total]));
 			}
 			else {
-				allRollsParts.push(parts.concat(Object.entries(targetBonuses).filter((bon) => bon[1].value).map((bon) => `@${bon[0]}`)));
+				allRollsParts.push(parts.concat(Object.entries(targetBonuses).filter((bon) => bon[1].shouldApply).map((bon) => `@${bon[0]}`)));
 				// populate the common attack bonuses into data
 				Object.keys(targetBonuses).forEach(function(key, index) {
-					data[key] = targetBonuses[key].bonus;
+					data[key] = targetBonuses[key].value;
 				});
 			}
 		}
@@ -424,10 +424,12 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const targetActor = targets[rollExpressionIdx]?.document.actor;
 			const IS_TARGET = true;
 			if (targetActor) await utils.applyEffects({ ...data, ...options.variance }, targetActor, itemData, weaponData, "attack", null, IS_TARGET, targetOptions);
-			// populate the common attack bonuses into data
-			Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
-				data[key] = targDataArray.targets[rollExpressionIdx].targetBonuses[key].bonus;
-			});
+			if (!fastForward) {
+				// populate the common attack bonuses into data
+				Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
+					data[key] = targDataArray?.targets[rollExpressionIdx].targetBonuses[key].value;
+				});
+			}
 			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}
 		catch(err) {

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -193,7 +193,7 @@ export function getAttackRollBonus({ parts = [], data = {}, options = {} }) {
  * @param {Object} form 
  * @param {Object} options
  * @param {string[]} options.parts
- * @param {Object[]} options.partsExpressionReplacement
+ * @param {Object[]} options.partsExpressionReplacements
  * @param {Item4e} options.item
  * @param {Item4e} options.weaponUse
  * @param {Object} options.data
@@ -425,6 +425,15 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
 				data[key] = targDataArray ? targDataArray.targets[rollExpressionIdx].targetBonuses[key].value : (targetBonusArray ? targetBonusArray[rollExpressionIdx][key].value : null);
 			});
+			const attacker = utils.tokenForActor(actor);
+			const target = targets[rollExpressionIdx];
+			for (const actorItem of [...actor.items]) {
+				if (actorItem.system.macro.launchOrder === "preAttack") {
+					const func = new Function("source", "item", "attacker", "target", "rollConfig", actorItem.system.macro.command);
+					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, targetOptions });
+				}
+			}
+			Hooks.callAll("dnd4e.preAttackRoll", item, attacker, target, { rollExpression, partsExpressionReplacements, targetOptions });
 			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}
 		catch(err) {
@@ -542,7 +551,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
  * @param {Array} parts           The dice roll component parts
  * @param {Array} partsCrit       The dice roll component parts for a criticalhit
  * @param {Array} partsMiss      The dice roll component parts for a miss
- * @param {Array} partsExpressionReplacement  Optional Array of replacement values for the parts array to create a formula to display where bonuses came from.
+ * @param {Array} partsExpressionReplacements  Optional Array of replacement values for the parts array to create a formula to display where bonuses came from.
  *                                 Each element should be in the form of { target: 'Text To Replace', value: 'text to replace with' }
  * @param {Array} partsCritExpressionReplacement  Optional Array of replacement values for the parts array to create a formula to display where bonuses came from.
  *                                 Each element should be in the form of { target: 'Text To Replace', value: 'text to replace with' }
@@ -566,12 +575,12 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
  *
  * @returns {Promise}              A Promise which resolves once the roll workflow has completed
  */
-export async function damageRoll({ parts, partsCrit, partsMiss, partsExpressionReplacement = [], partsCritExpressionReplacement = [], partsMissExpressionReplacement = [], actor,
+export async function damageRoll({ parts, partsCrit, partsMiss, partsExpressionReplacements = [], partsCritExpressionReplacement = [], partsMissExpressionReplacement = [], actor,
 	data, event = {}, messageMode = null, template, title, speaker, flavor, allowCritical = true,
 	critical = false, fastForward = null, onClose, dialogOptions, healingRoll, options }) {
 									
 	// First configure the Roll
-	const rollConfig = { parts, partsCrit, partsMiss, data, flavor, messageMode, partsExpressionReplacement, partsCritExpressionReplacement, partsMissExpressionReplacement, speaker, hitType: "normal", fastForward, options };
+	const rollConfig = { parts, partsCrit, partsMiss, data, flavor, messageMode, partsExpressionReplacements, partsCritExpressionReplacement, partsMissExpressionReplacement, speaker, hitType: "normal", fastForward, options };
 
 	// handle input arguments
 	mergeInputArgumentsIntoRollConfig(rollConfig, parts, event, messageMode, title, speaker, flavor, fastForward);
@@ -651,7 +660,7 @@ export async function damageRoll({ parts, partsCrit, partsMiss, partsExpressionR
  * @param {string} options.hitType
  * @param {string} options.flavor
  * @param {string} options.messageMode
- * @param {Object[]} options.partsExpressionReplacement
+ * @param {Object[]} options.partsExpressionReplacements
  * @param {Object[]} options.partsCritExpressionReplacement
  * @param {Object[]} options.partsMissExpressionReplacement
  * @param {Object} options.speaker
@@ -659,7 +668,7 @@ export async function damageRoll({ parts, partsCrit, partsMiss, partsExpressionR
  * @param {boolean} options.fastForward
  * @returns 
  */
-async function performDamageRollAndCreateChatMessage(form, { parts, partsCrit, partsMiss, data, hitType, flavor, messageMode, partsExpressionReplacement, partsCritExpressionReplacement, partsMissExpressionReplacement, speaker, options, fastForward }) {
+async function performDamageRollAndCreateChatMessage(form, { parts, partsCrit, partsMiss, data, hitType, flavor, messageMode, partsExpressionReplacements, partsCritExpressionReplacement, partsMissExpressionReplacement, speaker, options, fastForward }) {
 	manageBonusInParts(parts, form, data);
 	manageBonusInParts(partsCrit, form, data);
 	manageBonusInParts(partsMiss, form, data);
@@ -681,13 +690,13 @@ async function performDamageRollAndCreateChatMessage(form, { parts, partsCrit, p
 	let roll;
 	if (hitType === "immune") {
 		options.hitTypeDamage = false;
-		roll = RollWithOriginalExpression.createRoll(parts, partsExpressionReplacement, data, options);
+		roll = RollWithOriginalExpression.createRoll(parts, partsExpressionReplacements, data, options);
 		flavor = `${flavor} (${_loc("DND4E.Immune")})`;
 	}
 	else if (hitType === "normal") {
 		options.hitTypeDamage = true;
 		options.hitType = hitType;
-		roll = RollWithOriginalExpression.createRoll(parts, partsExpressionReplacement, data, options);
+		roll = RollWithOriginalExpression.createRoll(parts, partsExpressionReplacements, data, options);
 	}
 	else if (hitType === "crit") {
 		options.hitTypeDamage = true;
@@ -703,10 +712,10 @@ async function performDamageRollAndCreateChatMessage(form, { parts, partsCrit, p
 	}
 	else if (hitType === "heal") {
 		options.hitTypeHealing = true;
-		roll = RollWithOriginalExpression.createRoll(parts, partsExpressionReplacement, data, options);
+		roll = RollWithOriginalExpression.createRoll(parts, partsExpressionReplacements, data, options);
 		flavor = `${flavor} (${_loc("DND4E.Healing")})`;
 	} else {
-		roll = RollWithOriginalExpression.createRoll(parts, partsExpressionReplacement, data, options);
+		roll = RollWithOriginalExpression.createRoll(parts, partsExpressionReplacements, data, options);
 	}
 
 	if (form?.flavor.value) {

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -55,20 +55,39 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 	};
 	
 	if (actor && game.user.targets.size) {
+		const userBonuses = Object.keys(CONFIG.DND4E.commonAttackBonuses).reduce((bonuses, bonus) => {
+			bonuses[bonus] = {
+				value: false,
+				bonus: actor.system.commonAttackBonuses[bonus].value,
+			};
+			return bonuses;
+		}, {});
 		const numTargets = game.user.targets.size;
 		const targetArr = Array.from(game.user.targets);
 		targDataArray.hasTarget = true;
 		if (game.settings.get("dnd4e", "markAutomation") && actor.system?.marker) {
 			targDataArray.ignoringMark = !targetArr.some(t => (t.actor.uuid === data.marker));
+			userBonuses.ignoringMark.value = true;
 		}
+		// User conditions
+		if (userStatus.has("prone")) userBonuses.prone.value = true;
+		if (userStatus.has("restrained")) userBonuses.restrained.value = true;
+		if (userStatus.has("running")) userBonuses.running.value = true;
+		if (userStatus.has("squeezing")) userBonuses.squeez.value = true;
+		if (userStatus.has("comAdv")) userBonuses.comAdv.value = true;
+		if (isCharge) userBonuses.charge.value = true;
 		for (let targ = 0; targ < numTargets; targ++) {
+			const targetBonuses = foundry.utils.deepClone(userBonuses);
 			const targName = targetArr[targ].name;
 			targDataArray.targNameArray.push(targName);
+			const targetStatus = Array.from(targetArr[targ].actor.statuses);
+				
+			//Target conditions
+			if (targetStatus.filter(element => ["blinded", "dazed", "dominated", "helpless", "restrained", "stunned", "surprised", "squeezing", "running", "grantingCA"].includes(element)).length) targetBonuses.comAdv.value = true;
 			const targetDist = utils.computeDistance(actor, targetArr[targ]);
 			//console.debug(data);
-			let meleeVsProne = false;
 			if (targetArr[targ].actor.statuses.has("prone") && (["melee", "touch", "reach"].includes(item?.system.rangeType) || ((item?.system.rangeType === "weapon") && (weaponUse?.system.weaponType.slice(-1) === "M")))) {
-				meleeVsProne = true;
+				let meleeVsProne = true;
 				if (item?.system.rangeType === "weapon") {
 					if (weaponUse?.system.properties.thv || weaponUse?.system.properties.tlg) {
 						const meleeRange = weaponUse.system.properties.rch ? 2 : 1;
@@ -78,24 +97,36 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 						}
 					}
 				}
+				if (meleeVsProne) targetBonuses.comAdv = true;
 			}
-			let longRange = false;
 			if (((item?.system.rangeType === "range") && item?.system.range.long && (targetDist > item?.system.rangePower)) || ((item?.system.rangeType === "weapon") && weaponUse?.system.range.long && (targetDist > weaponUse?.system.range.value))) {
-				longRange = true;
+				targetBonuses.longRange.value = true;
 			}
-			let isFlanking = false;
 			if (utils.computeFlankingStatus(utils.tokenForActor(actor), targetArr[targ])) {
-				isFlanking = true;
+				targetBonuses.comAdv.value = true;
 			}
+			if (targetStatus.includes("bloodied")) targetBonuses.bloodied.value = true;
+			if (targetStatus.includes("concealed")) targetBonuses.conceal.value = true;	
+			if (targetStatus.includes("concealedTotal")) targetBonuses.concealTotal.value = true;
+			if (targetStatus.includes("cover")) targetBonuses.cover.value = true;		
+			if (targetStatus.includes("coverSup")) targetBonuses.coverSup.value = true;
+            
+			const attacker = utils.tokenForActor(actor);
+			const target = targetArr[targ];
+			for (const actorItem of [...actor.items]) {
+				if (actorItem.system.macro.launchOrder === "comBon") {
+					const func = new Function("item", "attacker", "target", "bonuses", actorItem.system.macro.command);
+					func(item, attacker, target, targetBonuses);
+				}
+			}
+			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, targetBonuses);
 			targDataArray.targets.push({
 				name: targetArr[targ].name,
 				status: targetArr[targ].actor.statuses,
 				attackMod: data?.item?.attack?.ability || "",
 				attackDef: options.attackedDef || "ac",
 				immune: targetArr[targ].actor.system.defences[options.attackedDef]?.none || false,
-				meleeVsProne: meleeVsProne,
-				longRange: longRange,
-				isFlanking: isFlanking,
+				targetBonuses,
 			});
 		}
 	} else {
@@ -135,6 +166,7 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 		label: _loc("DND4E.Roll"),
 		type: "submit",
 	}];
+	rollConfig.targDataArray = targDataArray;
 	return RollDialog.asPromise({ dialogData, rollConfig, buttons, window: { title }, callbackFn: performD20RollAndCreateMessage });
 }
 
@@ -175,10 +207,11 @@ export function getAttackRollBonus({ parts = [], data = {}, options = {} }) {
  * @param {boolean} options.isAttackRoll
  * @param {Object} options.options
  * @param {Set<string>} options.userStatus
+ * @param {Object[]} options.targDataArray
  * @param {boolean} options.fastForward
  * @returns 
  */
-async function performD20RollAndCreateMessage(form, { parts, partsExpressionReplacements, item, weaponUse, data, speaker, messageMode, flavor, critical, fumble, targetValue, actor, isAttackRoll, options, userStatus, fastForward }) {
+async function performD20RollAndCreateMessage(form, { parts, partsExpressionReplacements, item, weaponUse, data, speaker, messageMode, flavor, critical, fumble, targetValue, actor, isAttackRoll, options, userStatus, targDataArray, fastForward }) {
 	/*
 	 coming in the parts[] is in one of the following states:
 	 - Empty
@@ -208,10 +241,6 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 	let targetDefArray = [], targetAtkModArray = [];
 	
 	if (isAttackRoll && (form !== null)) {
-		// populate the common attack bonuses into data
-		Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
-			data[key] = data.commonAttackBonuses[key].value;
-		});
 		const individualAttack = (form.querySelector("#multibonus-toggle")?.value === "true");
 		for (let targetIndex = 0; targetIndex < numberOfTargets; targetIndex++) {
 			const targetBonuses = [];
@@ -230,7 +259,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			}
 			if (game.settings.get("dnd4e", "collapseSituationalBonus")) {
 				let total = 0;
-				targetBonuses.forEach(bonus => total += data.commonAttackBonuses[bonus.substring(1)].value);
+				targetBonuses.forEach(bonus => total += targDataArray.targets[targetIndex].targetBonuses[bonus.substring(1)].bonus);
 				const partsToPush = total ? parts.concat([total]) : parts;
 				allRollsParts.push(partsToPush);
 			}
@@ -259,31 +288,33 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 	else if (isAttackRoll && fastForward) {
 		// Logic to infer common bonuses based on user and target status under fast-forward conditions
 		const theTargets = Array.from(game.user.targets);
-		
-		// populate the common attack bonuses into data
-		Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
-			data[key] = data.commonAttackBonuses[key].value;
-		});
 				
 		let hasComAdv = false;
-		const userStatBonuses = [];
+		const userStatBonuses = Object.keys(CONFIG.DND4E.commonAttackBonuses).reduce((bonuses, bonus) => {
+			bonuses[bonus] = {
+				value: false,
+				bonus: data.commonAttackBonuses[bonus].value,
+			};
+			return bonuses;
+		}, {});
+
 		// User conditions
-		if (userStatus.has("prone")) userStatBonuses.push("@prone");
-		if (userStatus.has("restrained")) userStatBonuses.push("@restrained");
-		if (userStatus.has("running")) userStatBonuses.push("@running");
-		if (userStatus.has("squeezing")) userStatBonuses.push("@squeez");
+		if (userStatus.has("prone")) userStatBonuses.prone.value = true;
+		if (userStatus.has("restrained")) userStatBonuses.restrained.value = true;
+		if (userStatus.has("running")) userStatBonuses.running.value = true;
+		if (userStatus.has("squeezing")) userStatBonuses.squeez.value = true;
 		if (userStatus.has("comAdv")) hasComAdv = true;
-		if (options?.variance?.isCharge) userStatBonuses.push("@charge");
+		if (options?.variance?.isCharge) userStatBonuses.charge.value = true;
 		
 		if (game.settings.get("dnd4e", "markAutomation") && data?.marker) {
-			if (!theTargets.some(t => (t.actor.uuid === data.marker))) userStatBonuses.push("@marked");
+			if (!theTargets.some(t => (t.actor.uuid === data.marker))) userStatBonuses.marked.value = true;
 		}
 				
 		for (let targetIndex = 0; targetIndex < numberOfTargets; targetIndex++) {
 
 			targetDefArray.push(data.item.attack.def); targetAtkModArray.push(data.item.attack.ability);
 			
-			const targetBonuses = userStatBonuses;
+			const targetBonuses = foundry.utils.deepClone(userStatBonuses);
 			if (theTargets.length > 0) {
 				const targetStatus = Array.from(theTargets[targetIndex].actor.statuses);
 				
@@ -312,28 +343,35 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 				}
 
 				if (((item?.system.rangeType === "range") && item?.system.range.long && (targetDist > item?.system.rangePower)) || ((item?.system.rangeType === "weapon") && weaponUse?.system.range.long && (targetDist > weaponUse?.system.range.value))) {
-					targetBonuses.push("@longRange");
+					targetBonuses.longRange.value = true;
 				}
 
-				if (targetStatus.includes("bloodied")) targetBonuses.push("@bloodied");
-
-				if (targetStatus.includes("concealed")) targetBonuses.push("@conceal");		
-				
-				if (targetStatus.includes("concealedTotal")) targetBonuses.push("@concealTotal");
-				
-				if (targetStatus.includes("cover")) targetBonuses.push("@cover");		
-				
-				if (targetStatus.includes("coverSup")) targetBonuses.push("@coverSup");
-					
+				if (targetStatus.includes("bloodied")) targetBonuses.bloodied.value = true;
+				if (targetStatus.includes("concealed")) targetBonuses.conceal.value = true;	
+				if (targetStatus.includes("concealedTotal")) targetBonuses.concealTotal.value = true;
+				if (targetStatus.includes("cover")) targetBonuses.cover.value = true;		
+				if (targetStatus.includes("coverSup")) targetBonuses.coverSup.value = true;
 			}
-			if (hasComAdv) targetBonuses.push("@comAdv");
+			if (hasComAdv) targetBonuses.comAdv.value = true;
+			const attacker = utils.tokenForActor(actor);
+			const target = theTargets[targetIndex];
+			for (const actorItem of [...actor.items]) {
+				if (actorItem.system.macro.launchOrder === "comBon") {
+					const func = new Function("item", "attacker", "target", "bonuses", actorItem.system.macro.command);
+					func(item, attacker, target, targetBonuses);
+				}
+			}
+			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, targetBonuses);
 			if (game.settings.get("dnd4e", "collapseSituationalBonus")) {
-				let total = 0;
-				targetBonuses.forEach(bonus => total += data.commonAttackBonuses[bonus.substring(1)].value);
+				const total = Object.values(targetBonuses).filter((bon) => bon.value).map((bon) => bon.bonus).reduce((acc, curr) => acc + curr);
 				allRollsParts.push(parts.concat([total]));
 			}
 			else {
-				allRollsParts.push(parts.concat(targetBonuses));
+				allRollsParts.push(parts.concat(Object.entries(targetBonuses).filter((bon) => bon[1].value).map((bon) => `@${bon[0]}`)));
+				// populate the common attack bonuses into data
+				Object.keys(targetBonuses).forEach(function(key, index) {
+					data[key] = targetBonuses[key].bonus;
+				});
 			}
 		}
 		
@@ -386,6 +424,10 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const targetActor = targets[rollExpressionIdx]?.document.actor;
 			const IS_TARGET = true;
 			if (targetActor) await utils.applyEffects({ ...data, ...options.variance }, targetActor, itemData, weaponData, "attack", null, IS_TARGET, targetOptions);
+			// populate the common attack bonuses into data
+			Object.keys(data.commonAttackBonuses).forEach(function(key, index) {
+				data[key] = targDataArray.targets[rollExpressionIdx].targetBonuses[key].bonus;
+			});
 			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}
 		catch(err) {

--- a/module/helpers/macros.mjs
+++ b/module/helpers/macros.mjs
@@ -116,7 +116,7 @@ export function toggleEffect(effectName, type = "DOCUMENT.ActiveEffect") {
  * @returns {Promise}
  */
 export async function executeMacro(item) {
-	const macro = new Macro ({
+	const macro = new Macro({
 		name: item.name,
 		type: item.system.macro.type,
 		scope: item.system.macro.scope,

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -73,55 +73,44 @@
 						
               {{!-- Try to infer already active bonuses --}}
 					
-              {{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if ../../isCharge}}checked="true" disabled{{/if}}{{/if}}
+              {{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.value}}checked="true" disabled{{/if}}{{/if}}
 					
-						{{#if (eq b 'marked')}}{{#if ../../targetData.ignoringMark}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'marked')}}{{#if t.targetBonuses.ignoringMark.value}}checked="true"{{/if}}{{/if}}
 					 
-						{{#if (eq b 'prone')}}{{#if (contains 'prone'../../userStatus)}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'restrained')}}{{#if (contains 'restrained'../../userStatus)}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'squeez')}}{{#if (contains 'squeezing'../../userStatus)}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'running')}}{{#if (contains 'running'../../userStatus)}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'prone')}}{{#if t.targetBonuses.prone.value}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'restrained')}}{{#if t.targetBonuses.restrained.value}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'squeez')}}{{#if t.targetBonuses.squeez.value}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'running')}}{{#if t.targetBonuses.running.value}}checked="true"{{/if}}{{/if}}
 						
 						{{!-- Only if targets are provided --}}
 							{{#if ../../targetData.hasTarget}}
 								
 								{{#if (eq b 'bloodied')}}
-									{{#if (contains 'bloodied' t.status)}}checked="true"{{/if}}
+									{{#if t.targetBonuses.bloodied.value}}checked="true"{{/if}}
 								{{/if}}
 
 								{{#if (eq b 'comAdv')}}
-									{{#if (contains 'dazed' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'blinded' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'dominated' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'helpless' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'restrained' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'stunned' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'surprised' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'squeezing' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'running' t.status)}}checked="true"{{/if}}
-									{{#if (contains 'grantingCA' t.status)}}checked="true"{{/if}}
-									{{#if t.meleeVsProne}}checked="true"{{/if}}
-									{{#if t.isFlanking}}checked="true"{{/if}}
+									{{#if t.targetBonuses.comAdv.value}}checked="true"{{/if}}
 								{{/if}}
 								
 								{{#if (eq b 'conceal')}}
-									{{#if (contains 'conceal' t.status)}}checked="true"{{/if}}
+									{{#if t.targetBonuses.conceal.value}}checked="true"{{/if}}
 								{{/if}}
 								
 								{{#if (eq b 'concealTotal')}}
-									{{#if (contains 'concealTotal' t.status)}}checked="true"{{/if}}
+									{{#if t.targetBonuses.concealTotal.value}}checked="true"{{/if}}
 								{{/if}}
 								
 								{{#if (eq b 'cover')}}
-									{{#if (contains 'cover' t.status)}}checked="true"{{/if}}
+									{{#if t.targetBonuses.cover.value}}checked="true"{{/if}}
 								{{/if}}
 								
 								{{#if (eq b 'coverSup')}}
-									{{#if (contains 'coverSup' t.status)}}checked="true"{{/if}}
+									{{#if t.targetBonuses.coverSup.value}}checked="true"{{/if}}
 								{{/if}}
 
 								{{#if (eq b 'longRange')}}
-									{{#if t.longRange}}checked="true"{{/if}}
+									{{#if t.targetBonuses.longRange.value}}checked="true"{{/if}}
 								{{/if}}
 									
 							{{/if}}
@@ -130,7 +119,7 @@
 					{{!-- End already active --}}
 					
 						value="{{../checked}}"/> 
-            <span class="label">{{ localize a.label}} ({{a.value}})</span>
+            <span class="label">{{ localize a.label}} ({{ lookup (lookup t.targetBonuses b) "bonus"}})</span>
           </label>
         </div>
         {{/each}}

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -73,44 +73,44 @@
 						
               {{!-- Try to infer already active bonuses --}}
 					
-              {{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.value}}checked="true" disabled{{/if}}{{/if}}
+              {{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.shouldApply}}checked="true" disabled{{/if}}{{/if}}
 					
-						{{#if (eq b 'marked')}}{{#if t.targetBonuses.ignoringMark.value}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'marked')}}{{#if t.targetBonuses.ignoringMark.shouldApply}}checked="true"{{/if}}{{/if}}
 					 
-						{{#if (eq b 'prone')}}{{#if t.targetBonuses.prone.value}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'restrained')}}{{#if t.targetBonuses.restrained.value}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'squeez')}}{{#if t.targetBonuses.squeez.value}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'running')}}{{#if t.targetBonuses.running.value}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'prone')}}{{#if t.targetBonuses.prone.shouldApply}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'restrained')}}{{#if t.targetBonuses.restrained.shouldApply}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'squeez')}}{{#if t.targetBonuses.squeez.shouldApply}}checked="true"{{/if}}{{/if}}
+						{{#if (eq b 'running')}}{{#if t.targetBonuses.running.shouldApply}}checked="true"{{/if}}{{/if}}
 						
 						{{!-- Only if targets are provided --}}
 							{{#if ../../targetData.hasTarget}}
 								
 								{{#if (eq b 'bloodied')}}
-									{{#if t.targetBonuses.bloodied.value}}checked="true"{{/if}}
+									{{#if t.targetBonuses.bloodied.shouldApply}}checked="true"{{/if}}
 								{{/if}}
 
 								{{#if (eq b 'comAdv')}}
-									{{#if t.targetBonuses.comAdv.value}}checked="true"{{/if}}
+									{{#if t.targetBonuses.comAdv.shouldApply}}checked="true"{{/if}}
 								{{/if}}
 								
 								{{#if (eq b 'conceal')}}
-									{{#if t.targetBonuses.conceal.value}}checked="true"{{/if}}
+									{{#if t.targetBonuses.conceal.shouldApply}}checked="true"{{/if}}
 								{{/if}}
 								
 								{{#if (eq b 'concealTotal')}}
-									{{#if t.targetBonuses.concealTotal.value}}checked="true"{{/if}}
+									{{#if t.targetBonuses.concealTotal.shouldApply}}checked="true"{{/if}}
 								{{/if}}
 								
 								{{#if (eq b 'cover')}}
-									{{#if t.targetBonuses.cover.value}}checked="true"{{/if}}
+									{{#if t.targetBonuses.cover.shouldApply}}checked="true"{{/if}}
 								{{/if}}
 								
 								{{#if (eq b 'coverSup')}}
-									{{#if t.targetBonuses.coverSup.value}}checked="true"{{/if}}
+									{{#if t.targetBonuses.coverSup.shouldApply}}checked="true"{{/if}}
 								{{/if}}
 
 								{{#if (eq b 'longRange')}}
-									{{#if t.targetBonuses.longRange.value}}checked="true"{{/if}}
+									{{#if t.targetBonuses.longRange.shouldApply}}checked="true"{{/if}}
 								{{/if}}
 									
 							{{/if}}
@@ -119,7 +119,7 @@
 					{{!-- End already active --}}
 					
 						value="{{../checked}}"/> 
-            <span class="label">{{ localize a.label}} ({{ lookup (lookup t.targetBonuses b) "bonus"}})</span>
+            <span class="label">{{ localize a.label}} ({{ lookup (lookup t.targetBonuses b) "value"}})</span>
           </label>
         </div>
         {{/each}}


### PR DESCRIPTION
The new hook is `"dnd4e.evaluateCommonAttackBonuses"`.
Also add this hook to item macro passes so scripts to be run on this hook can be added directly to items

Scripts in this pass receive the following arguments:
`source`: the item the script is stored on
`item`: the power being used to make the attack
`attacker`: the attacking token
`target`: the target token
`bonuses`: an object holding the common attack bonuses:
    `bonuses.[bonus].shouldApply`: bool, whether or not the bonus should apply
    `bonuses.[bonus].value`: number, the actual bonus (or penalty) applying to the roll

Some work to do on naming/presentation, this is a first draft in that regard, but the behavior should be solid. I went ahead and opened the PR 'cause I think it's worth messing around with for us developers, it's a lot of fun.

You can also add arbitrary bonuses to the bonuses object, e.g.:
`bonuses.myCoolBonus = { shouldApply: true, value: 420 }`
All of these bonuses are inherently untyped.

Also added `dnd4e.preAttackRoll`. This hooks receives the same arguments as `evaluateCommonAttackBonuses`, with the exception that, instead of `bonuses`, it receives a `rollConfig` object with the following properties:
`rollConfig.rollExpression`: an array of roll parts
`rollConfig.partsExpressionReplacements`: replacement data for the roll parts (see helpers\dice.mjs for details)
`rollConfig.commonAttackBonuses`: the commonAttackBonuses object for the roll, discussed above, allowing code run at this point to know which of these bonuses applies to the roll
`rollConfig.targetOptions`: a more or less unbounded object of options that will be sent to the roll, most notably the `bonuses` object that holds the array of typed bonuses (as well as the untyped bonus array)

For both hooks, `source` only exists when the script is called from an item's item macro. Code run via hooks in worldscripts and the like have no concept of a source item.