### PR TITLE
Update Macro UI

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -671,13 +671,6 @@
 "DND4E.Ki": "Ki",
 "DND4E.LackRequiredWeapon": "You may not use this power as you do not have the proper weapon equipped.",
 "DND4E.Languages": "Languages",
-"DND4E.LaunchOrderBoth": "Both Pre & Post Item",
-"DND4E.LaunchOrderOff": "macro Off",
-"DND4E.LaunchOrderPre": "Pre-Item-Use",
-"DND4E.LaunchOrderPost": "Post-Item-Use",
-"DND4E.LaunchOrderSub": "Substitute-Item-Use",
-"DND4E.LaunchOrderHookComBon": "Hook: Evaluate Common Attack Bonuses",
-"DND4E.LaunchOrderHookPreAttack": "Hook: Pre Attack Roll",
 "DND4E.Level": "Level",
 "DND4E.LevelScaling": "Level Scaling",
 "DND4E.LimitedUses": "Limited Uses",
@@ -1397,6 +1390,19 @@
 	"Detection": "Detection",
 	"Counter": "Countermeasures",
 	"DefenceNullTip": "Click to toggle immunity to attacks vs. {def}"
+},
+
+"DND4E.MACROS": {
+  "ACTIVATION": {
+    "Label": "Activation",
+    "Both": "Before AND After Item Use",
+    "Manual": "Manual",
+    "Pre": "Before Item Use",
+    "Post": "After Item Use",
+    "Sub": "Replace Item Use",
+    "HookComBon": "Hook: Evaluate Common Attack Bonuses",
+    "HookPreAttack": "Hook: Pre Attack Roll"
+  }
 },
 
 "DND4E.Movement":{

--- a/lang/en.json
+++ b/lang/en.json
@@ -671,13 +671,6 @@
 "DND4E.Ki": "Ki",
 "DND4E.LackRequiredWeapon": "You may not use this power as you do not have the proper weapon equipped.",
 "DND4E.Languages": "Languages",
-"DND4E.LaunchOrderBoth": "Both Pre & Post Item",
-"DND4E.LaunchOrderOff": "macro Off",
-"DND4E.LaunchOrderPre": "Pre-Item-Use",
-"DND4E.LaunchOrderPost": "Post-Item-Use",
-"DND4E.LaunchOrderSub": "Substitute-Item-Use",
-"DND4E.LaunchOrderHookComBon": "Hook: Evaluate Common Attack Bonuses",
-"DND4E.LaunchOrderHookPreAttack": "Hook: Pre Attack Roll",
 "DND4E.Level": "Level",
 "DND4E.LevelScaling": "Level Scaling",
 "DND4E.LimitedUses": "Limited Uses",
@@ -1397,6 +1390,19 @@
 	"Detection": "Detection",
 	"Counter": "Countermeasures",
 	"DefenceNullTip": "Click to toggle immunity to attacks vs. {def}"
+},
+
+"DND4E.MACROS": {
+  "ACTIVATION": {
+    "Label": "Activation",
+    "Both": "Before AND After Item Use",
+    "Manual": "Manual",
+    "Pre": "Before Item Use",
+    "Post": "After Item Use",
+    "Sub": "Replace Item Use",
+    "HookComBon": "Hook: Evaluate Common Attack Bonuses",
+    "HookPreAttack": "Hook: Pre Attack Roll"
+  }
 },
 
 "DND4E.Movement":{

--- a/module/applications/sheets/item-sheet.mjs
+++ b/module/applications/sheets/item-sheet.mjs
@@ -62,6 +62,8 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			editPowerEffect: ItemSheet4e.#onPowerEffectControl,
 			deletePowerEffect: ItemSheet4e.#onPowerEffectControl,
 			manageActiveEffect: ItemSheet4e.#onManageActiveEffect,
+			addMacro: ItemSheet4e.#onMacroControl,
+			deleteMacro: ItemSheet4e.#onMacroControl,
 			// Container actions
 			itemRoll: ItemSheet4e.#onItemRoll,
 			editItem: ItemSheet4e.#onItemControl,
@@ -490,7 +492,7 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			if (tab?.condition && !tab.condition(this.document)) delete context.tabs[key];
 		}
 
