### PR TITLE
Add statuses to actor roll data

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -180,6 +180,10 @@ export default class Actor4e extends Actor {
 		const data = super.getRollData();
 
 		data.name = this.name;
+		data.statuses = {};
+		for (const status of Object.keys(CONFIG.DND4E.statusEffect)) {
+			data.statuses[status] = this.statuses.has(status) ? 1 : 0;
+		}
 
 		data.strMod = data?.abilities?.str.mod || 0;
 		data.conMod = data?.abilities?.con.mod || 0;


### PR DESCRIPTION
Statuses are stored under `@statuses` and are referenced via the status id, e.g.:
`@statuses.slowed`
`@statuses.dazed`

Each has a value of 1 if the status is currently affecting the actor and 0 if it isn't.