### PR TITLE
Adjust how saves handle situational bonuses from the roll dialog

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1980,12 +1980,6 @@ export default class Actor4e extends Actor {
 		const parts = [];
 		const partsExpressionReplacements = [];
 		const rollData = this.getRollData();
-		if (options.save) {		
-			parts.push(Roll.replaceFormulaData(options.save, rollData));
-			partsExpressionReplacements.push({ value: options.save, target: parts[0] });
-			// add the substitutions that were used in the expression to the data object for later
-			options.formulaInnerData = Roll.replaceFormulaData(options.save, rollData);
-		}
 		
 		await utils.applySaveEffects(rollData, this, this.effects.get(options.effectId), "save", options);
 
@@ -2028,10 +2022,7 @@ export default class Actor4e extends Actor {
 	async rollDeathSave(event, form, options) {
 		const updateData = {};
 		
-		const parts = [this.system.details.deathsavebon.value];
-		if (options.save) {
-			parts.push(options.save);
-		}
+		const parts = this.system.details.deathsavebon.value ? [this.system.details.deathsavebon.value] : [];
 		const rollConfig = foundry.utils.mergeObject({
 			parts,
 			actor: this,

--- a/templates/apps/death-save.hbs
+++ b/templates/apps/death-save.hbs
@@ -7,7 +7,7 @@
     <fieldset class="form-group vertical">
       <div class="form-group">
         <label>{{localize 'DND4E.RollSituationalBonus'}}</label>
-        <input type="text" name="save" value="" placeholder="">
+        <input type="text" name="bonus" value="" placeholder="">
       </div>
 
       <div class="form-group roll-times flexrow">

--- a/templates/apps/save-throw.hbs
+++ b/templates/apps/save-throw.hbs
@@ -28,7 +28,7 @@
 
     <div class="form-group">
       <label>{{localize 'DND4E.SaveSituational'}}?</label>
-      <input type="text" name="save" value="" placeholder="">
+      <input type="text" name="bonus" value="" placeholder="">
     </div>
 
     <div class="form-group roll-times flexrow">


### PR DESCRIPTION
Anything entered into the roll dialog's situational bonus input for saving throws is now represented by `@bonus` as with all other rolls.

Closes #726