-		context.editorLang = this.document.system.macro.type === "script" ? "javascript" : "";
+		context.editorLang = this.document.system.macro?.type === "script" ? "javascript" : "";
 		
 		return context;
 	}
@@ -649,6 +651,8 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 	static #onConfigureSource(event, target) {
 		return this._renderChild(new SourceConfig({ document: this.item, keyPath: "system.source" }));
 	}
+  
+
 
 	async shareItem() {
 		let changeBack = false;
@@ -1160,9 +1164,10 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 
 	/* -------------------------------------------- */
 
-	static async #onExecuteMacro() {
+	static async #onExecuteMacro(event, target){
 		await this.submit({ preventClose: true });
-		return macros.executeMacro(this.document);
+    const macroIndex = event.target.getAttribute("data-macro-index");
+		return macros.executeMacro(this.document,this.document.system.macros[macroIndex]);
 	}
 	
 	/* -------------------------------------------- */
@@ -1530,4 +1535,42 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 
 	/* -------------------------------------------- */
 
+	/**
+	 * Add or remove a macro
+	 * @param {Event} event     		The original click event
+	 * @param {HTMLElement} target	The target of the event
+	 * @returns {Promise}
+	 * @this {ItemSheet4e}
+	 */
+	static async #onMacroControl(event, target) {
+		const action = target.dataset.action;
+		// Add new damage component
+		if (action === "addMacro") {
+			await this.submit(event); // Submit any unsaved changes
+			const macros = this.item.system.macros;
+			return this.item.update({ "system.macros": macros.concat([{
+        "type": "script",
+        "scope": "global",
+        "launchOrder": "off",
+        "command": "",
+        "author": "",
+        "autoanimationHook": "",
+        "enabled": true
+      }])});
+		}
+
+		// Remove a damage component
+		if (action === "deleteMacro") {
+			await this.submit(event); // Submit any unsaved changes
+			const macro = target.closest(".macro");
+      const index = macro.getAttribute("data-macro-number");
+      const macros = foundry.utils.duplicate(this.item.system.macros);
+			macros.splice(macro.getAttribute("data-macro-number"), 1);
+			return this.item.update({ "system.macros": macros });
+		}
+	
+	}
+
+	/* -------------------------------------------- */
+  
 }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -80,13 +80,13 @@ DND4E.macroType = {
 preLocalize("macroType", { keys: ["label"] });
 
 DND4E.macroLaunchOrder = {
-	off: { label: "DND4E.LaunchOrderOff" },
-	both: { label: "DND4E.LaunchOrderBoth" },
-	pre: { label: "DND4E.LaunchOrderPre" },
-	post: { label: "DND4E.LaunchOrderPost" },
-	sub: { label: "DND4E.LaunchOrderSub" },
-	comBon: { label: "DND4E.LaunchOrderHookComBon" },
-	preAttack: { label: "DND4E.LaunchOrderHookPreAttack" },
+	off: { label: "DND4E.MACROS.ACTIVATION.Manual" },
+	pre: { label: "DND4E.MACROS.ACTIVATION.Pre" },
+	post: { label: "DND4E.MACROS.ACTIVATION.Post" },
+	both: { label: "DND4E.MACROS.ACTIVATION.Both" },
+	sub: { label: "DND4E.MACROS.ACTIVATION.Sub" },
+	comBon: { label: "DND4E.MACROS.ACTIVATION.HookComBon" },
+	preAttack: { label: "DND4E.MACROS.ACTIVATION.HookPreAttack" },
 };
 preLocalize("macroLaunchOrder", { keys: ["label"] });
 

--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -175,6 +175,11 @@
 		padding:0.5em;
 		gap:0;
 	}
