### PR TITLE
Ensure user changes to common attack bonus states are persisted

### DIFF
--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -252,9 +252,9 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 						let bonusName = v.name.split(".")[1];
 						if (v.checked) {
 							targetBonuses.push(`@${bonusName}`);
-							targDataArray.targets[targetIndex].targetBonuses[bonusName].shouldApply = true;
 						}
-                        targDataArray.targets[targetIndex].targetBonuses[bonusName].shouldApply = v.checked;
+						targDataArray.targets[targetIndex].targetBonuses[bonusName].shouldApply = v.checked;
+					}
 				}
 				if (!individualAttack && (k > 21)) {
 					break;

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -245,13 +245,16 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 		for (let targetIndex = 0; targetIndex < numberOfTargets; targetIndex++) {
 			const targetBonuses = [];
 			for (let [k, v] of Object.entries(form)) {
-				if (v.checked) {
+				if (v.checked !== undefined) {
 					let tabIndex = v.name.split(".")[0];
 					if ((individualAttack && (parseInt(tabIndex) === targetIndex)) // check if Individual Attack Bonuses
 					|| !individualAttack) { //otherwise just use Unified Attack Bonuses
 						let bonusName = v.name.split(".")[1];
-						targetBonuses.push(`@${bonusName}`);
-					}
+						if (v.checked) {
+							targetBonuses.push(`@${bonusName}`);
+							targDataArray.targets[targetIndex].targetBonuses[bonusName].shouldApply = true;
+						}
+                        targDataArray.targets[targetIndex].targetBonuses[bonusName].shouldApply = v.checked;
 				}
 				if (!individualAttack && (k > 21)) {
 					break;


### PR DESCRIPTION
I realized that if the user manually checks or unchecks common attack bonuses, those changes aren't stored for use in the later preAttackRoll hook. This change makes sure they are so that that hook sees data that reflects those user changes.