### PR TITLE
Refresh AE sheet on status effect selection

### DIFF
--- a/module/applications/sheets/active-effect-config.mjs
+++ b/module/applications/sheets/active-effect-config.mjs
@@ -370,5 +370,4 @@ export default class ActiveEffectConfig4e extends foundry.applications.sheets.Ac
 	_refresh(event) {
 		return this.submit({ preventClose: true }).then(() => this.render());
 	}
-	
 }

--- a/templates/sheets/active-effect/changes.hbs
+++ b/templates/sheets/active-effect/changes.hbs
@@ -31,7 +31,7 @@
       {{#each source.statuses as |status i|}}
       <li class="effect-status flexrow" data-status-id="{{status}}" data-index="{{i}}">
         <div class="status-select">
-          <select name="statuses.{{i}}" {{#unless (eq status "none")}} data-tooltip="{{status}}{{#unless (contains status ../config.statusEffects 'id')}}: {{localize 'DND4EUI.UnknownCondition.Tip'}}{{/unless}}" {{/unless}} >
+          <select class="refreshes" name="statuses.{{i}}" {{#unless (eq status "none")}} data-tooltip="{{status}}{{#unless (contains status ../config.statusEffects 'id')}}: {{localize 'DND4EUI.UnknownCondition.Tip'}}{{/unless}}" {{/unless}} >
             {{#unless (eq status "none")}}
             {{#unless (contains status ../config.statusEffects 'id')}}
             <option value="{{status}}" selected>{{localize 'DND4EUI.UnknownCondition.Label'}}</option>


### PR DESCRIPTION
We disable all the status effect copy buttons when the selected status isn't found in `config.statusEffects`, but simply selecting a new status from the dropdown wasn't committing the choice and re-evaluating that disabled state.

Closes #742 