+	.sheet-footer{
+		bottom:0px;
+    margin-top:auto;
+		position:sticky;
+	}
 }
 .themed.theme-dark,
 .themed.theme-dark :is(.application,.app).dnd4e:is(.default,.standard-form):not(.themed),
@@ -943,6 +948,10 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 	}
 	.right{
 		margin-left:auto;
+    text-align:right;
+    flex-basis:fit-content;
+    width:fit-content;
+    flex-grow:0;
 	}
 	table{
 		margin:0;
@@ -2858,12 +2867,6 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 		text-align:right;
 		opacity:0.75;
 	}
-	.macro-text{
-		height:calc(100% - 132px);
-	}
-	.macro-text textarea{
-		height:100%;
-	}
 	.item-damage .dmg-base-qty{
 		flex: 0.5 0 0;
 	}
@@ -2874,6 +2877,9 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 		max-height:76px;
 		line-height:22px;
 	}
+  .macro-type{
+    min-width:6em;
+  }
 }
 .sheet.default .item-consumable .form-group :is(.display-effect,.effect-html){
 	text-align:right;
@@ -2990,10 +2996,6 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 			position:relative;
 			/*grid-template-columns: 12fr 7fr 7fr 4fr 1rem;*/
 		}
-	}
-	.sheet-footer{
-		bottom:0px;
-		position:sticky;
 	}
 }
 
@@ -3314,7 +3316,7 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 	min-height:10em;
 	resize:vertical;
 }
