### PR TITLE
Fix `ignoringMark` penalty always applying

### DIFF
--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -68,7 +68,7 @@ export async function d20Roll(form, { parts = [], partsExpressionReplacements = 
 		targDataArray.hasTarget = !!targetArr.length;
 		if (game.settings.get("dnd4e", "markAutomation") && actor.system?.marker) {
 			targDataArray.ignoringMark = !targetArr.some(t => (t.actor.uuid === data.marker));
-			userBonuses.marked.shouldApply = true;
+			userBonuses.marked.shouldApply = targDataArray.ignoringMark;
 		}
 		// User conditions
 		if (userStatus.has("prone")) userBonuses.prone.shouldApply = true;

--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -1060,7 +1060,7 @@ export async function applyEffectsToTokens(effectMap, tokenTarget, condition, pa
 				}
 
 				if (e.statuses[0] && game.settings.get("dnd4e", "markAutomation")) {
-					const hasMark = e.statuses.has("mark");
+					const hasMark = e.statuses.some(s => s === "mark");
 						
 					if (hasMark) {
 						// If the effect already has `system.marker` assume it's for a reason


### PR DESCRIPTION
It turns out that if you just set something to true no matter what, it's always true!