### PR TITLE
Add defense evaluation hook and more

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1393,16 +1393,23 @@
 },
 
 "DND4E.MACROS": {
-  "ACTIVATION": {
-    "Label": "Activation",
-    "Both": "Before AND After Item Use",
-    "Manual": "Manual",
-    "Pre": "Before Item Use",
-    "Post": "After Item Use",
-    "Sub": "Replace Item Use",
-    "HookComBon": "Hook: Evaluate Common Attack Bonuses",
-    "HookPreAttack": "Hook: Pre Attack Roll"
-  }
+    "ACTIVATION": {
+        "Label": "Activation",
+        "Both": "Before AND After Item Use",
+        "Manual": "Manual",
+        "Pre": "Before Item Use",
+        "Post": "After Item Use",
+        "Sub": "Replace Item Use",
+        "HookComBon": {
+        "Attacker": "Hook: Evaluate Common Attack Bonuses - Attacker",
+            "Target": "Hook: Evaluate Common Attack Bonuses - Target"
+        },
+        "HookPreAttack": {
+            "Attacker": "Hook: Pre Attack Roll - Attacker",
+            "Target": "Hook: Pre Attack Roll - Target"
+        },
+        "HookEvalDef": "Hook: Evaluate Target Defence"
+    }
 },
 
 "DND4E.Movement":{

--- a/lang/en.json
+++ b/lang/en.json
@@ -1393,16 +1393,23 @@
 },
 
 "DND4E.MACROS": {
-  "ACTIVATION": {
-    "Label": "Activation",
-    "Both": "Before AND After Item Use",
-    "Manual": "Manual",
-    "Pre": "Before Item Use",
-    "Post": "After Item Use",
-    "Sub": "Replace Item Use",
-    "HookComBon": "Hook: Evaluate Common Attack Bonuses",
-    "HookPreAttack": "Hook: Pre Attack Roll"
-  }
+    "ACTIVATION": {
+        "Label": "Activation",
+        "Both": "Before AND After Item Use",
+        "Manual": "Manual",
+        "Pre": "Before Item Use",
+        "Post": "After Item Use",
+        "Sub": "Replace Item Use",
+        "HookComBon": {
+        "Attacker": "Hook: Evaluate Common Attack Bonuses - Attacker",
+            "Target": "Hook: Evaluate Common Attack Bonuses - Target"
+        },
+        "HookPreAttack": {
+            "Attacker": "Hook: Pre Attack Roll - Attacker",
+            "Target": "Hook: Pre Attack Roll - Target"
+        },
+        "HookEvalDef": "Hook: Evaluate Target Defense"
+    }
 },
 
 "DND4E.Movement":{

--- a/module/applications/sheets/item-sheet.mjs
+++ b/module/applications/sheets/item-sheet.mjs
@@ -652,8 +652,6 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 	static #onConfigureSource(event, target) {
 		return this._renderChild(new SourceConfig({ document: this.item, keyPath: "system.source" }));
 	}
-  
-
 
 	async shareItem() {
 		let changeBack = false;
@@ -1165,10 +1163,10 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 
 	/* -------------------------------------------- */
 
-	static async #onExecuteMacro(event, target){
+	static async #onExecuteMacro(event, target) {
 		await this.submit({ preventClose: true });
-    const macroIndex = event.target.getAttribute("data-macro-index");
-		return macros.executeMacro(this.document,this.document.system.macros[macroIndex]);
+		const macroIndex = event.target.getAttribute("data-macro-index");
+		return macros.executeMacro(this.document, this.document.system.macros[macroIndex]);
 	}
 	
 	/* -------------------------------------------- */
