### PR TITLE
Reinstate target click to select behavior

### DIFF
--- a/module/helpers/chat.mjs
+++ b/module/helpers/chat.mjs
@@ -259,7 +259,7 @@ export function chatMessageListener(html) {
 export const clickTokenActorName = function(event) {
 	event.preventDefault();
 
-	const tokenID = event.currentTarget.getAttribute("data-target-id") || event.currentTarget.getAttribute("target-id"); //second one was for legasy where improper typing is used, will get rid of in a month or so
+	const tokenID = event.target.getAttribute("data-target-id");
 	if (!tokenID) return;
 
 	const token = canvas.tokens.get(tokenID);
@@ -272,7 +272,6 @@ export const clickTokenActorName = function(event) {
 	}
 
 	token.control({ releaseOthers: false });
-	return canvas.animatePan(token.center);
 };
 
 //When hover over chat messages with "Target" from attack rolls, will highlight the token whose name is being hovered
@@ -538,7 +537,7 @@ Hooks.on("renderChatMessageHTML", (message, html) => {
 		});
 	});
 
-	html.querySelectorAll(".dice-roll").forEach(el => el.addEventListener("click", _onClickDiceRoll.bind(this)));
+	html.querySelectorAll("[data-action='expandRoll']").forEach(el => el.addEventListener("click", _onClickDiceRoll.bind(this)));
 });
 
 /**

--- a/templates/chat/roll-template-single.hbs
+++ b/templates/chat/roll-template-single.hbs
@@ -1,4 +1,4 @@
-<div class="dice-roll" data-action="expandRoll">
+<div class="dice-roll">
   {{#if flavor}}
   <div class="dice-flavor">{{flavor}}</div>
   {{/if}}
@@ -12,7 +12,7 @@
     {{/if}}
 		
     {{#unless attackRoll.immune}}
-    <div class="dice-container">
+    <div class="dice-container" data-action="expandRoll">
       <div class="dice-formula">{{{formula}}}</div>
       <div class="dice-tooltip dice-formula">{{{expression}}}</div>
       {{{tooltip}}}


### PR DESCRIPTION
As a consequence of this, we also have to slightly restrict the expand/collapse roll behavior, which now only functions when the actual roll container is clicked. This is to prevent clicking targets from also expanding/collapsing the roll.

Closes #719