### PR TITLE
Convert item macro to an array of macros

### DIFF
--- a/module/data/item/backpack.mjs
+++ b/module/data/item/backpack.mjs
@@ -33,6 +33,7 @@ export default class BackpackData extends foundry.abstract.TypeDataModel {
 	/** @inheritdoc */
 	static migrateData(source) {
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -81,6 +81,7 @@ export default class ConsumableData extends foundry.abstract.TypeDataModel {
 			}
 		}
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -64,6 +64,7 @@ export default class EquipmentData extends foundry.abstract.TypeDataModel {
 		}
 		if (source.armour?.subtype === "cloth") source.armour.subtype = "light";
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -38,6 +38,7 @@ export default class FeatureData extends foundry.abstract.TypeDataModel {
 	/** @inheritdoc */
 	static migrateData(source) {
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -25,6 +25,7 @@ export default class LootData extends foundry.abstract.TypeDataModel {
 	/** @inheritdoc */
 	static migrateData(source) {
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/power.mjs
+++ b/module/data/item/power.mjs
@@ -90,6 +90,7 @@ export default class PowerData extends foundry.abstract.TypeDataModel {
 			}
 		}
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/ritual.mjs
+++ b/module/data/item/ritual.mjs
@@ -34,6 +34,7 @@ export default class RitualData extends foundry.abstract.TypeDataModel {
 	/** @inheritdoc */
 	static migrateData(source) {
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/templates/item-macro.mjs
+++ b/module/data/item/templates/item-macro.mjs
@@ -1,17 +1,33 @@
-const { SchemaField, StringField } = foundry.data.fields;
+const { ArrayField, BooleanField, SchemaField, StringField } = foundry.data.fields;
 
 export default class ItemMacroTemplate extends foundry.abstract.DataModel {
 	/** @inheritDoc */
 	static defineSchema() {
 		return {
-			macro: new SchemaField({
+			macros: new ArrayField(new SchemaField({
 				type: new StringField({ initial: "script" }),
 				scope: new StringField({ initial: "global" }),
 				launchOrder: new StringField({ initial: "off" }),
 				command: new StringField({ initial: "" }),
 				author: new StringField({ initial: "" }),
 				autoanimationHook: new StringField({ initial: "" }),
-			}),
+				enabled: new BooleanField({ initial: true }),
+			}), { initial: [] }),
 		};
+	}
+
+	/* -------------------------------------------- */
+	/*  Data Migration                              */
+	/* -------------------------------------------- */
+    
+	/**
+     * Convert single macro into macro array.
+     * @param {Object} source  The candidate source data from which the model will be constructed.
+     */
+	static migrateMacro(source) {
+		if ("macro" in source) {
+			source.macros = [];
+			source.macros.push(source.macro);
+		}
 	}
 }

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -29,6 +29,7 @@ export default class ToolData extends foundry.abstract.TypeDataModel {
 	/** @inheritdoc */
 	static migrateData(source) {
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -133,6 +133,7 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
 			}
 		}
 		ItemDescriptionTemplate.migrateSource(source);
+		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);
 	}
 }

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1055,9 +1055,13 @@ export default class Item4e extends Item {
 		//console.debug(variance);
 		const rollData = this.getRollData({ variance });
 
-		if (["both", "pre", "sub"].includes(this.system.macro?.launchOrder)) {
-			await macros.executeMacro(this);
-			if (this.system.macro.launchOrder === "sub") return;
+		const subMacro = this.system.macros.find((m) => m.enabled && (m.launchOrder === "sub"));
+		if (subMacro) {
+			await macros.executeMacro(this, subMacro);
+			return;
+		}
+		for (const macro of this.system.macros.filter((m) => m.enabled && ["both", "pre"].includes(m.launchOrder))) {
+			await macros.executeMacro(this, macro);
 		}
 		const cardData = await (async () => {
 			if (((this.type === "power") || (this.type === "consumable")) && this.system.autoGenChatPowerCard) {
@@ -1186,8 +1190,8 @@ export default class Item4e extends Item {
 
 			ChatMessage.create(chatData);
 
-			if (["both", "post"].includes(this.system.macro?.launchOrder)) {
-				await macros.executeMacro(this);
+			for (const macro of this.system.macros.filter((m) => m.enabled && ["both", "post"].includes(m.launchOrder))) {
+				await macros.executeMacro(this, macro);
 			}
 		}
 		else return chatData;

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -114,8 +114,8 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 			const attacker = utils.tokenForActor(actor);
 			const target = targetArr[targ];
 			for (const actorItem of [...actor.items]) {
-				if (actorItem.system.macro.launchOrder === "comBon") {
-					const func = new Function("source", "item", "attacker", "target", "bonuses", actorItem.system.macro.command);
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBon"))) {
+					const func = new Function("source", "item", "attacker", "target", "bonuses", macro.command);
 					func(actorItem, item, attacker, target, targetBonuses);
 				}
 			}
@@ -356,8 +356,8 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const attacker = utils.tokenForActor(actor);
 			const target = theTargets[targetIndex];
 			for (const actorItem of [...actor.items]) {
-				if (actorItem.system.macro.launchOrder === "comBon") {
-					const func = new Function("source", "item", "attacker", "target", "bonuses", actorItem.system.macro.command);
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBon"))) {
+					const func = new Function("source", "item", "attacker", "target", "bonuses", macro.command);
 					func(actorItem, item, attacker, target, targetBonuses);
 				}
 			}
@@ -431,8 +431,8 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const attacker = utils.tokenForActor(actor);
 			const target = targets[rollExpressionIdx];
 			for (const actorItem of [...actor.items]) {
-				if (actorItem.system.macro.launchOrder === "preAttack") {
-					const func = new Function("source", "item", "attacker", "target", "rollConfig", actorItem.system.macro.command);
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "preAttack"))) {
+					const func = new Function("source", "item", "attacker", "target", "rollConfig", macro.command);
 					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
 				}
 			}

--- a/module/helpers/macros.mjs
+++ b/module/helpers/macros.mjs
@@ -113,6 +113,7 @@ export function toggleEffect(effectName, type = "DOCUMENT.ActiveEffect") {
 /**
  * Execute a macro with item variables
  * @param {Item4e} item
+ * @param {Object} macroData
  * @returns {Promise}
  */
 export async function executeMacro(item, macroData) {

--- a/module/helpers/macros.mjs
+++ b/module/helpers/macros.mjs
@@ -115,16 +115,16 @@ export function toggleEffect(effectName, type = "DOCUMENT.ActiveEffect") {
  * @param {Item4e} item
  * @returns {Promise}
  */
-export async function executeMacro(item) {
+export async function executeMacro(item, macroData) {
 	const macro = new Macro({
 		name: item.name,
-		type: item.system.macro.type,
-		scope: item.system.macro.scope,
-		command: item.system.macro.command, //cmd,
+		type: macroData.type,
+		scope: macroData.scope,
+		command: macroData.command, //cmd,
 		author: game.user.id,
 	});
 	macro.item = item;
 	macro.actor = item.actor;
-	macro.launch = item.system.macro.launchOrder;
+	macro.launch = macroData.launchOrder;
 	return macro.execute();
 }

--- a/module/helpers/macros.mjs
+++ b/module/helpers/macros.mjs
@@ -116,6 +116,9 @@ export function toggleEffect(effectName, type = "DOCUMENT.ActiveEffect") {
  * @returns {Promise}
  */
 export async function executeMacro(item, macroData) {
+	// The system shouldn't be calling this function on disabled macros, but just in case.
+	if (!macroData.enabled) return;
+
 	const macro = new Macro({
 		name: item.name,
 		type: macroData.type,


### PR DESCRIPTION
This still requires an update to the item sheet's macro tab (so consider my ability to test limited for the moment!), but this allows items to store and run multiple macros.

UI IMPLEMENTATION NOTES:
* I've added a bool to the macro data for whether or not it's enabled; this allows users to turn individual macros on/off without deleting the entire thing and losing the code.
* The new hook passes I've added don't run their macros in quite the same way as the passes we already had. `type`, `scope`, and `autoanimationhook` are meaningless for these new passes and should likely be hidden if such a pass is selected?

USAGE NOTE:
* If items can store multiple macros, that invites an obvious question of what happens if one stores multiple substitute item use macros. While this isn't invalid, data-wise, the simple answer is that we're only going to run the first one we find, and any additional ones just won't matter.