@@ -1550,30 +1548,30 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			await this.submit(event); // Submit any unsaved changes
 			const macros = this.item.system.macros;
 			return this.item.update({ "system.macros": macros.concat([{
-        "type": "script",
-        "scope": "global",
-        "launchOrder": "off",
-        "command": "",
-        "author": "",
-        "autoanimationHook": "",
-        "enabled": true
-      }])});
+				type: "script",
+				scope: "global",
+				launchOrder: "off",
+				command: "",
+				author: "",
+				autoanimationHook: "",
+				enabled: true,
+			}]) });
 		}
 
 		// Remove a damage component
 		if (action === "deleteMacro") {
 			await this.submit(event); // Submit any unsaved changes
 			const macro = target.closest(".macro");
-      const index = macro.getAttribute("data-macro-number");
-      const macros = foundry.utils.duplicate(this.item.system.macros);
+			const index = macro.getAttribute("data-macro-number");
+			const macros = foundry.utils.duplicate(this.item.system.macros);
 			macros.splice(macro.getAttribute("data-macro-number"), 1);
 			return this.item.update({ "system.macros": macros });
 		}
     
 		// Expand macro text
 		if (action === "expandMacro") {
-      target.parentElement.classList.toggle("collapsed");
-    }
+			target.parentElement.classList.toggle("collapsed");
+		}
 	
 	}
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -85,8 +85,11 @@ DND4E.macroLaunchOrder = {
 	post: { label: "DND4E.MACROS.ACTIVATION.Post" },
 	both: { label: "DND4E.MACROS.ACTIVATION.Both" },
 	sub: { label: "DND4E.MACROS.ACTIVATION.Sub" },
-	comBon: { label: "DND4E.MACROS.ACTIVATION.HookComBon" },
-	preAttack: { label: "DND4E.MACROS.ACTIVATION.HookPreAttack" },
+	comBonAttacker: { label: "DND4E.MACROS.ACTIVATION.HookComBon.Attacker" },
+	comBonTarget: { label: "DND4E.MACROS.ACTIVATION.HookComBon.Target" },
+	preAttackAttacker: { label: "DND4E.MACROS.ACTIVATION.HookPreAttack.Attacker" },
+	preAttackTarget: { label: "DND4E.MACROS.ACTIVATION.HookPreAttack.Target" },
+	evalDef: { label: "DND4E.MACROS.ACTIVATION.HookEvalDef" },
 };
 preLocalize("macroLaunchOrder", { keys: ["label"] });
 

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -114,12 +114,18 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 			const attacker = utils.tokenForActor(actor);
 			const target = targetArr[targ];
 			for (const actorItem of [...actor.items]) {
-				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBon"))) {
-					const func = new Function("source", "item", "attacker", "target", "bonuses", macro.command);
-					func(actorItem, item, attacker, target, targetBonuses);
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBonAttacker"))) {
+					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+					func(actorItem, item, attacker, target, { bonuses: targetBonuses });
 				}
 			}
-			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, targetBonuses);
+			for (const actorItem of [...target.actor.items]) {
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBonTarget"))) {
+					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+					func(actorItem, item, attacker, target, { bonuses: targetBonuses });
+				}
+			}
+			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, { bonuses: targetBonuses });
 			targDataArray.targets.push({
 				name: targetArr[targ]?.name || "",
 				status: targetArr[targ]?.actor.statuses || [],
@@ -359,12 +365,18 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 			const attacker = utils.tokenForActor(actor);
 			const target = theTargets[targetIndex];
 			for (const actorItem of [...actor.items]) {
-				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBon"))) {
-					const func = new Function("source", "item", "attacker", "target", "bonuses", macro.command);
-					func(actorItem, item, attacker, target, targetBonuses);
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBonAttacker"))) {
+					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+					func(actorItem, item, attacker, target, { bonuses: targetBonuses });
 				}
 			}
-			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, targetBonuses);
+			for (const actorItem of [...target.actor.items]) {
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBonTarget"))) {
+					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+					func(actorItem, item, attacker, target, { bonuses: targetBonuses });
+				}
+			}
+			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, { bonuses: targetBonuses });
 			if (game.settings.get("dnd4e", "collapseSituationalBonus")) {
 				const total = Object.values(targetBonuses).filter((bon) => bon.shouldApply).map((bon) => bon.value).reduce((acc, curr) => acc + curr);
 				allRollsParts.push(parts.concat([total]));
@@ -419,6 +431,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 	for (let rollExpressionIdx = 0; rollExpressionIdx < allRollsParts.length; rollExpressionIdx++) {
 		const rollExpression = allRollsParts[rollExpressionIdx];
 		let subroll;
+		const attacker = utils.tokenForActor(actor);
 		try {
 			let targetOptions = foundry.utils.deepClone(options);
 			const targetActor = targets[rollExpressionIdx]?.document.actor;
@@ -431,11 +444,16 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 					data[key] = commonAttackBonuses[key].value;
 				});
 			}
