### PR TITLE
Fix TAH Integration and FF Saving Throw

### DIFF
--- a/module/applications/sheets/actor-sheet.mjs
+++ b/module/applications/sheets/actor-sheet.mjs
@@ -811,7 +811,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 	}
 
 	/* -------------------------------------------- */
-
+	// this method is called by Token Action Hud, if changing please update module/compatibility/tokenActionHud.mjs
 	_sortPowers(powers) {
 		const sort = this.document.system.powerSortTypes || "actionType";
 		for (const [keyy, group] of Object.entries(powers)) {
@@ -832,7 +832,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 	}
 
 	/* -------------------------------------------- */
-
+	// this method is called by Token Action Hud, if changing please update module/compatibility/tokenActionHud.mjs
 	_groupPowers(power, powerGroups) {
 		if ((this.document.system.powerGroupTypes === "action") || !this.document.system.powerGroupTypes) {
 			if (Object.keys(powerGroups).includes(power.system.actionType)) return power.system.actionType;
@@ -858,6 +858,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		return "other";
 	}
 
+	// this method is called by Token Action Hud, if changing please update module/compatibility/tokenActionHud.mjs
 	_generatePowerGroups() {
 		const actorData = this.document.system;
 		const powerGroupTypes = actorData.powerGroupTypes ?? "usage";
@@ -877,6 +878,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		return displayConfig;
 	};
 
+	// this method is called by Token Action Hud, if changing please update module/compatibility/tokenActionHud.mjs
 	_checkItemAvailable(itemData) {
 		if ((!itemData.system.uses.value && itemData.system.preparedMaxUses && itemData.system.uses.per) || ((itemData.type === "power") && !itemData.system.prepared)) {
 			itemData.system.notAvailable = true;
@@ -1407,6 +1409,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 	static #onHealMenuDialog(event, target) {
 		if (!this.actor.isOwner) return;
 		event.preventDefault();
+		// this logic is duplicated for TAH, if changing please update module/compatibility/tokenActionHud.mjs
 		new apps.HealMenuDialog({ document: this.actor }).render(true);
 	}
 
@@ -1460,6 +1463,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		if (isFF) {
 			return this.actor.secondWind(event, { isFF });
 		}
+		// this logic is duplicated for TAH, if changing please update module/compatibility/tokenActionHud.mjs
 		new apps.SecondWindDialog({ document: this.actor }).render(true);		
 	}
 	
@@ -1472,6 +1476,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		if (isFF) {
 			return this.actor.actionPoint(event, { isFF });
 		}
+		// this logic is duplicated for TAH, if changing please update module/compatibility/tokenActionHud.mjs
 		new apps.ActionPointDialog({ document: this.actor }).render(true);
 	}
 
@@ -1519,6 +1524,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		if (isFF) {
 			return this.actor.rollDeathSave(event, { isFF });
 		}
+		// this logic is duplicated for TAH, if changing please update module/compatibility/tokenActionHud.mjs
 		new apps.DeathSaveDialog({ document: this.actor }).render(true);
 	}
 
@@ -1533,8 +1539,10 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		event.preventDefault();
 		const isFF = utils.isRollFastForwarded(event);
 		if (isFF) {
-			return this.actor.rollSave(event, { isFF });
+			// this logic is duplicated for TAH, if changing please update module/compatibility/tokenActionHud.mjs
+			return this.actor.rollSave(event, { isFF }, {});
 		}
+		// this logic is duplicated for TAH, if changing please update module/compatibility/tokenActionHud.mjs
 		return new apps.SaveThrowDialog({ document: this.actor }).render(true);
 	}
 
@@ -1634,7 +1642,7 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		const isFF = utils.isRollFastForwarded(event);
 		
 		if (isFF) {
-			return this.actor.rollSave(event, { isFF, effectSave: true, dc: saveDC, effectId: effectId });
+			return this.actor.rollSave(event, { isFF, effectSave: true, dc: saveDC, effectId: effectId }, {});
 		}
 
 		let save = new apps.SaveThrowDialog({ document: this.actor, effectSave: true, saveDC: saveDC, effectId: effectId }).render(true);
@@ -1646,10 +1654,15 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 	/* -------------------------------------------- */
 
 	static async #onItemRecharge(event, target) {
