### PR TITLE
Big consumables update!

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -262,8 +262,10 @@
 "DND4E.ConsumableAmmunition": "Ammunition",
 "DND4E.ConsumableFood": "Food",
 "DND4E.ConsumableLastChargeWarn": "This is the last charge of this unit and consuming it will also reduce the item's quantity by 1",
+"DND4E.ConsumableLoaded": "Loaded",
 "DND4E.ConsumablePoison": "Poison",
 "DND4E.ConsumablePotion": "Potion",
+"DND4E.ConsumablePrepared": "Prepared",
 "DND4E.ConsumableScroll": "Scroll",
 "DND4E.ConsumableTrinket": "Trinket",
 "DND4E.ConsumableUnitWarn": "units remaining",
@@ -1393,23 +1395,16 @@
 },
 
 "DND4E.MACROS": {
-    "ACTIVATION": {
-        "Label": "Activation",
-        "Both": "Before AND After Item Use",
-        "Manual": "Manual",
-        "Pre": "Before Item Use",
-        "Post": "After Item Use",
-        "Sub": "Replace Item Use",
-        "HookComBon": {
-        "Attacker": "Hook: Evaluate Common Attack Bonuses - Attacker",
-            "Target": "Hook: Evaluate Common Attack Bonuses - Target"
-        },
-        "HookPreAttack": {
-            "Attacker": "Hook: Pre Attack Roll - Attacker",
-            "Target": "Hook: Pre Attack Roll - Target"
-        },
-        "HookEvalDef": "Hook: Evaluate Target Defence"
-    }
+  "ACTIVATION": {
+    "Label": "Activation",
+    "Both": "Before AND After Item Use",
+    "Manual": "Manual",
+    "Pre": "Before Item Use",
+    "Post": "After Item Use",
+    "Sub": "Replace Item Use",
+    "HookComBon": "Hook: Evaluate Common Attack Bonuses",
+    "HookPreAttack": "Hook: Pre Attack Roll"
+  }
 },
 
 "DND4E.Movement":{
@@ -1714,7 +1709,7 @@
 "EFFECTDESC.defUp": "The creature has a temporary bonus to one or more defences.",
 "EFFECTDESC.defDown": "The creature has a temporary penalty to one or more defences.",
 "EFFECTDESC.regen": "At the start of the creature's turn, if it has at least 1 hit point, it regains the specified number of hit points.",
-"EFFECTDESC.ammoCount": "The creature is using special ammunitionor equipment.",
+"EFFECTDESC.ammoCount": "The creature is using special ammunition or equipment.",
 "EFFECTDESC.curse": "The creature is subject to a Warlock's Curse.",
 "EFFECTDESC.oath": "The creature is subject to an Oath of Enmity.",
 "EFFECTDESC.huntermark": "The creature is subject to a Hunter's Mark.",
@@ -1817,10 +1812,12 @@
 	"RollVariants": "Variant Roll Modes",
 	"RollVariantsTip": "Adds extra context menu options to roll this attack in a special way. When rolled this way, the attack will gain the specified property and activate any associated bonuses/penalties.",
 	"SearchFor": "Search for {term}",
-	"SecondaryCritForm": "Secondary Critical Damage Rolls",
-	"SecondaryCritTip": "Extra damage added here will be included when rolling critical damage",
-	"SecondaryDamageForm": "Secondary Damage Rolls",
-	"SecondaryDamageTip": "Extra damage added here will be included when rolling normal damage",
+	"SecondaryCritForm": "Added Critical Damage Rolls",
+	"SecondaryCritTip": "Included as additional/extra damage when rolling critical damage",
+	"SecondaryDamageForm": "Added Damage Rolls",
+	"SecondaryDamageTip": "Included as additional/extra when rolling normal damage",
+	"SecondaryMissForm": "Added Miss Damage Rolls",
+	"SecondaryMissTip": "Included as additional/extra damage when rolling miss damage",
 	"ShowImage": "Show image",
 	"SortBy": "Sort By",
 	"SpecialFields": "Special Field(s)",
@@ -1832,6 +1829,14 @@
 	"TriggerText": "Trigger Text",
 	"UnknownCondition.Label": "Unknown value",
 	"UnknownCondition.Tip": "No match was found for this id in the current status conditions configuration.",
+  "NOTIFICATIONS": {
+    "ammoInsufficient": "The {resourceType} requires {quantity} of '{target}' but the character only has {ammoCount}",
+    "ammoMissing": "The {resourceType} requires ammunition, but none could be found on the character",
+    "ammoUncounted": "The {resourceType} requires ammunition, but the quantity ('{quantity}') was empty",
+    "ammoUntyped": "The {resourceType} requires ammunition, but the type ('{target}') was empty",
+    "cantRoll": "You may not make an Attack Roll with this Item.",
+    "cantDamage": "You may not make a Damage Roll with this Item."
+  },
 	"Yes": "Yes"
 },
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -262,8 +262,10 @@
 "DND4E.ConsumableAmmunition": "Ammunition",
 "DND4E.ConsumableFood": "Food",
 "DND4E.ConsumableLastChargeWarn": "This is the last charge of this unit and consuming it will also reduce the item's quantity by 1",
+"DND4E.ConsumableLoaded": "Loaded",
 "DND4E.ConsumablePoison": "Poison",
 "DND4E.ConsumablePotion": "Potion",
+"DND4E.ConsumablePrepared": "Prepared",
 "DND4E.ConsumableScroll": "Scroll",
 "DND4E.ConsumableTrinket": "Trinket",
 "DND4E.ConsumableUnitWarn": "units remaining",
@@ -1393,23 +1395,16 @@
 },
 
 "DND4E.MACROS": {
-    "ACTIVATION": {
-        "Label": "Activation",
-        "Both": "Before AND After Item Use",
-        "Manual": "Manual",
-        "Pre": "Before Item Use",
-        "Post": "After Item Use",
-        "Sub": "Replace Item Use",
-        "HookComBon": {
-        "Attacker": "Hook: Evaluate Common Attack Bonuses - Attacker",
-            "Target": "Hook: Evaluate Common Attack Bonuses - Target"
-        },
-        "HookPreAttack": {
-            "Attacker": "Hook: Pre Attack Roll - Attacker",
-            "Target": "Hook: Pre Attack Roll - Target"
-        },
-        "HookEvalDef": "Hook: Evaluate Target Defense"
-    }
+  "ACTIVATION": {
+    "Label": "Activation",
+    "Both": "Before AND After Item Use",
+    "Manual": "Manual",
+    "Pre": "Before Item Use",
+    "Post": "After Item Use",
+    "Sub": "Replace Item Use",
+    "HookComBon": "Hook: Evaluate Common Attack Bonuses",
+    "HookPreAttack": "Hook: Pre Attack Roll"
+  }
 },
 
 "DND4E.Movement":{
@@ -1817,10 +1812,12 @@
 	"RollVariants": "Variant Roll Modes",
 	"RollVariantsTip": "Adds extra context menu options to roll this attack in a special way. When rolled this way, the attack will gain the specified property and activate any associated bonuses/penalties.",
 	"SearchFor": "Search for {term}",
-	"SecondaryCritForm": "Secondary Critical Damage Rolls",
-	"SecondaryCritTip": "Extra damage added here will be included when rolling critical damage",
-	"SecondaryDamageForm": "Secondary Damage Rolls",
-	"SecondaryDamageTip": "Extra damage added here will be included when rolling normal damage",
+	"SecondaryCritForm": "Added Critical Damage Rolls",
+	"SecondaryCritTip": "Included as additional/extra damage when rolling critical damage",
+	"SecondaryDamageForm": "Added Damage Rolls",
+	"SecondaryDamageTip": "Included as additional/extra when rolling normal damage",
+	"SecondaryMissForm": "Added Miss Damage Rolls",
+	"SecondaryMissTip": "Included as additional/extra damage when rolling miss damage",
 	"ShowImage": "Show image",
 	"SortBy": "Sort By",
 	"SpecialFields": "Special Field(s)",
@@ -1832,6 +1829,14 @@
 	"TriggerText": "Trigger Text",
 	"UnknownCondition.Label": "Unknown value",
 	"UnknownCondition.Tip": "No match was found for this id in the current status conditions configuration.",
+  "NOTIFICATIONS": {
+    "ammoInsufficient": "The {resourceType} requires {quantity} of '{target}' but the character only has {ammoCount}",
+    "ammoMissing": "The {resourceType} requires ammunition, but none could be found on the character",
+    "ammoUncounted": "The {resourceType} requires ammunition, but the quantity ('{quantity}') was empty",
+    "ammoUntyped": "The {resourceType} requires ammunition, but the type ('{target}') was empty",
+    "cantAttack": "You may not make an Attack Roll with this Item.",
+    "cantDamage": "You may not make a Damage Roll with this Item."
+  },
 	"Yes": "Yes"
 },
 

--- a/module/applications/sheets/actor-sheet.mjs
+++ b/module/applications/sheets/actor-sheet.mjs
@@ -582,7 +582,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 			this._checkItemAvailable(i);
 			i.hasUses = item.system.uses && (item.system.preparedMaxUses > 0) && (item.system.uses.per != "");
 			i.isDepleted = i.hasUses && (item.system.uses.value === 0);
-			i.isUnavailable = i.isDepleted || i.system.notAvailable || (["weapon", "equipment"].includes(item.type) && !item.system.equipped);
+			i.isUnavailable = i.isDepleted || i.system.notAvailable || (["weapon", "equipment","consumable"].includes(item.type) && !item.system?.equipped);
 			inventory[i.type].items.push(i);
 		}
 