-			const attacker = utils.tokenForActor(actor);
 			const target = targets[rollExpressionIdx];
 			for (const actorItem of [...actor.items]) {
-				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "preAttack"))) {
-					const func = new Function("source", "item", "attacker", "target", "rollConfig", macro.command);
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "preAttackAttacker"))) {
+					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
+				}
+			}
+			for (const actorItem of [...target.actor.items]) {
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "preAttackTarget"))) {
+					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
 					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
 				}
 			}
@@ -452,15 +470,24 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 
 		if (isAttackRoll && (targets.length > rollExpressionIdx)) {
 			const attackedDef = targetData.targDefArray[rollExpressionIdx];
-			let targName = targets[rollExpressionIdx].name;
-			let targDefVal = targets[rollExpressionIdx].document.actor.system.defences[attackedDef]?.value;
+			const target = targets[rollExpressionIdx];
+			let targName = target.name;
+			let targDefVal = target.document.actor.system.defences[attackedDef]?.value;
 			let defOptions = { bonuses: foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses) };
-			await utils.applyEffects({ ...data, ...options.variance }, targets[rollExpressionIdx].actor, itemData, weaponData, "defence", null, null, defOptions);
+            
+			const targetActor = target.actor;
+			await utils.applyEffects({ ...data, ...options.variance }, targetActor, itemData, weaponData, "defence", null, null, defOptions);
+			for (const actorItem of [...targetActor.items]) {
+				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "evalDef"))) {
+					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+					func(actorItem, item, attacker, target, { defence: attackedDef, bonuses: defOptions.bonuses });
+				}
+			}
+			Hooks.callAll("dnd4e.evaluateTargetDefence", item, attacker, target, { defence: attackedDef, bonuses: defOptions.bonuses });
 
 			let bonusesTotal = 0;
 			for (const [type, bonuses] of Object.entries(defOptions.bonuses)) {
 				if (bonuses.length) {
-					bonuses.push(actor.system.defences[attackedDef][type]);
 					const bonus = type == "untyped" ? bonuses.reduce((acc, curr) => acc + parseInt(curr), 0) : bonuses.reduce((max, curr) => Math.max(max, parseInt(curr)), -Infinity);
 					let currentBonus = 0;
 					if (type !== "untyped") {

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -54,7 +54,7 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 		targets: [],
 	};
 	
-	if (actor && game.user.targets.size) {
+	if (actor) {
 		const userBonuses = Object.keys(CONFIG.DND4E.commonAttackBonuses).reduce((bonuses, bonus) => {
 			bonuses[bonus] = {
 				shouldApply: false,
@@ -62,9 +62,9 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 			};
 			return bonuses;
 		}, {});
-		const numTargets = game.user.targets.size;
+		const numTargets = Math.max(1, game.user.targets.size);
 		const targetArr = Array.from(game.user.targets);
-		targDataArray.hasTarget = true;
+		targDataArray.hasTarget = !!targetArr.length;
 		if (game.settings.get("dnd4e", "markAutomation") && actor.system?.marker) {
 			targDataArray.ignoringMark = !targetArr.some(t => (t.actor.uuid === data.marker));
 			userBonuses.ignoringMark.shouldApply = true;
@@ -78,15 +78,15 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 		if (isCharge) userBonuses.charge.shouldApply = true;
 		for (let targ = 0; targ < numTargets; targ++) {
 			const targetBonuses = foundry.utils.deepClone(userBonuses);
-			const targName = targetArr[targ].name;
+			const targName = targetArr[targ]?.name || "";
 			targDataArray.targNameArray.push(targName);
-			const targetStatus = Array.from(targetArr[targ].actor.statuses);
+			const targetStatus = Array.from(targetArr[targ]?.actor.statuses || []);
 				
 			//Target conditions
 			if (targetStatus.filter(element => ["blinded", "dazed", "dominated", "helpless", "restrained", "stunned", "surprised", "squeezing", "running", "grantingCA"].includes(element)).length) targetBonuses.comAdv.shouldApply = true;
-			const targetDist = utils.computeDistance(actor, targetArr[targ]);
+			const targetDist = targetArr[targ] ? utils.computeDistance(actor, targetArr[targ]) : 0;
 			//console.debug(data);
-			if (targetArr[targ].actor.statuses.has("prone") && (["melee", "touch", "reach"].includes(item?.system.rangeType) || ((item?.system.rangeType === "weapon") && (weaponUse?.system.weaponType.slice(-1) === "M")))) {
+			if (targetArr[targ]?.actor.statuses.has("prone") && (["melee", "touch", "reach"].includes(item?.system.rangeType) || ((item?.system.rangeType === "weapon") && (weaponUse?.system.weaponType.slice(-1) === "M")))) {
 				let meleeVsProne = true;
 				if (item?.system.rangeType === "weapon") {
 					if (weaponUse?.system.properties.thv || weaponUse?.system.properties.tlg) {
@@ -102,7 +102,7 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 			if (((item?.system.rangeType === "range") && item?.system.range.long && (targetDist > item?.system.rangePower)) || ((item?.system.rangeType === "weapon") && weaponUse?.system.range.long && (targetDist > weaponUse?.system.range.value))) {
 				targetBonuses.longRange.shouldApply = true;
 			}
-			if (utils.computeFlankingStatus(utils.tokenForActor(actor), targetArr[targ])) {
+			if (targetArr[targ] && utils.computeFlankingStatus(utils.tokenForActor(actor), targetArr[targ])) {
 				targetBonuses.comAdv.shouldApply = true;
 			}
 			if (targetStatus.includes("bloodied")) targetBonuses.bloodied.shouldApply = true;
@@ -121,11 +121,11 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 			}
 			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, targetBonuses);
 			targDataArray.targets.push({
-				name: targetArr[targ].name,
-				status: targetArr[targ].actor.statuses,
+				name: targetArr[targ]?.name || "",
+				status: targetArr[targ]?.actor.statuses || [],
 				attackMod: data?.item?.attack?.ability || "",
 				attackDef: options.attackedDef || "ac",
-				immune: targetArr[targ].actor.system.defences[options.attackedDef]?.none || false,
+				immune: targetArr[targ]?.actor.system.defences[options.attackedDef]?.none || false,
 				targetBonuses,
 			});
 		}

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -71,9 +71,9 @@
           <label class="checkbox">
             <input type="checkbox" class="checkbox" name="{{n}}.{{b}}" data-dtype="Boolean" 
 
-				{{!-- Try to infer already active bonuses --}}
+              {{!-- Try to infer already active bonuses --}}
 
-				{{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.shouldApply}}checked="true" disabled{{/if}}{{/if}}
+              {{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.shouldApply}}checked="true" disabled{{/if}}{{/if}}
 
 				{{#if (eq b 'marked')}}{{#if t.targetBonuses.ignoringMark.shouldApply}}checked="true"{{/if}}{{/if}}
 

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -113,7 +113,7 @@
 				{{!-- End already active --}}
 					
 			value="{{../checked}}"/> 
-            <span class="label">{{ localize a.label}} ({{ lookup (lookup t.targetBonuses b) "value"}})</span>
+            <span class="label">{{ localize a.label}} ({{lookup (lookup t.targetBonuses b) "value"}})</span>
           </label>
         </div>
         {{/each}}

--- a/templates/chat/roll-dialog.hbs
+++ b/templates/chat/roll-dialog.hbs
@@ -70,56 +70,50 @@
         <div class="form-group bonus">
           <label class="checkbox">
             <input type="checkbox" class="checkbox" name="{{n}}.{{b}}" data-dtype="Boolean" 
-						
-          {{!-- Try to infer already active bonuses --}}
-					
-            {{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.shouldApply}}checked="true" disabled{{/if}}{{/if}}
-					
-						{{#if (eq b 'marked')}}{{#if t.targetBonuses.ignoringMark.shouldApply}}checked="true"{{/if}}{{/if}}
-					 
-						{{#if (eq b 'prone')}}{{#if t.targetBonuses.prone.shouldApply}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'restrained')}}{{#if t.targetBonuses.restrained.shouldApply}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'squeez')}}{{#if t.targetBonuses.squeez.shouldApply}}checked="true"{{/if}}{{/if}}
-						{{#if (eq b 'running')}}{{#if t.targetBonuses.running.shouldApply}}checked="true"{{/if}}{{/if}}
-						
-						{{!-- Only if targets are provided --}}
-							{{#if ../../targetData.hasTarget}}
-								
-								{{#if (eq b 'bloodied')}}
-									{{#if t.targetBonuses.bloodied.shouldApply}}checked="true"{{/if}}
-								{{/if}}
 
-								{{#if (eq b 'comAdv')}}
-									{{#if t.targetBonuses.comAdv.shouldApply}}checked="true"{{/if}}
-								{{/if}}
-								
-								{{#if (eq b 'conceal')}}
-									{{#if t.targetBonuses.conceal.shouldApply}}checked="true"{{/if}}
-								{{/if}}
-								
-								{{#if (eq b 'concealTotal')}}
-									{{#if t.targetBonuses.concealTotal.shouldApply}}checked="true"{{/if}}
-								{{/if}}
-								
-								{{#if (eq b 'cover')}}
-									{{#if t.targetBonuses.cover.shouldApply}}checked="true"{{/if}}
-								{{/if}}
-								
-								{{#if (eq b 'coverSup')}}
-									{{#if t.targetBonuses.coverSup.shouldApply}}checked="true"{{/if}}
-								{{/if}}
+				{{!-- Try to infer already active bonuses --}}
 
-								{{#if (eq b 'longRange')}}
-									{{#if t.targetBonuses.longRange.shouldApply}}checked="true"{{/if}}
-								{{/if}}
-									
-							{{/if}}
-						{{!-- End targets only --}}
-						
-					{{!-- End already active --}}
+				{{#if (eq b 'charge')}}{{#if ../../data.item.attack.isCharge}}checked="true" disabled{{/if}}{{#if t.targetBonuses.charge.shouldApply}}checked="true" disabled{{/if}}{{/if}}
+
+				{{#if (eq b 'marked')}}{{#if t.targetBonuses.ignoringMark.shouldApply}}checked="true"{{/if}}{{/if}}
+
+				{{#if (eq b 'prone')}}{{#if t.targetBonuses.prone.shouldApply}}checked="true"{{/if}}{{/if}}
+				{{#if (eq b 'restrained')}}{{#if t.targetBonuses.restrained.shouldApply}}checked="true"{{/if}}{{/if}}
+				{{#if (eq b 'squeez')}}{{#if t.targetBonuses.squeez.shouldApply}}checked="true"{{/if}}{{/if}}
+				{{#if (eq b 'running')}}{{#if t.targetBonuses.running.shouldApply}}checked="true"{{/if}}{{/if}}
+
+				{{#if (eq b 'bloodied')}}
+					{{#if t.targetBonuses.bloodied.shouldApply}}checked="true"{{/if}}
+				{{/if}}
+
+				{{#if (eq b 'comAdv')}}
+					{{#if t.targetBonuses.comAdv.shouldApply}}checked="true"{{/if}}
+				{{/if}}
+
+				{{#if (eq b 'conceal')}}
+					{{#if t.targetBonuses.conceal.shouldApply}}checked="true"{{/if}}
+				{{/if}}
+
+				{{#if (eq b 'concealTotal')}}
+					{{#if t.targetBonuses.concealTotal.shouldApply}}checked="true"{{/if}}
+				{{/if}}
+
+				{{#if (eq b 'cover')}}
+					{{#if t.targetBonuses.cover.shouldApply}}checked="true"{{/if}}
+				{{/if}}
+
+				{{#if (eq b 'coverSup')}}
+					{{#if t.targetBonuses.coverSup.shouldApply}}checked="true"{{/if}}
+				{{/if}}
+
+				{{#if (eq b 'longRange')}}
+					{{#if t.targetBonuses.longRange.shouldApply}}checked="true"{{/if}}
+				{{/if}}
+
+				{{!-- End already active --}}
 					
-						value="{{../checked}}"/> 
-            <span class="label">{{ localize a.label}} ({{#if ../targetData.hasTarget}}{{ lookup (lookup t.targetBonuses b) "value"}}{{else}}{{ lookup (lookup ../../data.commonAttackBonuses b) "value"}}{{/if}})</span>
+			value="{{../checked}}"/> 
+            <span class="label">{{ localize a.label}} ({{ lookup (lookup t.targetBonuses b) "value"}})</span>
           </label>
         </div>
         {{/each}}

--- a/templates/items/tabs/macros.hbs
+++ b/templates/items/tabs/macros.hbs
@@ -1,73 +1,75 @@
 <section class="tab scrollable {{tab.id}}{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
 
-	{{#each system.macros as |macro i|}}
-    <fieldset class="macro form-group vertical collapsed" data-macro-number="{{@index}}">
-      <legend class="macro-expand-toggle" data-action="expandMacro">{{localize 'Macro'}} {{@index}} ({{#with (lookup ../config.macroLaunchOrder macro.launchOrder)}}{{label}}{{/with}})</legend>
-      <div class="form-group loose">
-      
-        <div class="form-group loose">
-          <label>{{localize "DND4E.MACROS.ACTIVATION.Label"}}</label>
-          <select name="system.macros.{{@index}}.launchOrder">
-            {{selectOptions ../config.macroLaunchOrder selected=macro.launchOrder labelAttr="label"}}
-          </select>
-        </div>
-
-        {{#unless (eq macro.launchOrder "comBon")}}
-        {{#unless (eq macro.launchOrder "preAttack")}}
-        <div class="form-group loose">
-          <label>{{ localize "Type" }}</label>
-          <select name="system.macros.{{@index}}.type" class="macro-type">
-            {{selectOptions ../config.macroType selected=macro.type labelAttr="label"}}
-          </select>
-        </div>
-        {{/unless}}
-        {{/unless}}
-
-        <label class="checkbox right">
-          <input class="checkbox" type="checkbox" name="system.macros.{{@index}}.enabled" data-dtype="Boolean" {{checked macro.enabled}}> 
-          <span class="label">{{localize "DND4E.Active"}}</span>
-        </label>
-        <a class="macro-control macro-delete right" data-action="deleteMacro" data-tooltip="{{localize 'DND4EUI.Delete'}}"><i class="fas fa-trash"></i></a>
-        
-      </div>
+  {{#each system.macros as |macro i|}}
+  <fieldset class="macro form-group vertical collapsed" data-macro-number="{{@index}}">
+    <legend class="macro-expand-toggle" data-action="expandMacro">{{localize 'Macro'}} {{@index}} ({{#with (lookup ../config.macroLaunchOrder macro.launchOrder)}}{{label}}{{/with}})</legend>
+    <div class="form-group loose">
       
       <div class="form-group loose">
-      
-        {{!--<div class="form-group loose">
-          <label>{{ localize "Scope" }}</label>
-          <select name="system.macros.{{@index}}.scope" disabled>
-            {{selectOptions ../config.macroScope selected=macro.scope labelAttr="label"}}
-          </select>
-        </div>--}}
-        
-        {{#if autoanimationsActive}}
-        {{#unless (eq macro.launchOrder "comBon")}}
-        {{#unless (eq macro.launchOrder "preAttack")}}
-        <div class="form-group loose">
-          <label>Autoanimation Hook</label>
-          <select name="system.macros.{{@index}}.autoanimationHook">
-            <option value=""{{#if (eq macro.autoanimationHook "")}}selected{{/if}}>Automatic</option>
-            {{selectOptions ../config.autoanimationHook selected=macro.autoanimationHook localize=true}}
-          </select>
-        </div>
-        {{/unless}}
-        {{/unless}}
-        {{/if}}
-        
+        <label>{{localize "DND4E.MACROS.ACTIVATION.Label"}}</label>
+        <select name="system.macros.{{@index}}.launchOrder">
+          {{selectOptions ../config.macroLaunchOrder selected=macro.launchOrder labelAttr="label"}}
+        </select>
       </div>
-      
-      <div class="form-group stacked macro-text" tabindex="0">
-          <code-mirror name="system.macros.{{@index}}.command" language="{{editorLanguage}}" tabindex="0">
-            {{~ macro.command ~}}
-          </code-mirror>
+
+      {{#unless (eq macro.launchOrder "comBon")}}
+      {{#unless (eq macro.launchOrder "preAttack")}}
+      <div class="form-group loose">
+        <label>{{ localize "Type" }}</label>
+        <select name="system.macros.{{@index}}.type" class="macro-type">
+          {{selectOptions ../config.macroType selected=macro.type labelAttr="label"}}
+        </select>
       </div>
+      {{/unless}}
+      {{/unless}}
+
+      <label class="checkbox right">
+        <input class="checkbox" type="checkbox" name="system.macros.{{@index}}.enabled" data-dtype="Boolean" {{checked macro.enabled}}> 
+        <span class="label">{{localize "DND4E.Active"}}</span>
+      </label>
+      <a class="macro-control macro-delete right" data-action="deleteMacro" data-tooltip="{{localize 'DND4EUI.Delete'}}"><i class="fas fa-trash"></i></a>
+        
+    </div>
+      
+    <div class="form-group loose">
+      
+      {{!--
+      <div class="form-group loose">
+        <label>{{ localize "Scope" }}</label>
+        <select name="system.macros.{{@index}}.scope" disabled>
+          {{selectOptions ../config.macroScope selected=macro.scope labelAttr="label"}}
+        </select>
+      </div>
+      --}}
+        
+      {{#if autoanimationsActive}}
+      {{#unless (eq macro.launchOrder "comBon")}}
+      {{#unless (eq macro.launchOrder "preAttack")}}
+      <div class="form-group loose">
+        <label>Autoanimation Hook</label>
+        <select name="system.macros.{{@index}}.autoanimationHook">
+          <option value=""{{#if (eq macro.autoanimationHook "")}}selected{{/if}}>Automatic</option>
+          {{selectOptions ../config.autoanimationHook selected=macro.autoanimationHook localize=true}}
+        </select>
+      </div>
+      {{/unless}}
+      {{/unless}}
+      {{/if}}
+        
+    </div>
+      
+    <div class="form-group stacked macro-text" tabindex="0">
+      <code-mirror name="system.macros.{{@index}}.command" language="{{editorLanguage}}" tabindex="0">
+        {{~ macro.command ~}}
+      </code-mirror>
+    </div>
       
     <div class="form-group flexrow">
       <button class="execute" data-action="executeMacro" type="button" data-macro-index="{{@index}}"><i class="fas fa-dice-d20"></i> {{ localize "MACRO.Execute" }}</button>
     </div>
 	
-    </fieldset>
-	{{/each}}
+  </fieldset>
+  {{/each}}
   
   <div class="form-group right">
     <a class="macro-control macro-add label" data-action="addMacro">{{localize "DND4EUI.AddNew"}}</a>


### PR DESCRIPTION
Accidentally includes changes from #712, so merge that one first and there shouldn't be any conflicts.

Also splits the `preAttackRoll` and `evaluateCommonAttackBonuses` macro passes into "when attacking" and "when targeted" versions. The actual system hooks remain unchanged, since they're called from outside either actor.

Also standardizes argument names in item macros for these new macro passes. Each one receives:
`source`: the item the macro is stored on
`item`: the primary item involved in the attack
`attacker`: the attacking token
`target`: the target token
`config`: an object containing pass/hook-specific data, some of which can be modified to alter the roll formula