### PR TITLE
Evaluate Obscured Terrain conditions on attacker

### DIFF
--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -1052,7 +1052,7 @@ export async function applyEffectsToTokens(effectMap, tokenTarget, condition, pa
 					newEffectData.system.saveDC = String(Number(newEffectData.system.saveDC) + dcBonus);
 				}
 
-				if (e.statuses.length && game.settings.get("dnd4e", "markAutomation")) {
+				if (e.statuses.length && game.settings.get("dnd4e", "dynamicAutomation")) {
 					const hasMark = e.statuses.some(s => s === "mark");
 						
 					if (hasMark) {

--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -1837,7 +1837,7 @@ export function computeConcealment(token, target) {
 	let obscurementLevel = OBSCUREMENT.NONE;
 	for (const region of [...target.document.regions].filter((r) => r.behaviors.some((b) => b.type === "obscuredTerrain"))) {
 		for (const behavior of [...region.behaviors].filter((b) => b.type === "obscuredTerrain")) {
-			if (!behavior.system.evaluateConditions(target)) continue;
+			if (!behavior.system.evaluateConditions(token)) continue;
 			if (behavior.system.level > obscurementLevel) obscurementLevel = behavior.system.level;
 		}
 	}


### PR DESCRIPTION
I reread some of the powers that create zones that are conditionally obscured, and I'm 99% sure now that "obscured for your enemies" means "when your enemies target something in an obscured square" and not "when you target an enemy in an obscured square" because these powers suck otherwise.