-		event.preventDefault();
 		const itemId = target.closest(".item").dataset.itemId;
 		const item = this.actor.items.get(itemId);
+		return this._onItemRecharge(event, item)
+	}
 
+	// this method is called by Token Action Hud, if changing please update module/compatibility/tokenActionHud.mjs
+	async _onItemRecharge(event, item) {
+		event.preventDefault();
+		const itemId = item.id
 		if (item.type === "power") {
 
 			if (item.system.rechargeRoll || (!item.system.rechargeRoll && !item.system.rechargeCondition)) {

--- a/module/compatibility/tokenActionHud.mjs
+++ b/module/compatibility/tokenActionHud.mjs
@@ -1,5 +1,6 @@
 import { Actor4e, Item4e } from "../documents/_module.mjs";
 import * as utils from "../utils/utils.mjs";
+import * as apps from "../applications/apps/_module.mjs";
 
 /**
  * These methods are all called by https://github.com/Drental/fvtt-tokenactionhud, their method signature should not be changed without a code change there.
@@ -19,13 +20,13 @@ TokenBarHooks.isPowerAvailable = (actor, power) => {
 	return !power.system.notAvailable;
 };
 
-TokenBarHooks.quickSave = (actor, event) => actor.rollSave(event, { isFF: true });
+TokenBarHooks.quickSave = (actor, event) => actor.rollSave(event, { isFF: true }, {});
 
-TokenBarHooks.saveDialog = (actor, event) => actor.sheet._onSavingThrow(event);
+TokenBarHooks.saveDialog = (actor, event) => new apps.SaveThrowDialog({ document: actor }).render(true);
 
-TokenBarHooks.healDialog = (actor, event) => actor.sheet._onHealMenuDialog(event);
+TokenBarHooks.healDialog = (actor, event) => new apps.HealMenuDialog({ document: actor }).render(true);
 
-TokenBarHooks.rechargePower = (actor, power, event) => actor.sheet._onItemRecharge(event);
+TokenBarHooks.rechargePower = (actor, power, event) => actor.sheet._onItemRecharge(event, power);
 
 TokenBarHooks.rollPower = (actor, power, event) => {
 	const fastForward = utils.isRollFastForwarded(event);
@@ -38,11 +39,11 @@ TokenBarHooks.rollAbility = (actor, checkId, event) => actor.rollAbility(checkId
 
 TokenBarHooks.rollItem = (actor, item, event) => item.roll();
 
-TokenBarHooks.deathSave = (actor, event) => actor.sheet._onDeathSave(event);
+TokenBarHooks.deathSave = (actor, event) => new apps.DeathSaveDialog({ document: actor }).render(true);
 
-TokenBarHooks.secondWind = (actor, event) => actor.sheet._onSecondWind(event);
+TokenBarHooks.secondWind = (actor, event) => new apps.SecondWindDialog({ document: actor }).render(true);
 
-TokenBarHooks.actionPoint = (actor, event) => actor.sheet._onActionPointDialog(event);
+TokenBarHooks.actionPoint = (actor, event) => new apps.ActionPointDialog({ document: actor }).render(true);
 
 //v3 hook - get all the powers back grouped by sheet selection
 TokenBarHooks.powersBySheetGroup = (actor) => {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1862,7 +1862,7 @@ export default class Actor4e extends Actor {
 			speaker: ChatMessage.getSpeaker({ actor: this }),
 			messageData: { "options.flags.dnd4e.roll": { type: "save", actorId: this.id } },
 			fastForward: true,
-			messageMode: options.messageMode,
+			messageMode: options.messageMode ?? "public",
 			options,
 		});
 		rollConfig.event = event;

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -578,7 +578,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 	}
 
 	// Convert the roll to a chat message and return the roll
-	messageMode = form ? form.messageMode.value : messageMode;
+	messageMode = form?.messageMode ? form.messageMode.value : messageMode;
 
 	await roll.toMessage({
 		speaker: speaker,


### PR DESCRIPTION
Changes to the actor sheet had broken the quick utility calls in token action hud.  Most are duplicate dialog code, recharge power factored into a common method as there is a lot of logic there.

Also discovered that FFing a saving throw was broken as FF did not have an options, or a form to get the message mode from.