### PR TITLE
Hide hit/miss text if power doesn't have an attack

### DIFF
--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -800,14 +800,14 @@ export function preparePowerCardData(chatData, actorData = null, attackTotal = n
 			}
 			powerDetail += ` ${_loc("DND4E.VS")} ${CONFIG.DND4E.defensives[chatData.attack.def].labelShort}</p>`;
 		}
-	}
 
-	if (chatData.hit.detail) {
-		powerDetail += `<p class="hit alt-highlight"><strong>${_loc("DND4E.Hit")}:</strong> ${chatData.hit.detail}</p>`;
-	}
+		if (chatData.hit.detail) {
+			powerDetail += `<p class="hit alt-highlight"><strong>${_loc("DND4E.Hit")}:</strong> ${chatData.hit.detail}</p>`;
+		}
 
-	if (chatData.miss.detail) {
-		powerDetail += `<p class="miss alt-highlight"><strong>${_loc("DND4E.Miss")}:</strong> ${chatData.miss.detail}</p>`;
+		if (chatData.miss.detail) {
+			powerDetail += `<p class="miss alt-highlight"><strong>${_loc("DND4E.Miss")}:</strong> ${chatData.miss.detail}</p>`;
+		}
 	}
 
 	if (chatData.postEffect && chatData.effect.detail) {


### PR DESCRIPTION
I remember this was mentioned on Discord ages ago (why would anyone on Discord ever open a GitHub ticket), but if there's no attack then hit and miss have no meaning. We should just hide them rather than forcing the user to manually enable attack and delete the default hit string and then disable attack again.