@@ -878,7 +878,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 	};
 
 	_checkItemAvailable(itemData) {
-		if ((!itemData.system.uses.value && itemData.system.preparedMaxUses) || ((itemData.type === "power") && !itemData.system.prepared)) {
+		if ((!itemData.system.uses.value && itemData.system.preparedMaxUses && itemData.system.uses.per) || ((itemData.type === "power") && !itemData.system.prepared)) {
 			itemData.system.notAvailable = true;
 		}
 		

--- a/module/applications/sheets/item-sheet.mjs
+++ b/module/applications/sheets/item-sheet.mjs
@@ -47,6 +47,8 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			deleteDamage: ItemSheet4e.#onDamageControl,
 			addCriticalDamage: ItemSheet4e.#onDamageControl,
 			deleteCriticalDamage: ItemSheet4e.#onDamageControl,
+			addMissDamage: ItemSheet4e.#onDamageControl,
+			deleteMissDamage: ItemSheet4e.#onDamageControl,
 			addDamageImp: ItemSheet4e.#onDamageControl,
 			deleteDamageImp: ItemSheet4e.#onDamageControl,
 			addCriticalDamageImp: ItemSheet4e.#onDamageControl,
@@ -264,7 +266,7 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 		context.userInfo = game.user;
 
 		context.itemType = itemData.type;
-		context.itemTypeLabel = itemData.type.titleCase();
+		context.itemTypeLabel = _loc(`TYPES.Item.${itemData.type}`);
 		context.itemStatus = this._getItemStatus(itemData);
 		context.itemProperties = this._getItemProperties(itemData);
 		
@@ -324,6 +326,8 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			context.damageTypeOptions = { ...CONFIG.DND4E.damageTypes };
 			delete context.damageTypeOptions.damage;
 			delete context.damageTypeOptions.ongoing;
+      context.equippable = ['trinket','wondrous','other'].includes(itemData.system.consumableType);
+			context.hasEnhance = ['ammo'].includes(itemData.system.consumableType);
 		}
 
 		if (itemData.type === "equipment") {
@@ -390,7 +394,7 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			context.itemData = context.itemData.toSorted((a, b) => (a.sort || 0) - (b.sort || 0));
 		}
 
-		if (itemData.system?.rangeType) {
+		if (itemData.system?.rangeType && itemData.system?.consumableType != 'ammo') {
 			if (!["personal", "closeBurst", "closeBlast", "", "touch"].includes(itemData.system.rangeType)) itemData.system.isRange = true;
 			if (["closeBurst", "closeBlast", "rangeBurst", "rangeBlast", "wall"].includes(itemData.system.rangeType)) itemData.system.isArea = true;
 			if (["none", "enemies"].includes(itemData.system.autoTarget.mode)) itemData.system.excludeUserFromTargeting = true;
@@ -652,6 +656,8 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 	static #onConfigureSource(event, target) {
 		return this._renderChild(new SourceConfig({ document: this.item, keyPath: "system.source" }));
 	}
+  
+
 
 	async shareItem() {
 		let changeBack = false;
@@ -764,11 +770,11 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 		const actor = this.item.actor;
 
 		// Attributes (and Resources)
-		// this can work separate to an actor as the actors model is known at compile time
+		// This can work separate to an actor, as the actor's model is known at compile time
 		// if separate from an actor it will default to the PC model, as unlikely to be set with an NPC
 		if ((consume.type === "attribute") || (consume.type === "resource") || (consume.type === "currency") || (consume.type === "ritualcomp")) {
 			
-			/* Removed the logic to use token bar attributes in v13, as this was no longer returning the full set of attributes. Insetad using the actor model for all cases. - Fox
+		/* Removed the logic to use token bar attributes in v13, as this was no longer returning the full set of attributes. Instead using the actor model for all cases. - Fox
 		if (actor) {
 			const attributes = TokenDocument4e.getTrackedAttributes(actor.system)
 			attributes.bar.forEach(a => a.push("value"));
@@ -848,12 +854,12 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			/*}*/
 		}
 
-		// All the rest of them require the actor, because they are very tied to that individual actors stuff
+		// All the rest of them require the actor, because they are very tied to that individual actor's stuff
 		if (!actor) return {};
 
 		// Ammunition
 		else if (consume.type === "ammo") {
-			return { "": _loc("DND4E.None"), ...actor.itemTypes.consumable.reduce((ammo, i) => {
+			return { "": _loc("DND4E.None"), "auto": _loc("DND4EUI.Auto"), ...actor.itemTypes.consumable.reduce((ammo, i) => {
 				if (i.system.consumableType === "ammo") {
 					ammo[i.id] = `${i.name} (${i.system.quantity})`;
 				}
@@ -982,10 +988,8 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 		if (item?.type === "weapon") {
 			props.push(`<li class="weapon-summary">${CONFIG.DND4E.weaponTypes[item.system.weaponType]}</li>`);
 			const shortType = item.system.weaponType.substring(0, 3) || "";
-			
-			if (item.system.enhance != 0) {				
-				props.push(`<li class="enhancement">${_loc("DND4E.Enhancement")}\n +${item.system.enhance}&nbsp;${_loc("DND4E.RollsAtkDmg")}</li>`);
-			}
+						
+			if (labels.enh) props.push(`<li class="enhancement">${labels.enh}</li>`);
 
 			props.push(...Object.entries(item.system.properties)
 				.filter(e => (e[1] === true) && (e[0] != shortType))
@@ -1042,9 +1046,13 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 		else if (item.type === "ritual") {
 			if (labels.category) props.push(`<li class="category">${labels.category}</li>`);
 		}
+    
+		else if (item.type === "consumable"){
+			if (labels.enh) props.push(`<li class="enhancement">${labels.enh}</li>`);
+    }
 		
 		// Action type
-		if ((item.type !== "power") && item.system?.actionType) {
+		if ((item.type !== "power") && item.system?.actionType && item.system?.consumableType != 'ammo') {
 			if (item.system.actionType) {
 				const actionTypeLabel = CONFIG.DND4E.itemActionTypes[item.system.actionType] ?? CONFIG.DND4E.abilityActivationTypes[item.system.actionType]?.label;
 				props.push(`<li class="action ${item.system.actionType}">${actionTypeLabel ?? item.system.actionType}</li>`);
@@ -1163,10 +1171,10 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 
 	/* -------------------------------------------- */
 
-	static async #onExecuteMacro(event, target) {
+	static async #onExecuteMacro(event, target){
 		await this.submit({ preventClose: true });
-		const macroIndex = event.target.getAttribute("data-macro-index");
-		return macros.executeMacro(this.document, this.document.system.macros[macroIndex]);
+    const macroIndex = event.target.getAttribute("data-macro-index");
+		return macros.executeMacro(this.document,this.document.system.macros[macroIndex]);
 	}
 	
 	/* -------------------------------------------- */
@@ -1211,6 +1219,22 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			damageCrit.parts.splice(Number(li.dataset.damagePart), 1);
 			return this.item.update({ "system.damageCrit.parts": damageCrit.parts });
 		}
+	
+		// Add new Miss damage component
+		if (action === "addMissDamage") {
+			await this.submit(event); // Submit any unsaved changes
+			const damageMiss = this.item.system.damageMiss;
+			return this.item.update({ "system.damageMiss.parts": damageMiss.parts.concat([{ formula: "", type: "" }]) });
+		}
+
+		// Remove a Miss damage component
+		if (action === "deleteMissDamage") {
+			await this.submit(event); // Submit any unsaved changes
+			const li = target.closest(".damage-part");
+			const damageMiss = foundry.utils.duplicate(this.item.system.damageMiss);
+			damageMiss.parts.splice(Number(li.dataset.damagePart), 1);
+			return this.item.update({ "system.damageMiss.parts": damageMiss.parts });
+		}
 
 		// Add new implement damage component
 		if (action === "addDamageImp") {
@@ -1243,6 +1267,7 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			damageCritImp.parts.splice(Number(li.dataset.damagePart), 1);
 			return this.item.update({ "system.damageCritImp.parts": damageCritImp.parts });
 		}
+
 		// Add new damage res
 		if (action === "addDamageRes") {
 			await this.submit(event); // Submit any unsaved changes
@@ -1548,30 +1573,30 @@ export default class ItemSheet4e extends foundry.applications.api.HandlebarsAppl
 			await this.submit(event); // Submit any unsaved changes
 			const macros = this.item.system.macros;
 			return this.item.update({ "system.macros": macros.concat([{
-				type: "script",
-				scope: "global",
-				launchOrder: "off",
-				command: "",
-				author: "",
-				autoanimationHook: "",
-				enabled: true,
-			}]) });
+        "type": "script",
+        "scope": "global",
+        "launchOrder": "off",
+        "command": "",
+        "author": "",
+        "autoanimationHook": "",
+        "enabled": true
+      }])});
 		}
 
 		// Remove a damage component
 		if (action === "deleteMacro") {
 			await this.submit(event); // Submit any unsaved changes
 			const macro = target.closest(".macro");
-			const index = macro.getAttribute("data-macro-number");
-			const macros = foundry.utils.duplicate(this.item.system.macros);
+      const index = macro.getAttribute("data-macro-number");
+      const macros = foundry.utils.duplicate(this.item.system.macros);
 			macros.splice(macro.getAttribute("data-macro-number"), 1);
 			return this.item.update({ "system.macros": macros });
 		}
     
 		// Expand macro text
 		if (action === "expandMacro") {
-			target.parentElement.classList.toggle("collapsed");
-		}
+      target.parentElement.classList.toggle("collapsed");
+    }
 	
 	}
 

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -27,7 +27,7 @@ export default class ConsumableData extends foundry.abstract.TypeDataModel {
 				autoDestroy: new BooleanField({ initial: false }),
 				max: new StringField({ initial: "1" }),
 				value: new NumberField({ initial: 1, min: 0, integer: true }),
-				per: new StringField({ initial: "charges" }),
+				per: new StringField({ initial: "" }),
 			}),
 			target: new StringField({ initial: "" }),
 			rangeType: new StringField({ initial: "" }),
@@ -56,6 +56,7 @@ export default class ConsumableData extends foundry.abstract.TypeDataModel {
 				initialKeysOnly: true,
 			}),
 			keywordsCustom: new StringField({ initial: "" }),
+			enhance: new NumberField({ initial: 0, integer: true })
 		};
 	}
 

--- a/module/data/item/templates/attack-damage.mjs
+++ b/module/data/item/templates/attack-damage.mjs
@@ -59,6 +59,9 @@ export default class AttackAndDamageTemplate extends foundry.abstract.DataModel 
 			damageCrit: new SchemaField({
 				parts: new ArrayField(new DamagePartsField(), { initial: [] }),
 			}),
+			damageMiss: new SchemaField({
+				parts: new ArrayField(new DamagePartsField(), { initial: [] }),
+			}),
 			damageCritImp: new SchemaField({
 				parts: new ArrayField(new DamagePartsField(), { initial: [] }),
 			}),

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -643,12 +643,11 @@ export default class Item4e extends Item {
 			try {
 			
 				if (system?.armour?.enhance) {
-					let enhString = `${_loc("DND4E.Enhancement")} +${system.armour.enhance}`;
-					//The strings below begin with a non-breaking space character. Don't delete it unless you want to break the text wrapping!
+					let enhString = `${_loc("DND4E.Enhancement")}<br />+${system.armour.enhance}`;
 					if (system.armour.type === "armour") {
-						enhString += `&nbsp;${_loc("DND4E.DefAC")}`;
+						enhString += ` ${_loc("DND4E.DefAC")}`;
 					} else {
-						enhString += `&nbsp;${_loc("DND4E.DefFort")}/${_loc("DND4E.DefRef")}/${_loc("DND4E.DefWil")}`;
+						enhString += ` ${_loc("DND4E.DefFort")}/${_loc("DND4E.DefRef")}/${_loc("DND4E.DefWil")}`;
 					}
 					labels.enh = enhString;
 				}
@@ -673,7 +672,10 @@ export default class Item4e extends Item {
 		
 		// Weapons
 		else if (itemData.type === "weapon") {
-			try {
+			try {			
+        if (system.enhance != 0) {				
+          labels.enh = `${_loc("DND4E.Enhancement")}<br />+${system.enhance} ${_loc("DND4E.RollsAtkDmg")}`;
+        }
 				for (const [key, value] of Object.entries(system?.properties)) {
 					if (value && !((key == "imp") && (system.weaponType == "implement"))) {
 						const newKey = `props${key}`;
@@ -766,6 +768,47 @@ export default class Item4e extends Item {
 				} catch(e) {
 					console.error("Failed to get the category name for this ritual, probably due to an un-migrated item. Manually setting the category should fix this.");
 				}
+			}      
+      if (system.consume?.amount && system.consume?.type) {
+        let resourceLabel;
+        if (["ritualcomp", "currency"].includes(system.consume.type)) {
+          const resourceTarget = system.consume.target.split(".")[2];
+          if (system.consume?.type === "ritualcomp") {
+            resourceLabel = DND4E.ritualComponents[resourceTarget];
+          } else if (system.consume?.type === "currency") {
+            resourceLabel = DND4E.currencies[resourceTarget];
+          }
+        }
+        else if (system.consume?.type === "attribute") {
+          const resourceTarget = system.consume.target.split(".")[1];
+
+          if (DND4E.ritualComponents[resourceTarget]) {
+            resourceLabel = DND4E.ritualComponents[resourceTarget];
+          }
+          else if (DND4E.currencyConversion[resourceTarget]) {
+            resourceLabel = DND4E.currencies[resourceTarget];
+          }
+          else if (resourceTarget === "hp") {
+            resourceLabel = _loc("DND4E.HP");
+          }
+          else if (resourceTarget === "surges") {
+            resourceLabel = _loc("DND4E.HealingSurges");
+          }
+        }
+        if (resourceLabel) {
+          labels.component = `<strong>${_loc("DND4E.Component")}:</strong> ${resourceLabel} (${system.consume.amount})`;
+        }
+      }
+			// Duration Label
+			let dur = system.duration || {};
+			if (["inst", "perm"].includes(dur.units)) dur.value = null;
+			labels.duration = dur.value ? `<strong>${_loc("DND4E.Duration")}:</strong> ${[dur.value, C.timePeriods[dur.units]].filterJoin(" ")}` : null;
+
+			// CastTime Label
+			if (system.castTime) {
+				let castTime = system.castTime || {};
+				if (["inst", "perm"].includes(castTime.units)) castTime.value = null;
+				labels.castTime = `<strong>${_loc("DND4E.CastTime")}:</strong> ${[castTime.value, C.timePeriods[castTime.units]].filterJoin(" ")}`;
 			}
 		}
 
@@ -782,10 +825,13 @@ export default class Item4e extends Item {
 				}
 				// non healing damage expressions didn't work anyway
 			}
+			if (system.consumableType == 'ammo' && system?.enhance) {				
+				labels.enh = `${_loc("DND4E.Enhancement")}<br />+${system.enhance} ${_loc("DND4E.RollsAtkDmg")}`;
+			}
 		}	
 		
 		// Activated Items other than powers/features
-		if (!["power", "feature"].includes(itemData.type) && ("activation" in system)) {
+		if (!["power", "feature"].includes(itemData.type) && system?.consumableType != 'ammo' && ("activation" in system)) {
 			// Ability Activation Label
 			let act = system.activation || {};
 			if (act) labels.activation = [act.cost, C.abilityActivationTypes[act.type]].filterJoin(" ");
@@ -807,19 +853,6 @@ export default class Item4e extends Item {
 			}
 			labels.range = [rng.value, rng.long ? `/ ${rng.long}` : null, C.distanceUnits[rng.units]].filterJoin(" ");
 
-			// Duration Label
-			let dur = system.duration || {};
-			if (["inst", "perm"].includes(dur.units)) dur.value = null;
-
-			labels.duration = dur.value ? `<strong>${_loc("DND4E.Duration")}:</strong> ${[dur.value, C.timePeriods[dur.units]].filterJoin(" ")}` : null;
-
-			// CastTime Label
-			if (system.castTime) {
-				let castTime = system.castTime || {};
-				if (["inst", "perm"].includes(castTime.units)) castTime.value = null;
-				labels.castTime = `<strong>${_loc("DND4E.CastTime")}:</strong> ${[castTime.value, C.timePeriods[castTime.units]].filterJoin(" ")}`;
-			}
-
 			// Attribute Label
 			if (system.attribute) {
 				const attribute = system.attribute.split(".")[1];
@@ -828,40 +861,6 @@ export default class Item4e extends Item {
 				}
 				else if (DND4E.skills[attribute]) {
 					labels.attribute = `<strong>${_loc("DND4E.Skill")}:</strong> ${DND4E.skills[attribute]?.label}`;
-				}
-			}
-
-			//Component type + cost Label
-			if (itemData.type === "ritual") {
-				if (system.consume?.amount && system.consume?.type) {
-					let resourceLabel;
-					if (["ritualcomp", "currency"].includes(system.consume.type)) {
-						const resourceTarget = system.consume.target.split(".")[2];
-						if (system.consume?.type === "ritualcomp") {
-							resourceLabel = DND4E.ritualComponents[resourceTarget];
-						} else if (system.consume?.type === "currency") {
-							resourceLabel = DND4E.currencies[resourceTarget];
-						}
-					}
-					else if (system.consume?.type === "attribute") {
-						const resourceTarget = system.consume.target.split(".")[1];
-
-						if (DND4E.ritualComponents[resourceTarget]) {
-							resourceLabel = DND4E.ritualComponents[resourceTarget];
-						}
-						else if (DND4E.currencyConversion[resourceTarget]) {
-							resourceLabel = DND4E.currencies[resourceTarget];
-						}
-						else if (resourceTarget === "hp") {
-							resourceLabel = _loc("DND4E.HP");
-						}
-						else if (resourceTarget === "surges") {
-							resourceLabel = _loc("DND4E.HealingSurges");
-						}
-					}
-					if (resourceLabel) {
-						labels.component = `<strong>${_loc("DND4E.Component")}:</strong> ${resourceLabel} (${system.consume.amount})`;
-					}
 				}
 			}
 
@@ -909,75 +908,77 @@ export default class Item4e extends Item {
 		}
 		
 		// Range, action
-		try {
-			//Action
-			if (system?.actionType) {
-				labels.action = C.abilityActivationTypes[system.actionType].label;
-			}
-			
-			//Range
-			if (["power", "consumable"].includes(itemData.type) && system?.rangeType) {
-				let rangeString = "";
-				if (system?.rangeType === "weapon") {
-					const weaponUse = (itemData.actor ? utils.getWeaponUse(system, itemData.actor) : null);
-					if (weaponUse != null) {
-						if (weaponUse.isRanged) {
-							rangeString = `${_loc("DND4E.Ranged")} ${weaponUse.system.range.value}/${weaponUse.system.range.value}`;
-						} else {
-							rangeString = _loc("DND4E.Melee");
-							if (weaponUse.system.properties.rch) {
-								rangeString += " 2";
-							} else {
-								rangeString += " 1";
-							}							
-						}
-					} else {
-						if (system?.weaponType === "melee") {
-							rangeString = _loc("DND4E.WeaponMelee");
-						} else if (system?.weaponType === "ranged") {
-							rangeString = _loc("DND4E.WeaponRanged");
-						} else {
-							rangeString = C.rangeType.weapon.label;
-						}
-					}
-				} else {
-					const isRange = !["personal", "closeBurst", "closeBlast", "", "touch"].includes(itemData.system.rangeType);
-					const isArea = ["closeBurst", "closeBlast", "rangeBurst", "rangeBlast", "wall"].includes(itemData.system.rangeType);
-					
-					rangeString += C.rangeType[system.rangeType].label;
-					
-					if (isArea) {
-						let areaString = system.area || "";
-						if (this.actor && areaString) {
-							areaString = utils.evaluateFormula(areaString, actorData, { strict: true, contextName: "areaString" });
-						}
-						rangeString += ` ${areaString}`;
-					}
-					
-					if (isArea && isRange) rangeString += ` ${_loc("DND4E.RangeWithin")}`;
-					
-					if (isRange) {
-						let rangeValue = system.rangePower || "";
-						if (this.actor && rangeValue) {
-							rangeValue = utils.evaluateFormula(rangeValue, actorData, { strict: true, contextName: "rangeValue" });
-						}
-						rangeString += ` ${rangeValue}`;
-					}
-					
-					if (isRange && system.range?.long && !isArea) {
-						let longRangeValue = system.range.long;
-						if (this.actor) {
-							longRangeValue = utils.evaluateFormula(longRangeValue, actorData, { strict: true, contextName: "longRangeValue" });
-						}
-						rangeString += `/${longRangeValue}`;
-					}
-				}
-				if (rangeString != "") labels.range = rangeString;
-			}
-		} catch(e) {
-			console.error(`Item labels failed for ${itemData.type}: ${itemData.name}. Item data has been dumped to debug. ${e}`);
-			console.debug(itemData);
-		}
+		if (system?.consumableType != 'ammo') {
+      try {
+        //Action
+        if (system?.actionType) {
+          labels.action = C.abilityActivationTypes[system.actionType].label;
+        }
+        
+        //Range
+        if (["power", "consumable"].includes(itemData.type) && system?.rangeType) {
+          let rangeString = "";
+          if (system?.rangeType === "weapon") {
+            const weaponUse = (itemData.actor ? utils.getWeaponUse(system, itemData.actor) : null);
+            if (weaponUse != null) {
+              if (weaponUse.isRanged) {
+                rangeString = `${_loc("DND4E.Ranged")} ${weaponUse.system.range.value}/${weaponUse.system.range.value}`;
+              } else {
+                rangeString = _loc("DND4E.Melee");
+                if (weaponUse.system.properties.rch) {
+                  rangeString += " 2";
+                } else {
+                  rangeString += " 1";
+                }							
+              }
+            } else {
+              if (system?.weaponType === "melee") {
+                rangeString = _loc("DND4E.WeaponMelee");
+              } else if (system?.weaponType === "ranged") {
+                rangeString = _loc("DND4E.WeaponRanged");
+              } else {
+                rangeString = C.rangeType.weapon.label;
+              }
+            }
+          } else {
+            const isRange = !["personal", "closeBurst", "closeBlast", "", "touch"].includes(itemData.system.rangeType);
+            const isArea = ["closeBurst", "closeBlast", "rangeBurst", "rangeBlast", "wall"].includes(itemData.system.rangeType);
+            
+            rangeString += C.rangeType[system.rangeType].label;
+            
+            if (isArea) {
+              let areaString = system.area || "";
+              if (this.actor && areaString) {
+                areaString = utils.evaluateFormula(areaString, actorData, { strict: true, contextName: "areaString" });
+              }
+              rangeString += ` ${areaString}`;
+            }
+            
+            if (isArea && isRange) rangeString += ` ${_loc("DND4E.RangeWithin")}`;
+            
+            if (isRange) {
+              let rangeValue = system.rangePower || "";
+              if (this.actor && rangeValue) {
+                rangeValue = utils.evaluateFormula(rangeValue, actorData, { strict: true, contextName: "rangeValue" });
+              }
+              rangeString += ` ${rangeValue}`;
+            }
+            
+            if (isRange && system.range?.long && !isArea) {
+              let longRangeValue = system.range.long;
+              if (this.actor) {
+                longRangeValue = utils.evaluateFormula(longRangeValue, actorData, { strict: true, contextName: "longRangeValue" });
+              }
+              rangeString += `/${longRangeValue}`;
+            }
+          }
+          if (rangeString != "") labels.range = rangeString;
+        }
+      } catch(e) {
+        console.error(`Item labels failed for ${itemData.type}: ${itemData.name}. Item data has been dumped to debug. ${e}`);
+        console.debug(itemData);
+      }
+    }
 
 		// Assign labels
 		this.labels = labels;
@@ -1113,8 +1114,9 @@ export default class Item4e extends Item {
 		if (this.type === "feat") {
 			let configured = await this._rollFeature(configureDialog);
 			if ( configured === false ) return;
-		}
-		else*/ if (this.type === "consumable") {
+		}*/
+		//else 
+    if (this.type === "consumable") {
 			let configured = await this._rollConsumable(configureDialog);
 			if (configured === false) return;
 		}
@@ -1321,6 +1323,9 @@ export default class Item4e extends Item {
 				quantity = consumed || 0;
 				break;
 			case "ammo":
+        consumed = utils.getAmmoUse(itemData, actor);
+				quantity = consumed ? consumed.system.quantity : 0;
+				break;
 			case "material":
 				consumed = actor.items.get(consume.target);
 				quantity = consumed ? consumed.system.quantity : 0;
@@ -1601,13 +1606,14 @@ export default class Item4e extends Item {
 		const itemData = this.getRollData({ variance: options.variance }).item;
 		const actorData = this.actor;
 		options.bonuses = foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses);
-		// itemData.weaponUse = 2nd dropdown - default/none/weapon
-		// itemData.weaponType = first dropdown: melee/ranged/implement/none etc...
 		// find details on the weapon being used, if any.   This is null if no weapon is being used.
-		
+		// itemData.weaponUse = 2nd dropdown - default/none/weapon
+		// itemData.weaponType = first dropdown: melee/ranged/implement/none etc...		
 		//console.debug(options);
 		const weaponUse = utils.getWeaponUse(itemData, this.actor);
 		const weaponData = weaponUse?.getRollData().item;
+		const weaponAmmo = weaponUse ? utils.getAmmoUse(weaponData, this.actor) : null;
+		const powerAmmo = utils.getAmmoUse(itemData, this.actor) || null;
 
 		if (utils.lacksRequiredWeaponEquipped(itemData, weaponUse)) {
 			ui.notifications.error(_loc("DND4E.LackRequiredWeapon"));
@@ -1615,7 +1621,7 @@ export default class Item4e extends Item {
 		}
 
 		if (!this.hasAttack) {
-			ui.notifications.error("You may not place an Attack Roll with this Item.");
+			ui.notifications.error("DND4EUI.NOTIFICATIONS.cantAttack");
 			return null;
 		}
 
@@ -1655,11 +1661,11 @@ export default class Item4e extends Item {
 			options.formulaInnerData = utils.getDataObject(itemData.attack.formula, actorData.getRollData());
 		}
 
-		const handlePowerAndWeaponAmmoBonuses = (onHasBonus, consumable, resourceType) => {
+		const handlePowerAndWeaponAmmoBonuses = (onHasBonus, ammo, consumable, resourceType) => {
 			if (consumable?.type === "ammo") {
 				if (utils.isNonEmpty(consumable.target) && utils.isNonEmpty(consumable.amount))
 				{
-					const ammo = this.actor?.items.get(consumable.target);
+					//const ammo = this.actor?.items.get(consumable.target);
 					if (ammo) {
 						const ammoCount = ammo.system.quantity;
 						if (ammoCount && (ammoCount - consumable.amount >= 0)) {
@@ -1669,22 +1675,22 @@ export default class Item4e extends Item {
 							}
 						}
 						else {
-							ui.notifications.warn(_loc("The {resourceType} requires {quantity} of '{target}' but the character only has {ammoCount}",
+							ui.notifications.warn(_loc("DND4EUI.NOTIFICATIONS.ammoInsufficient",
 								{ resourceType, ammoCount, target: ammo.name, quantity: consumable.amount }));
 						}
 					}
 					else {
-						ui.notifications.warn(_loc("The {resourceType} requires a ammunition but none could be found on the character",
+						ui.notifications.warn(_loc("DND4EUI.NOTIFICATIONS.ammoMissing",
 							{ resourceType, target: consumable.target }));
 					}
 				}
 				else {
 					if (!utils.isNonEmpty(consumable.target)) {
-						ui.notifications.warn(_loc("The {resourceType} requires ammunition, but the type ('{target}') was empty",
+						ui.notifications.warn(_loc("DND4EUI.NOTIFICATIONS.ammoUntyped",
 							{ resourceType, target: consumable.target, quantity: consumable.amount }));
 					}
 					if (!utils.isNonEmpty(consumable.quantity)) {
-						ui.notifications.warn(_loc("The {resourceType} requires ammunition, but the quantity ('{quantity}') was empty",
+						ui.notifications.warn(_loc("DND4EUI.NOTIFICATIONS.ammoUncounted",
 							{ resourceType, target: consumable.target, quantity: consumable.amount }));
 					}
 				}
@@ -1693,24 +1699,24 @@ export default class Item4e extends Item {
 
 		// Ammunition Bonus from power.
 		delete this._ammo;
-		const powerHasAmmoWithBonus = (ammo, ammoBonus) => {
+		const powerHasAmmoWithBonus = (powerAmmo, ammoBonus) => {
 			parts.push("@ammo");
 			rollData["ammo"] = ammoBonus;
 			title += ` [${ammo.name}]`;
-			this._ammo = ammo;
+			this._ammo = powerAmmo;
 		};
-		handlePowerAndWeaponAmmoBonuses(powerHasAmmoWithBonus, itemData.consume, "power");
+		handlePowerAndWeaponAmmoBonuses(powerHasAmmoWithBonus, powerAmmo, itemData.consume, "power");
 	
 		// Ammunition Bonus from weapon.
-		if (weaponUse) {
+		if (weaponAmmo) {
 			delete weaponUse._ammo;
-			const weaponHasAmmoWithBonus = (ammo, ammoBonus) => {
+			const weaponHasAmmoWithBonus = (weaponAmmo, ammoBonus) => {
 				if (parts[parts.length - 1] !== "@ammo") parts.push("@ammo");
 				rollData["ammo"] ? rollData["ammo"] += ammoBonus : rollData["ammo"] = ammoBonus;
 				title += ` [${ammo.name}]`;
-				weaponUse._ammo = ammo;
+				weaponUse._ammo = weaponAmmo;
 			};
-			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponUse.system.consume, "weapon used by the power");
+			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponAmmo, weaponUse.system.consume, "weapon used by the power");
 		}
 		
 		await utils.applyEffects(rollData, actorData, itemData, weaponData, "attack", null, null, options);
@@ -1777,9 +1783,10 @@ export default class Item4e extends Item {
 		const weaponUse = utils.getWeaponUse(itemData, this.actor);
 		const weaponData = weaponUse?.getRollData().item;
 
-		if (utils.lacksRequiredWeaponEquipped(itemData, weaponUse)) {
-			return;
-		}
+		if (utils.lacksRequiredWeaponEquipped(itemData, weaponUse)) return;
+    
+		const powerAmmo = utils.getAmmoUse(itemData, this.actor) || null;
+		const weaponAmmo = weaponUse ? utils.getAmmoUse(weaponData, this.actor) : null;
 
 		const rollData = this.getRollData(options);
 
@@ -1798,42 +1805,41 @@ export default class Item4e extends Item {
 			options.formulaInnerData = utils.getDataObject(itemData.attack.formula, actorData.getRollData());
 		}
 
-		const handlePowerAndWeaponAmmoBonuses = (onHasBonus, consumable, resourceType) => {
-			if (consumable?.type === "ammo") {
-				if (utils.isNonEmpty(consumable.target) && utils.isNonEmpty(consumable.amount))
+		const handlePowerAndWeaponAmmoBonuses = (onHasBonus, ammo, consumable, resourceType) => {
+			if (ammo) {
+        //console.debug(ammo);
+				if (utils.isNonEmpty(ammo.id) && utils.isNonEmpty(consumable.amount))
 				{
-					const ammo = this.actor?.items.get(consumable.target);
-					if (ammo) {
-						const ammoCount = ammo.system.quantity;
-						if (ammoCount && (ammoCount - consumable.amount >= 0)) {
-							let ammoBonus = ammo.system.attackBonus;
-							if (ammoBonus) {
-								onHasBonus(ammo, ammoBonus);
-							}
-						}
-					}
+          //const ammo = this.actor?.items.get(consumable.target);
+          const ammoCount = ammo.system.quantity;
+          if (ammoCount && (ammoCount - consumable.amount >= 0)) {
+            let ammoBonus = ammo.system.attack.formula;
+            if (ammoBonus) {
+              onHasBonus(ammo, ammoBonus);
+            }
+          }
 				}
 			}
 		};
 
 		// Ammunition Bonus from power.
 		delete this._ammo;
-		const powerHasAmmoWithBonus = (ammo, ammoBonus) => {
+		const powerHasAmmoWithBonus = (powerAmmo, ammoBonus) => {
 			parts.push("@ammo");
 			rollData["ammo"] = ammoBonus;
 			this._ammo = ammo;
 		};
-		handlePowerAndWeaponAmmoBonuses(powerHasAmmoWithBonus, itemData.consume, "power");
+		handlePowerAndWeaponAmmoBonuses(powerHasAmmoWithBonus, powerAmmo, itemData.consume, "power");
 	
 		// Ammunition Bonus from weapon.
 		if (weaponUse) {
 			delete weaponUse._ammo;
-			const weaponHasAmmoWithBonus = (ammo, ammoBonus) => {
+			const weaponHasAmmoWithBonus = (weaponAmmo, ammoBonus) => {
 				if (parts[parts.length - 1] !== "@ammo") parts.push("@ammo");
 				rollData["ammo"] ? rollData["ammo"] += ammoBonus : rollData["ammo"] = ammoBonus;
 				weaponUse._ammo = ammo;
 			};
-			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponUse.system.consume, "weapon used by the power");
+			handlePowerAndWeaponAmmoBonuses(weaponHasAmmoWithBonus, weaponAmmo, weaponUse.system.consume, "weapon used by the power");
 		}
 		await utils.applyEffects(rollData, actorData, itemData, weaponData, "attack", null, null, options);
 
@@ -2099,12 +2105,15 @@ export default class Item4e extends Item {
 			ui.notifications.error(_loc("DND4E.LackRequiredWeapon"));
 			return null;
 		}
+    
+		const weaponAmmo = weaponUse ? utils.getAmmoUse(weaponData, actorData) : null;
+		const powerAmmo = utils.getAmmoUse(itemData, actorData);
 
 		if (!this.hasDamage) {
-			ui.notifications.error("You may not make a Damage Roll with this Item.");
+			ui.notifications.error(_loc("DND4EUI.NOTIFICATIONS.cantAttack"));
 			return null;
 		}
-		const messageData = { "options.flags.dnd4e.roll": { type: "damage", itemId: this.id } };
+		const messageData = { "flags.dnd4e.roll": { type: "damage", itemId: this.id } };
 
 		// Get roll data
 		const rollData = this.getRollData({ variance: variance });
@@ -2261,31 +2270,42 @@ export default class Item4e extends Item {
 		}
 
 		// Ammunition Damage from power
-		if (this._ammo) {
-			parts.push("@ammo");
-			partsCrit.push("@ammo");
-
-			if (!missDamageFormula.includes("@damageFormula") && !missDamageFormula.includes("@halfDamageFormula")) {
-				partsMiss.push("@ammo");
+		if (powerAmmo) {
+      if(powerAmmo.system?.damage.parts.length > 0){
+        parts.push("@powAmmo");
+        rollData["powAmmo"] = powerAmmo.system.damage.parts.map(p => p.formula).join("+");
+      }
+      if(powerAmmo.system?.damageCrit.parts.length > 0){
+        partsCrit.push("@powAmmoC");
+        rollData["powAmmoC"] = powerAmmo.system.damageCrit.parts.map(p => p.formula).join("+");
+      }
+			if (powerAmmo.system?.damageMiss.parts.length > 0) {
+				partsMiss.push("@powAmmoM");
+        rollData["powAmmoM"] = powerAmmo.system.damageMiss.parts.map(p => p.formula).join("+");
 			}
-
-			rollData["ammo"] = this._ammo.system.damage.parts.map(p => p.formula).join("+");
-			flavor += ` [${this._ammo.name}]`;
+			flavor += ` [${ammo.name}]`;
 			delete this._ammo;
 		}
 	
 		// Ammunition Damage from weapon
 		if (weaponUse) {
-			if (weaponUse._ammo) {
-				parts.push("@ammoW");
-				partsCrit.push("@ammoW");
-
-				if (!missDamageFormula.includes("@damageFormula") && !missDamageFormula.includes("@halfDamageFormula")) {
-					partsMiss.push("@ammoW");
-				}
-
-				rollData["ammoW"] = weaponUse._ammo.system.damage.parts.map(p => p.formula).join(" + ");
-				flavor += ` [${weaponUse._ammo.name}]`;
+      console.debug(weaponUse?._ammo);
+			if (weaponAmmo) {
+        console.debug(weaponAmmo);
+        if(weaponAmmo.system?.damage.parts.length > 0){
+          parts.push("@ammo");
+          rollData["ammo"] = weaponAmmo.system.damage.parts.map(p => p.formula).join("+");
+        }
+        if(weaponAmmo.system?.damageCrit.parts.length > 0){
+          partsCrit.push("@ammoC");
+          rollData["ammoC"] = weaponAmmo.system.damageCrit.parts.map(p => p.formula).join("+");
+        }
+        if (weaponAmmo.system?.damageMiss.parts.length > 0) {
+          partsMiss.push("@ammoM");
+          rollData["ammoM"] = weaponAmmo.system.damageMiss.parts.map(p => p.formula).join("+");
+        }
+        
+				flavor += ` [${weaponAmmo.name}]`;
 				delete weaponUse._ammo;
 			}
 			title += ` with ${weaponUse.name}`;
@@ -2401,7 +2421,7 @@ export default class Item4e extends Item {
 			ui.notifications.error("You may not make a Healing Roll with this Item.");
 			return null;
 		}
-		const messageData = { "options.flags.dnd4e.roll": { type: "healing", itemId: this.id } };
+		const messageData = { "flags.dnd4e.roll": { type: "healing", itemId: this.id } };
 
 		// Get roll data
 		const rollData = this.getRollData();
@@ -2904,8 +2924,14 @@ export default class Item4e extends Item {
 		// Weapon/Implement properties:
 		const weapon = this.type === "weapon" ? this : (this.type == "power" ? utils.getWeaponUse(this.system, this.actor) : null);
 		const weaponData = weapon ? weapon.system : null;
+    const ammo = weaponData ? utils.getAmmoUse(weaponData, this.actor) : utils.getAmmoUse(this.system, this.actor);
+		const ammoData = ammo ? ammo.system : null;
+    
 		if (weaponData) {
 			let enhValue = weaponData.enhance || 0;
+      
+      //Ammo enhancement should override weapon enhancement, if it has one
+      if(ammoData && ammoData?.enhance > 0 ) enhValue = ammoData.enhance;
 			
 			//Using inherent enhancements?
 			if (game.settings.get("dnd4e", "inhEnh")) {

--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -137,6 +137,27 @@ export function getWeaponUse(itemData, actor) {
 }
 
 /**
+ * Determine ammo use for a given weapon or power.
+ * Either the specified ammunition, or a consumable that matches the consumableType.ammo category if itemData.consume.target is set to auto
+ * @param {CharacterData} itemData The weapon/power being used
+ * @param {Actor4e} actor The actor that owns the weapon/power
+ * @returns {Item4e|null} The ammo details, or null if either no suitable ammo is found or itemData.consume.target is set to none.
+ */
+export function getAmmoUse(itemData, actor) {
+	if (!itemData || itemData.consume?.type !== "ammo" || itemData.consume?.target === "none") return null;
+	let ammoUse = null;
+	//If ammo is automatic, find a suitable consumable
+	if (itemData.consume.target === "auto") {
+		return actor.itemTypes.consumable.find((i) =>	{
+			if (i.system.consumableType === "ammo" && i.system.equipped) return i;
+		}, {});
+	} else {
+    ammoUse = actor?.items.get(itemData.consume.target);
+  }
+	return ammoUse;
+}
+
+/**
  * Returns true if we should error out because the power needs a weapon equipped and the character doesn't have one
  * @param itemData The data object of the Power being used
  * @param weaponUse The details of the weapon being used for the power from getWeaponUse
@@ -167,12 +188,17 @@ export async function applyEffects(rollData, actor, powerData = {}, weaponData =
 	const suitableKeywords = ["global"];
 	const effectsToProcess = [];
 	const actorEffects = actor.appliedEffects;
+  //console.debug(powerData);
+  const ammo = weaponData ? getAmmoUse(weaponData, actor) : getAmmoUse(powerData, actor);
+  
 	if (actorEffects.length) {
-		let enhValue = weaponData?.enhance || 0;
 		if (debug) {
 			console.log(`${debug} Debugging ${effectType} effects for ${powerData.name}.	Supplied Weapon: ${weaponData?.name}`);
 		}
-			
+    
+		let enhValue = weaponData?.enhance || 0;
+    //Ammo enhancement should override weapon enhancement, if it has one
+    if(ammo && ammo?.system?.enhance > 0) enhValue = ammo.system.enhance;
 		//Using inherent enhancements?
 		if (game.settings.get("dnd4e", "inhEnh")) {
 			//If our enhancement is lower than the inherent level, adjust it upward
@@ -211,7 +237,7 @@ export async function applyEffects(rollData, actor, powerData = {}, weaponData =
 
 			suitableKeywords.push(powerData.identifier);
 			_addKeywords(suitableKeywords, powerData.damageType);
-			_addKeywords(suitableKeywords, powerData.effectType);
+			_addKeywords(suitableKeywords, powerData.effectType);      
 			if (weaponData) {
 				suitableKeywords.push(weaponData.identifier);
 				_addKeywords(suitableKeywords, weaponData.weaponGroup);
@@ -223,7 +249,11 @@ export async function applyEffects(rollData, actor, powerData = {}, weaponData =
 				}
 				options.weaponUuid = weaponData.uuid;
 			}
-
+      if (ammoData) {
+        options.ammoUuid = ammoData.uuid;
+				_addKeywords(suitableKeywords, ammoData.damageType);
+        _addKeywords(suitableKeywords, ammoData.effectType);
+      }
 			if (powerData.powersource) {
 				suitableKeywords.push(powerData.powersource);
 			}
@@ -514,7 +544,7 @@ async function _applyEffectsInternal(effectsToProcess, suitableKeywords, actor, 
 			const keywords = keyParts.slice(2, -1);
 			for (const keyword of keywords) {
 				if (keyword === "self") {
-					if (options.weaponUuid === effect.itemUuid) {
+					if ([options.weaponUuid,options.ammoUuid].includes(effect.itemUuid)) {
 						continue;
 					} else {
 						return false;

--- a/templates/items/parts/details-consumable.hbs
+++ b/templates/items/parts/details-consumable.hbs
@@ -12,7 +12,7 @@
   <div class="form-group">
     <label class="checkbox">
       <input type="checkbox" name="system.equipped" {{checked system.equipped}}>
-      {{ localize "DND4E.Equipped" }}
+      {{#if (eq system.consumableType 'ammo')}}{{ localize "DND4E.ConsumableLoaded" }}{{else if equippable}}{{ localize "DND4E.Equipped" }}{{else}}{{ localize "DND4E.ConsumablePrepared" }}{{/if}}
     </label>
     <label class="checkbox">
       <input type="checkbox" name="system.identified" {{checked system.identified}}>
@@ -25,260 +25,298 @@
   </div>
 </div>
 
-<h3 class="form-header">{{ localize "DND4E.ItemConsumableUsage" }}</h3>
-  
-<div class="form-group">
-  <label class="auto-card">{{ localize "DND4EUI.PowerCardAuto" }}</label>
-  <span class="checkbox">
-    <input type="checkbox" name="system.autoGenChatPowerCard" data-dtype="Boolean" {{checked system.autoGenChatPowerCard}}>
-  </span>
-</div>
+{{#if (eq system.consumableType 'ammo')}}{{!-- Ammo needs special fields --}}
 
-{{!-- Action Type --}}
-<div class="form-group select">
-  <label>{{ localize "DND4E.ItemActionType" }}</label>
-  <select name="system.actionType">
-    {{selectOptions config.abilityActivationTypes selected=system.actionType labelAttr="label"}}
-  </select>
-</div>
-  
-<div class="form-group range">
-  <label>{{ localize "DND4E.Range" }}</label>
-  <div class="form-fields item-range">
-    <select name="system.rangeType">
-      {{selectOptions config.rangeTypeNoWeapon selected=system.rangeType labelAttr="label"}}
-    </select>
-    {{#if system.isArea}}
-    <span>{{ localize "DND4E.AreaOf" }}</span>
-    <input type="text" name="system.area" value="{{system.area}}">
-    {{/if}}					
-      
-    {{#if system.isRange}}
-    {{#if system.isArea}}<span class="range-within-of">{{ localize "DND4E.RangeWithinOf" }}</span>{{/if}}
-		  
-    {{#unless system.isArea}}
+  {{!-- Enhancement --}}
+  <div class="form-group">    
+    <label data-tooltip="{{ localize 'DND4E.BonusTypeEnhancement' }}">{{ localize 'DND4E.BonusTypeEnhancement' }}:</label>
     <div class="form-fields">
-      {{/unless}}
-		  
-      <input type="text" name="system.rangePower" data-tooltip="{{ localize 'DND4E.WeaponRangeShort' }}: {{ localize 'DND4E.WeaponRangeShortTip' }}" value="{{system.rangePower}}" data-dtype="String">
-		  
-      {{#unless system.isArea}}
-      <input class="hidden" type="text" name="system.range.value" value="{{#if system.range.long}}{{system.rangePower}}{{/if}}" data-dtype="String">
-      {{#if (eq system.rangeType 'range')}}
-      <span class="sep">/</span>
-      <input type="text" name="system.range.long" value="{{system.range.long}}" data-tooltip="{{ localize 'DND4E.WeaponRangeLong' }}: {{ localize 'DND4E.WeaponRangeLongTip' }}" placeholder="{{ localize 'DND4E.WeaponRangeLong' }}" data-dtype="String" onClick="this.select();">
-      {{/if}}
-      {{/unless}}
-		  
-      {{#unless system.isArea}}
+      <input type="text" name="system.enhance" value="{{system.enhance}}" data-tooltip="{{ localize 'DND4E.BonusTypeEnhancement' }}" placeholder="0" data-dtype="String" onClick="this.select();">
     </div>
-    {{/unless}}					
-    {{/if}}
-      
   </div>
-</div>
 
-{{#if system.isArea}}
-<div class="form-group short">
-  <label>{{ localize "DND4E.AutoTarget" }}</label>
-  <div class="form-fields auto-target">
-    <select name="system.autoTarget.mode">
-      {{selectOptions config.autoTargetModes selected=system.autoTarget.mode}}
+{{else}}
+
+  <h3 class="form-header">{{ localize "DND4E.ItemConsumableUsage" }}</h3>
+
+  {{!-- Action Type --}}
+  <div class="form-group select">
+    <label>{{ localize "DND4E.ItemActionType" }}</label>
+    <select name="system.actionType">
+      {{selectOptions config.abilityActivationTypes selected=system.actionType labelAttr="label"}}
     </select>
-    {{#unless system.excludeUserFromTargeting}}
-    <label>{{ localize "DND4E.AutoTargetIncludeSelf" }}</label>
-    <span class="checkbox">
-      <input class="checkbox" type="checkbox" name="system.autoTarget.includeSelf" data-dtype="Boolean" {{checked system.autoTarget.includeSelf}}>
-    </span>
-    {{/unless}}
   </div>
-</div>
-{{/if}}
-  
-{{!-- Limited Uses --}}
-<div class="vertical">
-  <div class="form-group uses-per">
-    <label>{{ localize "DND4E.LimitedUses" }}</label>
-    <div class="form-fields">
-      <input type="text" name="system.uses.value" value="{{system.uses.value}}" data-dtype="Number">
-      <span class="sep"> {{ localize "DND4E.of" }} </span>
-      <input type="text" name="system.uses.max" value="{{system.uses.max}}">
-      <select name="system.uses.per">
-        {{selectOptions config.limitedUsePeriods selected=system.uses.per labelAttr="label"}}
+    
+  <div class="form-group range">
+    <label>{{ localize "DND4E.Range" }}</label>
+    <div class="form-fields item-range">
+      <select name="system.rangeType">
+        {{selectOptions config.rangeTypeNoWeapon selected=system.rangeType labelAttr="label"}}
       </select>
+      {{#if system.isArea}}
+      <span>{{ localize "DND4E.AreaOf" }}</span>
+      <input type="text" name="system.area" value="{{system.area}}">
+      {{/if}}					
+        
+      {{#if system.isRange}}
+      {{#if system.isArea}}<span class="range-within-of">{{ localize "DND4E.RangeWithinOf" }}</span>{{/if}}
+        
+      {{#unless system.isArea}}
+      <div class="form-fields">
+        {{/unless}}
+        
+        <input type="text" name="system.rangePower" data-tooltip="{{ localize 'DND4E.WeaponRangeShort' }}: {{ localize 'DND4E.WeaponRangeShortTip' }}" value="{{system.rangePower}}" data-dtype="String">
+        
+        {{#unless system.isArea}}
+        <input class="hidden" type="text" name="system.range.value" value="{{#if system.range.long}}{{system.rangePower}}{{/if}}" data-dtype="String">
+        {{#if (eq system.rangeType 'range')}}
+        <span class="sep">/</span>
+        <input type="text" name="system.range.long" value="{{system.range.long}}" data-tooltip="{{ localize 'DND4E.WeaponRangeLong' }}: {{ localize 'DND4E.WeaponRangeLongTip' }}" placeholder="{{ localize 'DND4E.WeaponRangeLong' }}" data-dtype="String" onClick="this.select();">
+        {{/if}}
+        {{/unless}}
+        
+        {{#unless system.isArea}}
+      </div>
+      {{/unless}}					
+      {{/if}}
+        
     </div>
   </div>
-	  
-  <div class="form-group right">
+
+  {{#if system.isArea}}
+  <div class="form-group short">
+    <label>{{ localize "DND4E.AutoTarget" }}</label>
+    <div class="form-fields auto-target">
+      <select name="system.autoTarget.mode">
+        {{selectOptions config.autoTargetModes selected=system.autoTarget.mode}}
+      </select>
+      {{#unless system.excludeUserFromTargeting}}
+      <label>{{ localize "DND4E.AutoTargetIncludeSelf" }}</label>
+      <span class="checkbox">
+        <input class="checkbox" type="checkbox" name="system.autoTarget.includeSelf" data-dtype="Boolean" {{checked system.autoTarget.includeSelf}}>
+      </span>
+      {{/unless}}
+    </div>
+  </div>
+  {{/if}}
+    
+  {{!-- Limited Uses --}}
+  <div class="vertical">
+    <div class="form-group uses-per">
+      <label>{{ localize "DND4E.LimitedUses" }}</label>
+      <div class="form-fields">
+        <input type="text" name="system.uses.value" value="{{system.uses.value}}" data-dtype="Number">
+        <span class="sep"> {{ localize "DND4E.of" }} </span>
+        <input type="text" name="system.uses.max" value="{{system.uses.max}}">
+        <select name="system.uses.per">
+          {{selectOptions config.limitedUsePeriods selected=system.uses.per labelAttr="label"}}
+        </select>
+      </div>
+    </div>
+      
+    <div class="form-group right">
+      <label class="checkbox">
+        <input type="checkbox" name="system.uses.autoDestroy" {{checked system.uses.autoDestroy}}>
+        {{ localize "DND4E.ItemDestroyEmpty" }}
+      </label>
+    </div>
+  </div>
+    
+  {{!-- Consumption --}}
+  <div class="form-group uses-per">
+    <label>{{ localize "DND4E.ConsumeTitle" }}</label>
+    <div class="form-fields consumption">
+      <select class="consume-type" name="system.consume.type">
+        {{selectOptions config.abilityConsumptionTypes selected=system.consume.type labelAttr="label"}}
+      </select>
+      {{#if system.consume.type}}
+      <select name="system.consume.target">
+        {{selectOptions abilityConsumptionTargets selected=system.consume.target}}
+      </select>
+      <input type="text" name="system.consume.amount" value="{{system.consume.amount}}" data-dtype="Number">
+      {{/if}}
+    </div>
+  </div>
+
+  {{#if system.activation.type}}
+  <div class="form-group">
     <label class="checkbox">
       <input type="checkbox" name="system.uses.autoDestroy" {{checked system.uses.autoDestroy}}>
       {{ localize "DND4E.ItemDestroyEmpty" }}
     </label>
   </div>
-</div>
-  
-{{!-- Consumption --}}
-<div class="form-group uses-per">
-  <label>{{ localize "DND4E.ConsumeTitle" }}</label>
-  <div class="form-fields consumption">
-    <select class="consume-type" name="system.consume.type">
-      {{selectOptions config.abilityConsumptionTypes selected=system.consume.type labelAttr="label"}}
-    </select>
-    {{#if system.consume.type}}
-    <select name="system.consume.target">
-      {{selectOptions abilityConsumptionTargets selected=system.consume.target}}
-    </select>
-    <input type="text" name="system.consume.amount" value="{{system.consume.amount}}" data-dtype="Number">
-    {{/if}}
-  </div>
-</div>
-
-{{#if system.activation.type}}
-<div class="form-group">
-  <label class="checkbox">
-    <input type="checkbox" name="system.uses.autoDestroy" {{checked system.uses.autoDestroy}}>
-    {{ localize "DND4E.ItemDestroyEmpty" }}
-  </label>
-</div>
-{{/if}}
-  
-{{!-- Other Formula --}}
-<div class="form-group">
-  <label>{{ localize "DND4E.OtherFormula" }}</label>
-  <input type="text" name="system.formula" value="{{system.formula}}" placeholder="{{ localize 'DND4E.Formula' }}">
-</div>
-  
-{{!-- Effect --}}
-<fieldset>
-  <legend>{{ localize "DND4EUI.EffectDetailsText" }}</legend>
-  <div class="form-group right">
-    <label class="label long">{{ localize "DND4EUI.EffectHTMLInput" }} <span class="label-hint">({{ localize "DND4EUI.EffectHTMLTip" }})</span></label>
-    <input type="checkbox" name="system.effectHTML" data-dtype="Boolean" {{checked system.effectHTML}} {{ localize "DND4EUI.EffectHTMLInput" }}></span>
-  </div>
-  {{#if system.effectHTML}}
-  {{!--{{editor effectDetailHTML target="system.effect.detail" button=true owner=owner editable=editable engine="prosemirror"}}--}}
-  <prose-mirror class="rich-effect {{#if system.effect.detail}} has-content{{/if}}" toggled name="system.effect.detail" {{disabled (not editable)}} value="{{system.effect.detail}}">
-    {{{effectDetailHTML}}}
-  </prose-mirror>
-  {{else}}
-  <textarea class="no-mono" name="system.effect.detail" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">
-    {{system.effect.detail}}</textarea>
   {{/if}}
-  <div class="form-group right">
-    <label>{{ localize "DND4EUI.DisplayEffect" }}</label> 
-    <input type="checkbox" name="system.postEffect" data-dtype="Boolean" {{checked system.postEffect}}>
+{{/if}}
+    
+  {{!-- Other Formula --}}
+  <div class="form-group">
+    <label>{{ localize "DND4E.OtherFormula" }}</label>
+    <input type="text" name="system.formula" value="{{system.formula}}" placeholder="{{ localize 'DND4E.Formula' }}">
   </div>
-</fieldset>
 
-{{!------------ ATTACK ------------}}
+{{#unless (eq system.consumableType 'ammo')}}
 
-{{!-- Attack Details--}}
-<h3 class="form-header checkbox flexrow">
-  {{ localize "DND4E.Attack" }}
-  <input type="checkbox" name="system.attack.isAttack" data-dtype="Boolean" {{checked system.attack.isAttack}} data-tooltip="{{ localize 'DND4E.IsAttack' }}">
-</h3>
+  {{!------------ ATTACK ------------}}
+
+  {{!-- Attack Details--}}
+  <h3 class="form-header checkbox flexrow">
+    {{ localize "DND4E.Attack" }}
+    <input type="checkbox" name="system.attack.isAttack" data-dtype="Boolean" {{checked system.attack.isAttack}} data-tooltip="{{ localize 'DND4E.IsAttack' }}">
+  </h3>
+    
+  {{#if system.attack.isAttack}}
+    
+  {{!-- Attack--}}
+  <div class="form-group attack">
+    <label>{{ localize "DND4E.FormulaAttack" }}</label>
+    <div class="form-fields">
+      <input type="text" name="system.attack.formula" value="{{system.attack.formula}}" placeholder="5 + @dexMod">
+      {{ localize "DND4E.VS" }}
+      <select class="tight" name="system.attack.def">
+        {{selectOptions config.defensives selected=system.attack.def labelAttr="abbreviation"}}
+      </select>
+    </div>
+  </div>
+
+  {{/if}}
   
-{{#if system.attack.isAttack}}
+{{/unless}}
+
+  <h3 class="form-header checkbox flexrow">
+    {{ localize "DND4E.Damage" }}
+    <input type="checkbox" name="system.hit.isDamage" data-dtype="Boolean" {{#if (eq system.consumableType 'ammo')}}checked="true" disabled{{else}}{{checked system.hit.isDamage}}{{/if}} data-tooltip="{{ localize 'DND4E.IsDamage' }}">
+  </h3>
   
-{{!-- Attack--}}
-<div class="form-group attack">
-  <label>{{ localize "DND4E.FormulaAttack" }}</label>
-  <div class="form-fields">
-    <input type="text" name="system.attack.formula" value="{{system.attack.formula}}" placeholder="5 + @dexMod">
-    {{ localize "DND4E.VS" }}
-    <select class="tight" name="system.attack.def">
-      {{selectOptions config.defensives selected=system.attack.def labelAttr="abbreviation"}}
+  {{#if system.hit.isDamage}}
+    
+  {{!-- Hit Details --}}
+  {{!-- Damage --}}
+  {{#unless (eq system.consumableType 'ammo')}}
+    <div class="form-group">
+      <label>{{ localize 'DND4E.FormulaDamage' }}</label>
+      <input type="text" name="system.hit.formula" value="{{system.hit.formula}}" placeholder="{{ localize 'DND4E.FormulaDamageExample' }}">
+    </div>
+
+    {{!-- Damage Type --}}
+    <fieldset class="form-group stacked columns-4">
+      <legend>{{ localize 'DND4E.Damage' }} {{ localize 'DND4E.Type' }}</legend>
+      {{#each config.damageTypes as |name type|}}
+      <label class="checkbox">
+        <input type="checkbox" name="system.damageType.{{type}}" {{checked (lookup ../system.damageType type)}}/>
+        {{ name }}
+      </label>
+      {{/each}}
+    </fieldset>
+  {{/unless}}
+  <fieldset>
+    <legend>{{ localize 'DND4EUI.SecondaryDamageForm' }}</legend>
+    <label class="damage-header hint">{{ localize 'DND4EUI.SecondaryDamageTip' }}
+      <a class="damage-control" data-action="addDamage"><i class="fas fa-plus"></i></a>
+    </label>
+    <ol class="damage-parts form-group">
+      {{#each system.damage.parts as |part i| }}
+      <li class="damage-part flexrow" data-damage-part="{{i}}">
+        <input type="text" name="system.damage.parts.{{i}}.formula" value="{{lookup this 'formula'}}" placeholder="{{ localize 'DND4E.FormulaDamageExample' }}">
+        <multi-select name="system.damage.parts.{{i}}.type" class="inline">
+          {{selectOptions ../damageTypeOptions selected=part.type}}			
+        </multi-select>
+        <a class="damage-control" data-action="deleteDamage"><i class="fas fa-minus"></i></a>
+      </li>
+      {{/each}}
+    </ol>
+  </fieldset>
+
+  {{!-- Crit Damage --}}
+  {{#unless (eq system.consumableType 'ammo')}}
+  <div class="form-group ">
+    <label>{{ localize 'DND4E.Critical' }} {{ localize 'DND4E.FormulaDamage' }}</label>
+    <input type="text" name="system.hit.critFormula" value="{{system.hit.critFormula}}" placeholder="{{ localize 'DND4E.FormulaDamageCritExample' }}">
+  </div>
+  {{/unless}}
+  
+  <fieldset>
+    <legend>{{ localize 'DND4EUI.SecondaryCritForm' }}</legend>
+    <label class="damage-header hint">{{ localize 'DND4EUI.SecondaryCritTip' }}
+      <a class="damage-control" data-action="addCriticalDamage"><i class="fas fa-plus"></i></a>
+    </label>
+    <ol class="damage-parts form-group">
+      {{#each system.damageCrit.parts as |part i| }}
+      <li class="damage-part flexrow" data-damage-part="{{i}}">
+        <input type="text" name="system.damageCrit.parts.{{i}}.formula" value="{{lookup this 'formula'}}" placeholder="{{ localize 'DND4E.FormulaDamageExample' }}">
+        <multi-select name="system.damageCrit.parts.{{i}}.type" class="inline">
+          {{selectOptions ../damageTypeOptions selected=part.type}}			
+        </multi-select>
+        <a class="damage-control" data-action="deleteCriticalDamage"><i class="fas fa-minus"></i></a>
+      </li>
+      {{/each}}
+    </ol>
+  </fieldset>
+  
+  {{!-- Miss Damage --}}
+  {{#if system.attack.isAttack}}
+  <fieldset>
+    <legend>{{ localize 'DND4E.Miss' }} {{ localize 'DND4E.Damage' }}</legend>
+    <div class="form-group">
+      <label>{{ localize "DND4E.MissHalfDamage" }} <i data-tooltip="{{ localize 'DND4E.MissHalfDamageTooltip'}}" class="fa-solid fa-circle-question"></i></span></label> 
+      <input type="checkbox" name="system.miss.halfDamage" data-dtype="Boolean" {{checked system.miss.halfDamage}}>
+    </div>
+
+    {{#unless system.miss.halfDamage}}
+    <div class="form-group">
+      <label>{{ localize 'DND4E.Miss' }} {{ localize 'DND4E.FormulaDamage' }} <i data-tooltip="{{ localize 'DND4EUI.MissFormulaTip' }}" class="fa-solid fa-circle-question"></i></label>
+      <input type="text" name="system.miss.formula" value="{{system.miss.formula}}" placeholder="@halfDamageFormula">
+    </div>
+    {{/unless}}
+  </fieldset>
+  {{/if}}
+  
+  {{#if (eq system.consumableType 'ammo')}}
+    <fieldset>
+      <legend>{{ localize 'DND4EUI.SecondaryMissForm' }}</legend>
+      <label class="damage-header hint">{{ localize 'DND4EUI.SecondaryMissTip' }}
+        <a class="damage-control" data-action="addMissDamage"><i class="fas fa-plus"></i></a>
+      </label>
+      <ol class="damage-parts form-group">
+        {{#each system.damageMiss.parts as |part i| }}
+        <li class="damage-part flexrow" data-damage-part="{{i}}">
+          <input type="text" name="system.damageMiss.parts.{{i}}.formula" value="{{lookup this 'formula'}}" placeholder="{{ localize 'DND4E.FormulaDamageExample' }}">
+          <multi-select name="system.damageMiss.parts.{{i}}.type" class="inline">
+            {{selectOptions ../damageTypeOptions selected=part.type}}			
+          </multi-select>
+          <a class="damage-control" data-action="deleteMissDamage"><i class="fas fa-minus"></i></a>
+        </li>
+        {{/each}}
+      </ol>
+    </fieldset>
+  {{/if}}
+
+{{/if}}
+
+{{#unless (eq system.consumableType 'ammo')}}
+  <h3 class="form-header checkbox flexrow">
+    {{ localize "DND4E.Healing" }}
+    <input type="checkbox" name="system.hit.isHealing" data-dtype="Boolean" {{checked system.hit.isHealing}} data-tooltip="{{ localize 'DND4E.IsHealing' }}">
+  </h3>
+
+  {{#if system.hit.isHealing}}
+  <div class="form-group">
+    <label>{{ localize 'DND4E.Healing' }} {{ localize "DND4E.Formula" }}</label>
+    <input type="text" name="system.hit.healFormula" value="{{system.hit.healFormula}}">
+  </div>
+
+  <div class="form-group select">
+    <label>{{ localize "DND4E.HealingSurgeSpending" }}</label>
+    <select name="system.hit.healSurge">
+      <option value=""{{#if (eq system.hit.healSurge "")}} selected{{/if}}>{{ localize "DND4E.None" }}</option>
+      <option value="surge"{{#if (eq system.hit.healSurge "surge")}} selected{{/if}}>{{ localize "DND4E.HealingSurgeSpend" }}</option>
+      <option value="surgeCost"{{#if (eq system.hit.healSurge "surgeCost")}} selected{{/if}}>{{ localize "DND4E.HealingSurgeCost" }}</option>
+      <option value="surgeValue"{{#if (eq system.hit.healSurge "surgeValue")}} selected{{/if}}>{{ localize "DND4E.HealingSurgeValue" }}</option>
     </select>
   </div>
-</div>
 
-{{!-- Hit Text --}}
-<div class="form-group vertical">
-  <label>{{ localize "DND4EUI.HitDetailsText" }}</label>
-  <textarea name="system.hit.detail" class="no-mono" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">{{system.hit.detail}}</textarea>
-</div>
-	
-{{!-- Miss Text --}}
-<div class="form-group vertical">
-  <label>{{ localize "DND4EUI.MissDetailsText" }}</label>
-  <textarea name="system.miss.detail" class="no-mono" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">{{system.miss.detail}}</textarea>
-</div>
-
-{{/if}}
-
-<h3 class="form-header checkbox flexrow">
-  {{ localize "DND4E.Damage" }}
-  <input type="checkbox" name="system.hit.isDamage" data-dtype="Boolean" {{checked system.hit.isDamage}} data-tooltip="{{ localize 'DND4E.IsDamage' }}">
-</h3>
+  {{/if}}
   
-{{#if system.hit.isDamage}}
-  
-{{!-- Hit Details --}}
-{{!-- Damage --}}
-<div class="form-group">
-  <label>{{ localize 'DND4E.FormulaDamage' }}</label>
-  <input type="text" name="system.hit.formula" value="{{system.hit.formula}}" placeholder="{{ localize 'DND4E.FormulaDamageExample' }}">
-</div>
-
-{{!-- Damage Type --}}
-<fieldset class="form-group stacked columns-4">
-  <legend>{{ localize 'DND4E.Damage' }} {{ localize 'DND4E.Type' }}:</legend>
-  {{#each config.damageTypes as |name type|}}
-  <label class="checkbox">
-    <input type="checkbox" name="system.damageType.{{type}}" {{checked (lookup ../system.damageType type)}}/>
-    {{ name }}
-  </label>
-  {{/each}}
-</fieldset>
-
-<fieldset>
-  <legend>{{ localize 'DND4EUI.SecondaryDamageForm' }}</legend>
-  <label class="damage-header">{{ localize 'DND4EUI.SecondaryDamageTip' }}
-    <a class="damage-control" data-action="addDamage"><i class="fas fa-plus"></i></a>
-  </label>
-  <ol class="damage-parts form-group">
-    {{#each system.damage.parts as |part i| }}
-    <li class="damage-part flexrow" data-damage-part="{{i}}">
-      <input type="text" name="system.damage.parts.{{i}}.formula" value="{{lookup this 'formula'}}" placeholder="{{ localize 'DND4E.FormulaDamageExample' }}">
-      <multi-select name="system.damage.parts.{{i}}.type" class="inline">
-        {{selectOptions ../damageTypeOptions selected=part.type}}			
-      </multi-select>
-      <a class="damage-control" data-action="deleteDamage"><i class="fas fa-minus"></i></a>
-    </li>
-    {{/each}}
-  </ol>
-</fieldset>
-
-{{!-- Critical --}}
-<div class="form-group ">
-  <label>{{ localize 'DND4E.Critical' }} {{ localize 'DND4E.FormulaDamage' }}</label>
-  <input type="text" name="system.hit.critFormula" value="{{system.hit.critFormula}}" placeholder="{{ localize 'DND4E.FormulaDamageCritExample' }}">
-</div>
-  
-{{/if}}
-  
-<h3 class="form-header checkbox flexrow">
-  {{ localize "DND4E.Healing" }}
-  <input type="checkbox" name="system.hit.isHealing" data-dtype="Boolean" {{checked system.hit.isHealing}} data-tooltip="{{ localize 'DND4E.IsHealing' }}">
-</h3>
-  
-{{#if system.hit.isHealing}}
-<div class="form-group">
-  <label>{{ localize 'DND4E.Healing' }} {{ localize "DND4E.Formula" }}</label>
-  <input type="text" name="system.hit.healFormula" value="{{system.hit.healFormula}}">
-</div>
-
-<div class="form-group select">
-  <label>{{ localize "DND4E.HealingSurgeSpending" }}</label>
-  <select name="system.hit.healSurge">
-    <option value=""{{#if (eq system.hit.healSurge "")}} selected{{/if}}>{{ localize "DND4E.None" }}</option>
-    <option value="surge"{{#if (eq system.hit.healSurge "surge")}} selected{{/if}}>{{ localize "DND4E.HealingSurgeSpend" }}</option>
-    <option value="surgeCost"{{#if (eq system.hit.healSurge "surgeCost")}} selected{{/if}}>{{ localize "DND4E.HealingSurgeCost" }}</option>
-    <option value="surgeValue"{{#if (eq system.hit.healSurge "surgeValue")}} selected{{/if}}>{{ localize "DND4E.HealingSurgeValue" }}</option>
-  </select>
-</div>
-
-{{/if}}
+{{/unless}}
   
 <h3 class="form-header">{{ localize "DND4E.Keywords" }}</h3>
   
@@ -302,49 +340,135 @@
 <fieldset class="form-group stacked weapon-properties columns-4">
   <legend class="damage-type">{{localize 'DND4E.ThingType' thing=(localize 'DND4E.Damage')}}</legend>
   {{#if system.damageTypeOverride}}
-  {{#each config.damageTypes as |name type|}}
-  {{#unless (eq type "ongoing")}}
-  {{#unless (eq type "damage")}}
-  <label class="checkbox">
-    <input disabled="disabled" type="checkbox" name="system.weaponDamageType.{{type}}" {{checked (lookup ../system.weaponDamageType type)}}/>
-    {{ name }}
-  </label>
-  {{/unless}}
-  {{/unless}}
-  {{/each}}
+    {{#each config.damageTypes as |name type|}}
+    {{#unless (eq type "ongoing")}}
+    {{#unless (eq type "damage")}}
+    <label class="checkbox">
+      <input disabled="disabled" type="checkbox" name="system.weaponDamageType.{{type}}" {{checked (lookup ../system.weaponDamageType type)}}/>
+      {{ name }}
+    </label>
+    {{/unless}}
+    {{/unless}}
+    {{/each}}
   {{else}}
-  {{#each config.damageTypes as |name type|}}
-  {{#unless (eq type "ongoing")}}
-  {{#unless (eq type "damage")}}
-  <label class="checkbox">
-    <input type="checkbox" name="system.damageType.{{type}}" {{checked (lookup ../system.damageType type)}}/>
-    {{ name }}
-  </label>
-  {{/unless}}
-  {{/unless}}
-  {{/each}}
+    {{#each config.damageTypes as |name type|}}
+    {{#unless (eq type "ongoing")}}
+    {{#unless (eq type "damage")}}
+    <label class="checkbox">
+      <input type="checkbox" name="system.damageType.{{type}}" {{checked (lookup ../system.damageType type)}}/>
+      {{ name }}
+    </label>
+    {{/unless}}
+    {{/unless}}
+    {{/each}}
   {{/if}}
 </fieldset>
 {{/unless}}
     
-{{!--
-<div class="form-group">
-  <legend>{{localize 'DND4EUI.AutoFromConfig'}}</legend>
-  <ul class="auto-keywords inline-list" data-tooltip="{{localize 'DND4EUI.AutoFromConfigTip'}}">
-    {{#if labels.damageTypes}}
-    <li>{{labels.damageTypes}}</li>
+  <div class="form-group">
+    <legend>{{localize 'DND4EUI.AutoFromConfig'}}</legend>
+    <ul class="auto-keywords inline-list" data-tooltip="{{localize 'DND4EUI.AutoFromConfigTip'}}">
+      {{#if labels.damageTypes}}
+      <li>{{labels.damageTypes}}</li>
+      {{/if}}
+      
+      {{#each system.autoKeys as |kw|}}
+      <li>{{localize kw.label}}</li>
+      {{/each}}
+      
+    </ul>
+  </div>
+    
+  <div class="form-group long">
+    <label>{{ localize "DND4E.Custom" }}</label>
+    <input type="text" name="system.keywordsCustom" value="{{system.keywordsCustom}}" placeholder="{{ localize 'DND4EUI.StringEnterValues'}}" data-tooltip="{{ localize 'DND4EUI.StringEnterValues'}}">
+  </div>
+{{!------------ DISPLAY ------------}}
+
+<h3 class="form-header checkbox flexrow">
+  {{ localize "Display" }}
+  <label class="checkbox">
+    <span class="label">{{ localize "DND4EUI.PowerCardAuto" }} <i data-tooltip="{{localize 'DND4EUI.AutoCardTip'}}" class="fa-solid fa-circle-question"></i></span>
+    <input type="checkbox" name="system.autoGenChatPowerCard" data-dtype="Boolean" {{checked system.autoGenChatPowerCard}}>
+  </label>
+</h3>
+
+{{#if system.autoGenChatPowerCard}}
+
+  {{!-- Chat Message Flavor --}}
+  <div class="form-group vertical">
+    <label>{{ localize "DND4EUI.ChatFlavor" }}</label>
+    <textarea class="no-mono" name="system.description.chat" placeholder="{{ localize 'DND4EUI.ChatFlavorPlaceholder'}}">{{system.description.chat}}</textarea>
+  </div>
+
+  {{!-- Effect --}}
+  <fieldset>
+    <legend>{{ localize "DND4EUI.EffectDetailsText" }}</legend>
+    <div class="form-group right">
+      <label class="label long">{{ localize "DND4EUI.EffectHTMLInput" }} <span class="label-hint hint">({{ localize "DND4EUI.EffectHTMLTip" }})</span></label>
+      <input type="checkbox" name="system.effectHTML" data-dtype="Boolean" {{checked system.effectHTML}} {{ localize "DND4EUI.EffectHTMLInput" }}></span>
+    </div>
+    {{#if system.effectHTML}}
+    {{!--{{editor effectDetailHTML target="system.effect.detail" button=true owner=owner editable=editable engine="prosemirror"}}--}}
+    <prose-mirror class="rich-effect {{#if system.effect.detail}} has-content{{/if}}" toggled name="system.effect.detail" {{disabled (not editable)}} value="{{system.effect.detail}}">
+      {{{effectDetailHTML}}}
+    </prose-mirror>
+    {{else}}
+    <textarea class="no-mono" name="system.effect.detail" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">
+      {{system.effect.detail}}</textarea>
     {{/if}}
     
-    {{#each system.autoKeys as |kw|}}
-    <li>{{localize kw.label}}</li>
-    {{/each}}
-    
-  </ul>
-</div>
---}}
+    {{#unless (eq system.consumableType 'ammo')}}
+      <div class="form-group right">
+        <label>{{ localize "DND4EUI.DisplayEffect" }}</label> 
+        <input type="checkbox" name="system.postEffect" data-dtype="Boolean" {{checked system.postEffect}}>
+      </div>
+    {{/unless}}
+  </fieldset>
   
-<div class="form-group long">
-  <label>{{ localize "DND4E.Custom" }}</label>
-  <input type="text" name="system.keywordsCustom" value="{{system.keywordsCustom}}" placeholder="{{ localize 'DND4EUI.StringEnterValues'}}" data-tooltip="{{ localize 'DND4EUI.StringEnterValues'}}">
-</div>
-</div>
+{{#unless (eq system.consumableType 'ammo')}}
+  {{!-- Optional Parameters --}}
+  <div class="form-group">
+    <label>{{ localize "DND4EUI.RequirementsText" }}</label>
+    <div class="form-fields">
+      <input type="text" name="system.requirement" value="{{system.requirement}}">
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label>{{ localize "DND4EUI.TriggerText" }}</label>
+    <div class="form-fields">
+      <input type="text" name="system.trigger" value="{{system.trigger}}">
+    </div>
+  </div>
+
+  <div class="form-group">
+    <label>{{ localize "DND4EUI.TargetText" }}</label>
+    <div class="form-fields">
+      <input type="text" name="system.target" value="{{system.target}}">
+    </div>
+  </div>
+  
+  {{#if system.attack.isAttack}}
+    {{!-- Attack Text --}}
+    <div class="form-group">
+      <label>{{ localize "DND4EUI.AttackDetailsText" }} <i data-tooltip="{{ localize 'DND4EUI.AttackDetailsTextHint' }}" class="fa-solid fa-circle-question"></i></label>
+      <input type="text" name="system.attack.detail" value="{{system.attack.detail}}" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">
+    </div>
+  
+    {{!-- Hit Text --}}
+    <div class="form-group vertical">
+      <label>{{ localize "DND4EUI.HitDetailsText" }}</label>
+      <textarea name="system.hit.detail" class="no-mono" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">{{system.hit.detail}}</textarea>
+    </div>
+      
+    {{!-- Miss Text --}}
+    <div class="form-group vertical">
+      <label>{{ localize "DND4EUI.MissDetailsText" }}</label>
+      <textarea name="system.miss.detail" class="no-mono" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">{{system.miss.detail}}</textarea>
+    </div>
+  {{/if}}
+  
+{{/unless}}
+
+{{/if}}{{!-- End display fields --}}

--- a/templates/items/parts/details-equipment.hbs
+++ b/templates/items/parts/details-equipment.hbs
@@ -110,8 +110,7 @@
 {{!-- Damage Res --}}
 <fieldset class="form-group columns-4">
   <legend>{{localize 'DND4E.DamRes'}}</legend>
-  <label>
-    {{localize 'DND4EUI.ResistancesTip'}}
+  <label class="hint">{{localize 'DND4EUI.ResistancesTip'}}
     <a class="damage-control" data-action="addDamageRes"><i class="fas fa-plus"></i></a>
   </label>
   <ol class="damage-parts form-group">

--- a/templates/items/parts/details-power.hbs
+++ b/templates/items/parts/details-power.hbs
@@ -298,7 +298,7 @@
 {{!--Secondary Damage Instances --}}
 <fieldset>
   <legend>{{ localize 'DND4EUI.SecondaryDamageForm' }}</legend>
-  <label class="damage-header">{{ localize 'DND4EUI.SecondaryDamageTip' }} <a class="damage-control" data-action="addDamage"><i class="fas fa-plus"></i></a></label>
+  <label class="damage-header hint">{{ localize 'DND4EUI.SecondaryDamageTip' }} <a class="damage-control" data-action="addDamage"><i class="fas fa-plus"></i></a></label>
   <ol class="damage-parts form-group">
     {{#each system.damage.parts as |part i| }}
     <li class="damage-part flexrow" data-damage-part="{{i}}">
@@ -321,7 +321,7 @@
 {{!-- Secondary Critical Damage --}}
 <fieldset>
   <legend>{{ localize 'DND4EUI.SecondaryCritForm' }}</legend>
-  <label class="damage-header">{{ localize 'DND4EUI.SecondaryCritTip' }} <a class="damage-control" data-action="addCriticalDamage"><i class="fas fa-plus"></i></a></label>
+  <label class="damage-header hint">{{ localize 'DND4EUI.SecondaryCritTip' }} <a class="damage-control" data-action="addCriticalDamage"><i class="fas fa-plus"></i></a></label>
   <ol class="damage-parts form-group">
     {{#each system.damageCrit.parts as |part i| }}
     <li class="damage-part flexrow" data-damage-part="{{i}}">
@@ -491,7 +491,7 @@
   </div>
 </div>
 
-{{#if system.attack.isAttack}}	
+{{#if system.attack.isAttack}}
 {{!-- Attack Text --}}
 <div class="form-group">
   <label>{{ localize "DND4EUI.AttackDetailsText" }} <i data-tooltip="{{ localize 'DND4EUI.AttackDetailsTextHint' }}" class="fa-solid fa-circle-question"></i></label>
@@ -515,7 +515,7 @@
 <fieldset>
   <legend>{{ localize "DND4EUI.EffectDetailsText" }}</legend>
   <div class="form-group right">
-    <label class="label long">{{ localize "DND4EUI.EffectHTMLInput" }} <span class="label-hint">({{ localize "DND4EUI.EffectHTMLTip" }})</span></label>
+    <label class="label long">{{ localize "DND4EUI.EffectHTMLInput" }} <span class="label-hint hint">({{ localize "DND4EUI.EffectHTMLTip" }})</span></label>
     <input type="checkbox" name="system.effectHTML" data-dtype="Boolean" {{checked system.effectHTML}} {{ localize "DND4EUI.EffectHTMLInput" }}></span>
   </div>
   {{#if system.effectHTML}}

--- a/templates/items/parts/details-weapon.hbs
+++ b/templates/items/parts/details-weapon.hbs
@@ -150,7 +150,7 @@
     <select class="consume-type" name="system.consume.type">
       {{selectOptions config.abilityConsumptionTypes selected=system.consume.type labelAttr="label"}}
     </select>
-    <select class="conusme-target" name="system.consume.target">
+    <select class="consume-target" name="system.consume.target">
       {{selectOptions abilityConsumptionTargets selected=system.consume.target}}
     </select>
     <input type="text" name="system.consume.amount" value="{{system.consume.amount}}" data-dtype="Number">
@@ -164,7 +164,7 @@
 {{#unless (eq system.weaponType "implement")}}
 <fieldset class="weapon-damage">
   <legend>{{ localize 'DND4E.DiceWeapon' }}</legend>
-  <label class="damage-header" for="damage-parts">{{ localize 'DND4E.DiceWeaponTip' }}<a class="damage-control" data-action="addDice"><i class="fas fa-plus"></i></a></label>
+  <label class="damage-header hint" for="damage-parts">{{ localize 'DND4E.DiceWeaponTip' }}<a class="damage-control" data-action="addDice"><i class="fas fa-plus"></i></a></label>
 
   <ol class="damage-parts form-group" name="damage-parts">
     {{#each system.damageDice.parts as |part i| }}
@@ -219,7 +219,7 @@
   
 <fieldset class="weapon-damage" name="extra-damage">
   <legend>{{ localize 'DND4EUI.SecondaryDamageForm' }}</legend>
-  <label>{{ localize 'DND4EUI.SecondaryDamageTip' }}
+  <label class="hint">{{ localize 'DND4EUI.SecondaryDamageTip' }}
     <a class="damage-control" data-action="addDamage"><i class="fas fa-plus"></i></a></label>
   <ol class="damage-parts form-group">
     {{#each system.damage.parts as |part i| }}
@@ -243,7 +243,7 @@
 
 <fieldset name="extra-damage-crit">
   <legend class="damage-header">{{ localize 'DND4EUI.SecondaryCritForm' }}</legend>
-  <label class="damage-header">
+  <label class="damage-header hint">
     {{ localize 'DND4EUI.SecondaryCritTip' }} 
     <a class="damage-control" data-action="addCriticalDamage"><i class="fas fa-plus"></i></a>
   </label>


### PR DESCRIPTION
I started out with "oh, the sheet would be much more useful for ammunition if I took all this stuff off", and then this happened <XD

- Exposed many hidden fields for consumables: Miss damage, Added Damage arrays, chat flavour/display text fields, and rich text description.
- The `equipped` setting is now labelled differently based on the consumable type:
  - Ammuntion: "Loaded"
  - Trinkets and Wondrous Items: "Equipped"
  - Other types: "Readied". (This has no specific system meaning, so it can be used generically for characters who use something like a potion bandolier to keep some consumables more accessible than others.)
- Amended consumables so "uses per" defaults to "none". Most consumables are depleted based on quantity rather than charges, and this section will now be hidden for ammunition, so it's more efficient to use a blank default.
- Updated actor sheet so items no longer display as unavailable based on limited uses when `uses.per` is blank.
- Substantially improved `ammunition` type consumables:
  - As per system rules, ammunition can now specify an enhancement bonus, which overrides weapon enhancement if > 0
  - A weapon's ammunition consumption can now be set to "auto" instead of a specfic item. Auto setting will select the first "equipped" ammunition in the character's inventory when making an attack (or calculating attack values). This should make it easy to prioritise a specialised ammunition and fall back to a generic one, without needing to open weapon config.
  - Ammunition now has arrays for damage to add to Normal hits, Crits, and Misses while it is in use. This replaces the previous behaviour of one shared value between hit and crit, and adding miss damage based on whether the attack has a miss formula. This should allow for more system-accurate ammunition behaviour.
  - When configuring Ammunition, the consumables sheet is now streamlined to only show relevant fields.