### PR TITLE
Standardize `...roll.type` property in rollConfigs for module compatibility

### DIFF
--- a/module/applications/ux/enrichers/roll.mjs
+++ b/module/applications/ux/enrichers/roll.mjs
@@ -456,7 +456,7 @@ async function rollAttack(config, event) {
 			left: window.innerWidth - 710,
 		},
 		isAttackRoll: true,
-		messageData: { "flags.dnd4e.roll": { type: "attack" } },
+		messageData: { "options.flags.dnd4e.roll": { type: "attack" } },
 		options,
 	};
 
@@ -560,7 +560,7 @@ async function rollDamageHealing(config, event) {
 			top: options.event ? options.event.clientY - 80 : null,
 			left: window.innerWidth - 710,
 		},
-		messageData: { "flags.dnd4e.roll": { type: "damage" } },
+		messageData: { "options.flags.dnd4e.roll": { type: "damage" } },
 		healingRoll: ["healing", "temphp"].includes(type),
 		options,
 		allowCritical: !!partsCrit?.length,

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1820,6 +1820,7 @@ export default class Actor4e extends Actor {
 			critical: 21,
 			fumble: 0,
 			targetValue: Number(options.dc),
+			messageData: { "options.flags.dnd4e.roll": { type: "skill", actorId: this.id } },
 		}, { overwrite: false });
 
 		// Roll and return
@@ -1853,6 +1854,7 @@ export default class Actor4e extends Actor {
 			critical: 21,
 			fumble: 0,
 			targetValue: Number(options.dc),
+			messageData: { "options.flags.dnd4e.roll": { type: "ability", actorId: this.id } },
 			// flavor: "Flowery Text Here. MORE AND MORE AND \r\n MORE S MORE " + _loc("DND4E.AbilityPromptTitle", {ability: CONFIG.DND4E.abilities[label]}),
 			// halflingLucky: feats.halflingLucky
 		}, { overwrite: false });
@@ -1949,7 +1951,7 @@ export default class Actor4e extends Actor {
 			title: _loc("DND4E.InitiativeRoll"),
 			speaker: ChatMessage.getSpeaker({ actor: this }),
 			flavor: isReroll ? `${this.name} ${_loc("DND4E.RollsInitReroll")}!` : `${this.name} ${_loc("DND4E.RollsInit")}!`,
-			"options.flags.dnd4e.roll.type": "init",
+			messageData: { "options.flags.dnd4e.roll": { type: "initiative", actorId: this.id } },
 		});
 	
 		const initRoll = await d20Roll(rollConfig);
@@ -1990,7 +1992,7 @@ export default class Actor4e extends Actor {
 			title: "",
 			flavor: message,
 			speaker: ChatMessage.getSpeaker({ actor: this }),
-			messageData: { "flags.dnd4e.roll": { type: "save", itemId: this.id } },
+			messageData: { "options.flags.dnd4e.roll": { type: "save", actorId: this.id } },
 			fastForward: true,
 			messageMode: options.messageMode,
 			options,
@@ -2032,7 +2034,7 @@ export default class Actor4e extends Actor {
 			title: "",
 			flavor: _loc("DND4E.RollDeathSave"),
 			speaker: ChatMessage.getSpeaker({ actor: this }),
-			messageData: { "flags.dnd4e.roll": { type: "save", itemId: this.id } },
+			messageData: { "options.flags.dnd4e.roll": { type: "save", actorId: this.id, isDeathSave: true } },
 			fastForward: true,
 			messageMode: options.messageMode,
 		});

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1735,7 +1735,7 @@ export default class Item4e extends Item {
 			isAttackRoll: true,
 			isCharge: options?.variance?.isCharge || false,
 			isOpp: options?.variance?.isOpp || false,
-			messageData: { "flags.dnd4e.roll": { type: "attack", itemId: this.id } },
+			messageData: { "options.flags.dnd4e.roll": { type: "attack", itemId: this.id } },
 			options,
 		};
 		
@@ -2104,7 +2104,7 @@ export default class Item4e extends Item {
 			ui.notifications.error("You may not make a Damage Roll with this Item.");
 			return null;
 		}
-		const messageData = { "flags.dnd4e.roll": { type: "damage", itemId: this.id } };
+		const messageData = { "options.flags.dnd4e.roll": { type: "damage", itemId: this.id } };
 
 		// Get roll data
 		const rollData = this.getRollData({ variance: variance });
@@ -2401,7 +2401,7 @@ export default class Item4e extends Item {
 			ui.notifications.error("You may not make a Healing Roll with this Item.");
 			return null;
 		}
-		const messageData = { "flags.dnd4e.roll": { type: "healing", itemId: this.id } };
+		const messageData = { "options.flags.dnd4e.roll": { type: "healing", itemId: this.id } };
 
 		// Get roll data
 		const rollData = this.getRollData();
