### PR TITLE
Item macro collapse/expand

### DIFF
--- a/module/applications/sheets/item-sheet.mjs
+++ b/module/applications/sheets/item-sheet.mjs
@@ -64,6 +64,7 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			manageActiveEffect: ItemSheet4e.#onManageActiveEffect,
 			addMacro: ItemSheet4e.#onMacroControl,
 			deleteMacro: ItemSheet4e.#onMacroControl,
+			expandMacro: ItemSheet4e.#onMacroControl,
 			// Container actions
 			itemRoll: ItemSheet4e.#onItemRoll,
 			editItem: ItemSheet4e.#onItemControl,
@@ -1568,6 +1569,11 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			macros.splice(macro.getAttribute("data-macro-number"), 1);
 			return this.item.update({ "system.macros": macros });
 		}
+    
+		// Expand macro text
+		if (action === "expandMacro") {
+      target.parentElement.classList.toggle("collapsed");
+    }
 	
 	}
 

--- a/styles/dnd4e.css
+++ b/styles/dnd4e.css
@@ -2772,7 +2772,7 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 		&.two-input input.source-name{
 			flex-basis:20%;
 		}
-		}
+  }
 	span.sep{
 		flex:0 0 8px;
 	}
@@ -2877,8 +2877,38 @@ body.theme-light .dnd4e:is(.application,.app):is(.default,.standard-form):not(.t
 		max-height:76px;
 		line-height:22px;
 	}
-  .macro-type{
-    min-width:6em;
+  .tab.macros{
+    .macro{
+      flex:fit-content 0 100;
+      
+      & .macro-expand-toggle::after{
+        padding:0.5em;
+        font-family:var(--fa-family-classic);
+        content:"\f107";
+      }
+      &:first-child{
+        flex-basis:100%;
+      }
+      &:not(.collapsed){
+        flex:100% 100 0;
+        flex-shrink:0;
+        max-height:100%;
+        
+        & .macro-expand-toggle::after{
+          content:"\f106";
+        }
+      }
+    }
+    .macro-type{
+      min-width:6em;
+    }
+    .macro-text{
+      flex:1em 100 0;
+      min-height:2em;
+      code-mirror{
+        min-height:100%;
+      }
+    }
   }
 }
 .sheet.default .item-consumable .form-group :is(.display-effect,.effect-html){

--- a/templates/items/tabs/macros.hbs
+++ b/templates/items/tabs/macros.hbs
@@ -3,9 +3,8 @@
 	{{log system.macros}}
 	{{#each system.macros as |macro i|}}
 	{{log macro}}{{log i}}
-    <fieldset class="macro form-group vertical" data-macro-number="{{@index}}">
-      <legend>{{localize 'Macro'}} {{@index}} ({{#with (lookup ../config.macroLaunchOrder macro.launchOrder)}}{{label}}{{/with}})</legend>
-      
+    <fieldset class="macro form-group vertical collapsed" data-macro-number="{{@index}}">
+      <legend class="macro-expand-toggle" data-action="expandMacro">{{localize 'Macro'}} {{@index}} ({{#with (lookup ../config.macroLaunchOrder macro.launchOrder)}}{{label}}{{/with}})</legend>
       <div class="form-group loose">
       
         <div class="form-group loose">
@@ -59,8 +58,8 @@
         
       </div>
       
-      <div class="form-group stacked macro-text">
-          <code-mirror name="system.macros.{{@index}}.command" language="{{editorLanguage}}">
+      <div class="form-group stacked macro-text" tabindex="0">
+          <code-mirror name="system.macros.{{@index}}.command" language="{{editorLanguage}}" tabindex="0">
             {{~ macro.command ~}}
           </code-mirror>
       </div>


### PR DESCRIPTION
Resolved my misgivings about the multi-macro command field by giving them a collapse/expand button. A bit easier than making a popout form, but I reckon it does the trick.