-.bonus-add:before{
+:is(.bonus-add,.macro-add):before{
 	content:'+';
 	display:inline-block;
 	font-weight:bold;
@@ -3829,6 +3831,11 @@ input[type="text"].dice-count{
 		.hidden-dc { display: none; }
 		.visible-dc { display: contents; }
 	}
+}
+
+/* FOUNDRY WHY YOU KILL CODEMIRROR CARET?! */
+.ͼ4 .cm-line{
+    caret-color:var(--color-text-emphatic) !important;
 }
 
 @media (prefers-reduced-transparency){

--- a/templates/items/tabs/macros.hbs
+++ b/templates/items/tabs/macros.hbs
@@ -1,52 +1,79 @@
 <section class="tab scrollable {{tab.id}}{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
 
-  <div class="form-group">
-    <label>{{ localize "Scope" }}</label>
-    <select name="system.macro.scope" disabled>
-      {{selectOptions config.macroScope selected=system.macro.scope labelAttr="label"}}
-    </select>
+	{{log system.macros}}
+	{{#each system.macros as |macro i|}}
+	{{log macro}}{{log i}}
+    <fieldset class="macro form-group vertical" data-macro-number="{{@index}}">
+      <legend>{{localize 'Macro'}} {{@index}} ({{#with (lookup ../config.macroLaunchOrder macro.launchOrder)}}{{label}}{{/with}})</legend>
+      
+      <div class="form-group loose">
+      
+        <div class="form-group loose">
+          <label>{{localize "DND4E.MACROS.ACTIVATION.Label"}}</label>
+          <select name="system.macros.{{@index}}.launchOrder">
+            {{selectOptions ../config.macroLaunchOrder selected=macro.launchOrder labelAttr="label"}}
+          </select>
+        </div>
+
+        {{#unless (eq macro.launchOrder "comBon")}}
+        {{#unless (eq macro.launchOrder "preAttack")}}
+        <div class="form-group loose">
+          <label>{{ localize "Type" }}</label>
+          <select name="system.macros.{{@index}}.type" class="macro-type">
+            {{selectOptions ../config.macroType selected=macro.type labelAttr="label"}}
+          </select>
+        </div>
+        {{/unless}}
+        {{/unless}}
+
+        <label class="checkbox right">
+          <input class="checkbox" type="checkbox" name="system.macros.{{@index}}.enabled" data-dtype="Boolean" {{checked macro.enabled}}> 
+          <span class="label">{{localize "DND4E.Active"}}</span>
+        </label>
+        <a class="macro-control macro-delete right" data-action="deleteMacro" data-tooltip="{{localize 'DND4EUI.Delete'}}"><i class="fas fa-trash"></i></a>
+        
+      </div>
+      
+      <div class="form-group loose">
+      
+        {{!--<div class="form-group loose">
+          <label>{{ localize "Scope" }}</label>
+          <select name="system.macros.{{@index}}.scope" disabled>
+            {{selectOptions ../config.macroScope selected=macro.scope labelAttr="label"}}
+          </select>
+        </div>--}}
+        
+        {{#if autoanimationsActive}}
+        {{#unless (eq macro.launchOrder "comBon")}}
+        {{#unless (eq macro.launchOrder "preAttack")}}
+        <div class="form-group loose">
+          <label>Autoanimation Hook</label>
+          <select name="system.macros.{{@index}}.autoanimationHook">
+            <option value=""{{#if (eq macro.autoanimationHook "")}}selected{{/if}}>Automatic</option>
+            {{selectOptions ../config.autoanimationHook selected=macro.autoanimationHook localize=true}}
+          </select>
+        </div>
+        {{/unless}}
+        {{/unless}}
+        {{/if}}
+        
+      </div>
+      
+      <div class="form-group stacked macro-text">
+          <code-mirror name="system.macros.{{@index}}.command" language="{{editorLanguage}}">
+            {{~ macro.command ~}}
+          </code-mirror>
+      </div>
+      
+    <div class="form-group flexrow">
+      <button class="execute" data-action="executeMacro" type="button" data-macro-index="{{@index}}"><i class="fas fa-dice-d20"></i> {{ localize "MACRO.Execute" }}</button>
+    </div>
+	
+    </fieldset>
+	{{/each}}
+  
+  <div class="form-group right">
+    <a class="macro-control macro-add label" data-action="addMacro">{{localize "DND4EUI.AddNew"}}</a>
   </div>
-
-  <div class="form-group">
-    <label>{{ localize "Type" }}</label>
-    <select name="system.macro.type">
-      {{selectOptions config.macroType selected=system.macro.type labelAttr="label"}}
-    </select>
-  </div>
-
-  <div class="form-group">
-    <label>Launch Order</label>
-    <select name="system.macro.launchOrder">
-      {{selectOptions config.macroLaunchOrder selected=system.macro.launchOrder labelAttr="label"}}
-    </select>
-  </div>
-
-  {{#if autoanimationsActive}}
-  <div class="form-group">
-    <label>Autoanimation Hook</label>
-    <select name="system.macro.autoanimationHook">
-      <option value=""{{#if (eq system.macro.autoanimationHoo "")}}selected{{/if}}>Automatic</option>
-      {{selectOptions config.autoanimationHook selected=system.macro.autoanimationHook localize=true}}
-    </select>
-  </div>
-  {{/if}}
-
-  <!--<div class="form-group stacked ">
-    <label></label>
-    </div>-->
-
-  <div class="form-group stacked macro-text">
-    {{!-- 
-    <textarea name="system.macro.command">{{system.macro.command}}</textarea>
-    --}}
-    <code-mirror name="system.macro.command" language="{{editorLanguage}}">
-      {{~ system.macro.command ~}}
-    </code-mirror>
-  </div>
-
-  <footer class="sheet-footer flexrow">
-    <!-- <button type="submit"><i class="fas fa-save"></i> {{ localize "MACRO.Save" }}</button> -->
-    <button class="execute" data-action="executeMacro" type="button"><i class="fas fa-dice-d20"></i> {{ localize "MACRO.Execute" }}</button>
-  </footer>
 
 </section>


### PR DESCRIPTION
Updates the macro tab of item sheets to accommodate new multi-macro capability.
- Convert singular display to array loop
- New macros can now be added with the footer button, and existing macros deleted using the garbage button in their fieldset
- Added new "enabled" checkbox
- Manual macro activation update to select the current macro

NOTE: I'm not sure about the macro content/command field. Making it too big would make multiple macros very unwieldy, but it's too small to edit any complex macros. I'm hoping it can be made resizable, but so far I've had no luck working out how.