@@ -2446,7 +2446,7 @@ export default class Item4e extends Item {
 		if (weaponUse) {
 			if (weaponUse.system.properties["ver"] && (weaponUse.system.weaponHand === "hTwo")) {
 				parts.push("1");
-				messageData["flags.dnd4e.roll"].versatile = true;
+				messageData["options.flags.dnd4e.roll"].versatile = true;
 				partsExpressionReplacements.push({ target: "1", value: "@versatile" });
 			}
 		}
@@ -2531,7 +2531,7 @@ export default class Item4e extends Item {
 			speaker: ChatMessage.getSpeaker({ actor: this.actor }),
 			flavor: this.system.description.chat || title,
 			messageMode: game.settings.get("core", "messageMode"),
-			messageData: { "flags.dnd4e.roll": { type: "other", itemId: this.id } },
+			messageData: { "options.flags.dnd4e.roll": { type: "other", itemId: this.id } },
 		});
 		return roll;
 	}
@@ -2688,7 +2688,7 @@ export default class Item4e extends Item {
 				top: options.event ? options.event.clientY - 80 : null,
 				left: window.innerWidth - 710,
 			},
-			messageData: { "flags.dnd4e.roll": { type: rollType, itemId: this.id } },
+			messageData: { "options.flags.dnd4e.roll": { type: rollType, itemId: this.id } },
 		}, options);
 
 		rollConfig.event = options.event;

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -54,7 +54,7 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 		targets: [],
 	};
 	
-	if (actor) {
+	if (actor && isAttackRoll) {
 		const userBonuses = Object.keys(CONFIG.DND4E.commonAttackBonuses).reduce((bonuses, bonus) => {
 			bonuses[bonus] = {
 				shouldApply: false,
@@ -119,10 +119,12 @@ export async function d20Roll({ parts = [], partsExpressionReplacements = [], it
 					func(actorItem, item, attacker, target, { bonuses: targetBonuses });
 				}
 			}
-			for (const actorItem of [...target.actor.items]) {
-				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBonTarget"))) {
-					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
-					func(actorItem, item, attacker, target, { bonuses: targetBonuses });
+			if (target?.actor) {
+				for (const actorItem of [...target.actor.items]) {
+					for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBonTarget"))) {
+						const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+						func(actorItem, item, attacker, target, { bonuses: targetBonuses });
+					}
 				}
 			}
 			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, { bonuses: targetBonuses });
@@ -370,10 +372,12 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 					func(actorItem, item, attacker, target, { bonuses: targetBonuses });
 				}
 			}
-			for (const actorItem of [...target.actor.items]) {
-				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBonTarget"))) {
-					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
-					func(actorItem, item, attacker, target, { bonuses: targetBonuses });
+			if (target?.actor) {
+				for (const actorItem of [...target.actor.items]) {
+					for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "comBonTarget"))) {
+						const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+						func(actorItem, item, attacker, target, { bonuses: targetBonuses });
+					}
 				}
 			}
 			Hooks.callAll("dnd4e.evaluateCommonAttackBonuses", item, attacker, target, { bonuses: targetBonuses });
@@ -444,20 +448,24 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 					data[key] = commonAttackBonuses[key].value;
 				});
 			}
-			const target = targets[rollExpressionIdx];
-			for (const actorItem of [...actor.items]) {
-				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "preAttackAttacker"))) {
-					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
-					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
+			if (isAttackRoll) {
+				const target = targets[rollExpressionIdx];
+				for (const actorItem of [...actor.items]) {
+					for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "preAttackAttacker"))) {
+						const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+						func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
+					}
 				}
-			}
-			for (const actorItem of [...target.actor.items]) {
-				for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "preAttackTarget"))) {
-					const func = new Function("source", "item", "attacker", "target", "config", macro.command);
-					func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
+				if (target?.actor) {
+					for (const actorItem of [...target.actor.items]) {
+						for (const macro of actorItem.system.macros.filter((m) => m.enabled && (m.launchOrder === "preAttackTarget"))) {
+							const func = new Function("source", "item", "attacker", "target", "config", macro.command);
+							func(actorItem, item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
+						}
+					}
 				}
+				Hooks.callAll("dnd4e.preAttackRoll", item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
 			}
-			Hooks.callAll("dnd4e.preAttackRoll", item, attacker, target, { rollExpression, partsExpressionReplacements, commonAttackBonuses, targetOptions });
 			subroll = await roll.addNewRoll(rollExpression, partsExpressionReplacements, data, targetOptions);
 		}
 		catch(err) {


### PR DESCRIPTION
Closes #714

I don't think the system uses any of this currently? But if it would benefit modules and also be tidier, it's easy to do.

`options.flags.dnd4e.roll.type` can have the following values:
* "attack"
* "damage"
* "healing"
* "initiative"
* "ability"
* "skill"
* "tool"
* "ritual"
* "save"

Death saves are marked by an additional property, `options.flags.dnd4e.roll.isDeathSave`, but are included under the `save` type.

Also includes fixes for a couple bugs I noticed while testing this (did you know that initiative rolls are MultiAttackRolls? I sure as heck did not).