### PR TITLE
Fix issue when cleaning improperly formed `@scale` objects in formulae

### DIFF
--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -32,7 +32,7 @@ export default class FormulaField extends foundry.data.fields.StringField {
 				value = value.replace(/@scale(\d+)/gm, "(scale(@lv, $1))");
 				value = value.replace(/@scale/gm, "(scale(@lv))");
 
-				// Try to fix a prior error in the above:
+				// Try to fix a prior error in the above.
 				value = value.replace(/scale\(@lv, \)/gm, "scale(@lv)");
 			}
 			const operatorRegex = /\s*([+\-*/])\s*/g;

--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -29,7 +29,7 @@ export default class FormulaField extends foundry.data.fields.StringField {
 			}
 			if (value.includes("@scale")) {
 				// Convert @scaleX to scale(@lv, X).
-				value = value.replace(/@scale(\d*)/gm, "(scale(@lv, $1))");
+				value = value.replace(/@scale(\d+)/gm, "(scale(@lv, $1))");
 				value = value.replace(/@scale/gm, "(scale(@lv))");
 			}
 			const operatorRegex = /\s*([+\-*/])\s*/g;

--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -31,6 +31,9 @@ export default class FormulaField extends foundry.data.fields.StringField {
 				// Convert @scaleX to scale(@lv, X).
 				value = value.replace(/@scale(\d+)/gm, "(scale(@lv, $1))");
 				value = value.replace(/@scale/gm, "(scale(@lv))");
+
+				// Try to fix a prior error in the above:
+				value = value.replace(/scale\(@lv, \)/gm, "scale(@lv)");
 			}
 			const operatorRegex = /\s*([+\-*/])\s*/g;
 			value = value.replace(operatorRegex, " $1 ");

--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -31,7 +31,8 @@ export default class FormulaField extends foundry.data.fields.StringField {
 				// Convert @scaleX to scale(@lv, X).
 				value = value.replace(/@scale(\d+)/gm, "(scale(@lv, $1))");
 				value = value.replace(/@scale/gm, "(scale(@lv))");
-
+			}
+			if (value.includes("scale(@lv, )")) {
 				// Try to fix a prior error in the above.
 				value = value.replace(/scale\(@lv, \)/gm, "scale(@lv)");
 			}


### PR DESCRIPTION
Regex is hard.