### PR TITLE
Common attack bonus fix

### DIFF
--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -71,9 +71,9 @@
           <label class="checkbox">
             <input type="checkbox" class="checkbox" name="{{n}}.{{b}}" data-dtype="Boolean" 
 						
-              {{!-- Try to infer already active bonuses --}}
+          {{!-- Try to infer already active bonuses --}}
 					
-              {{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.shouldApply}}checked="true" disabled{{/if}}{{/if}}
+            {{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.shouldApply}}checked="true" disabled{{/if}}{{/if}}
 					
 						{{#if (eq b 'marked')}}{{#if t.targetBonuses.ignoringMark.shouldApply}}checked="true"{{/if}}{{/if}}
 					 
@@ -119,7 +119,7 @@
 					{{!-- End already active --}}
 					
 						value="{{../checked}}"/> 
-            <span class="label">{{ localize a.label}} ({{ lookup (lookup t.targetBonuses b) "value"}})</span>
+            <span class="label">{{ localize a.label}} ({{#if ../targetData.hasTarget}}{{ lookup (lookup t.targetBonuses b) "value"}}{{else}}{{ lookup (lookup ../../data.commonAttackBonuses b) "value"}}{{/if}})</span>
           </label>
         </div>
         {{/each}}

--- a/templates/items/tabs/macros.hbs
+++ b/templates/items/tabs/macros.hbs
@@ -1,8 +1,6 @@
 <section class="tab scrollable {{tab.id}}{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
 
-	{{log system.macros}}
 	{{#each system.macros as |macro i|}}
-	{{log macro}}{{log i}}
     <fieldset class="macro form-group vertical collapsed" data-macro-number="{{@index}}">
       <legend class="macro-expand-toggle" data-action="expandMacro">{{localize 'Macro'}} {{@index}} ({{#with (lookup ../config.macroLaunchOrder macro.launchOrder)}}{{label}}{{/with}})</legend>
       <div class="form-group loose">


### PR DESCRIPTION
- Fixes an error where the value of common attack bonuses didn't display unless there was a target.
- From item macros tab, removes the debug logging I forgot to take out >3>;