### PR TITLE
Gate concealment automation behind Dynamic Automation setting

### DIFF
--- a/module/canvas/placeables/token.mjs
+++ b/module/canvas/placeables/token.mjs
@@ -70,7 +70,21 @@ export default class Token4e extends foundry.canvas.placeables.Token {
 		const testPoints = targetToken.document.getVisibilityTestPoints();
 		const config = canvas.visibility._createVisibilityTestConfig(testPoints, { object: targetToken, tolerance: 0 });
 		const allowed = modes ? new Set(modes) : null;
-		const detected = Object.entries(this.detectionModes).some(([id, mode]) => {
+		const detectionModes = foundry.utils.mergeObject(this.detectionModes, {
+			lightPerception: {
+				enabled: true,
+				range: Infinity,
+			},
+			basicSight: {
+				enabled: true,
+				range: 0,
+			},
+		}, {
+			insertKeys: true,
+			insertValues: true,
+			overwrite: false,
+		});
+		const detected = Object.entries(detectionModes).some(([id, mode]) => {
 			if (allowed && !allowed.has(id)) return false;
 			return CONFIG.Canvas.detectionModes[id]?.testVisibility(visionSource, mode, config) === true;
 		});

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1367,9 +1367,6 @@ preLocalize("autoTargetModes");
 DND4E.senses = {
 	nv: {
 		label: "DND4E.VisionNormal",
-		detectionMode: "lightPerception",
-		grantsSight: true,
-		range: Infinity,
 	},
 	lv: {
 		label: "DND4E.VisionLowLight",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1398,6 +1398,7 @@ DND4E.senses = {
 		label: "DND4E.SpecialSensesTS",
 		detectionMode: "feelTremor",
 		grantsSight: true,
+		visionMode: "tremorsense",
 	},
 	tr: {
 		label: "DND4E.SpecialSensesTR",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1367,6 +1367,9 @@ preLocalize("autoTargetModes");
 DND4E.senses = {
 	nv: {
 		label: "DND4E.VisionNormal",
+		detectionMode: "lightPerception",
+		grantsSight: true,
+		range: Infinity,
 	},
 	lv: {
 		label: "DND4E.VisionLowLight",
@@ -1385,7 +1388,7 @@ DND4E.senses = {
 		label: "DND4E.SpecialSensesBS",
 		detectionMode: "seeAll",
 		grantsSight: true,
-		visionMode: "basicSight",
+		visionMode: "darkvision",
 	},
 	dv: {
 		label: "DND4E.SpecialSensesDV",
@@ -1403,7 +1406,7 @@ DND4E.senses = {
 		label: "DND4E.SpecialSensesTR",
 		detectionMode: "seeAll",
 		grantsSight: true,
-		visionMode: "basicSight",
+		visionMode: "darkvision",
 	},
 };
 preLocalize("senses", { keys: ["label"], sort: true });

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -75,10 +75,9 @@ export default class TokenDocument4e extends TokenDocument {
 		}
 
 		const sight = maxSightRange > -Infinity
-			? { enabled: true, range: maxSightRange }
+			? { enabled: true, range: maxSightRange, visionMode: sightVisionMode ?? "basic" }
 			: {};
 
-		if (sightVisionMode) sight.visionMode = sightVisionMode;
 		return { sight, detectionModes };
 	}
 

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -59,7 +59,7 @@ export default class TokenDocument4e extends TokenDocument {
 	 */
 	static computeSenseOverrides(senses) {
 		const detectionModes = {};
-		let maxSightRange = -1;
+		let maxSightRange = -Infinity;
 		let sightVisionMode = null;
 
 		for (const [key, config] of Object.entries(CONFIG.DND4E.senses)) {
@@ -74,7 +74,7 @@ export default class TokenDocument4e extends TokenDocument {
 			}
 		}
 
-		const sight = maxSightRange > 0
+		const sight = maxSightRange > -Infinity
 			? { enabled: true, range: maxSightRange }
 			: {};
 

--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -116,11 +116,12 @@ export async function d20Roll(form, { parts = [], partsExpressionReplacements = 
 				if (targetStatus.includes("bloodied")) targetBonuses.bloodied.shouldApply = true;
 
 				const closeOrArea = ["closeBurst", "closeBlast", "rangeBurst", "rangeBlast"].includes(item.system.rangeType);
-				if ((targetStatus.includes("concealed") || (utils.computeConcealment(attacker, target) === CONFIG.DND4E.CONCEALMENT.PARTIAL)) && !closeOrArea) targetBonuses.conceal.shouldApply = true;	
-				if ((targetStatus.includes("concealedTotal") || (utils.computeConcealment(attacker, target) === CONFIG.DND4E.CONCEALMENT.TOTAL)) && !closeOrArea) targetBonuses.concealTotal.shouldApply = true;
-
-				if (targetStatus.includes("cover")) targetBonuses.cover.shouldApply = true;		
+				const concealment = game.settings.get("dnd4e", "dynamicAutomation") ? utils.computeConcealment(attacker, target) : CONFIG.DND4E.CONCEALMENT.NONE;
+				if ((targetStatus.includes("concealedTotal") || (concealment === CONFIG.DND4E.CONCEALMENT.TOTAL)) && !closeOrArea) targetBonuses.concealTotal.shouldApply = true;
+				else if ((targetStatus.includes("concealed") || (concealment === CONFIG.DND4E.CONCEALMENT.PARTIAL)) && !closeOrArea) targetBonuses.conceal.shouldApply = true;	
+	
 				if (targetStatus.includes("coverSup")) targetBonuses.coverSup.shouldApply = true;
+				else if (targetStatus.includes("cover")) targetBonuses.cover.shouldApply = true;	
 			}
       
 			// Check Macros and Trigger Hook
@@ -373,11 +374,12 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 					if (targetStatus.includes("bloodied")) targetBonuses.bloodied.shouldApply = true;
 
 					const closeOrArea = ["closeBurst", "closeBlast", "rangeBurst", "rangeBlast"].includes(item.system.rangeType);
-					if ((targetStatus.includes("concealed") || (utils.computeConcealment(attacker, target) === CONFIG.DND4E.CONCEALMENT.PARTIAL)) && !closeOrArea) targetBonuses.conceal.shouldApply = true;	
-					if ((targetStatus.includes("concealedTotal") || (utils.computeConcealment(attacker, target) === CONFIG.DND4E.CONCEALMENT.TOTAL)) && !closeOrArea) targetBonuses.concealTotal.shouldApply = true;
+					const concealment = game.settings.get("dnd4e", "dynamicAutomation") ? utils.computeConcealment(attacker, target) : CONFIG.DND4E.CONCEALMENT.NONE;	
+					if ((targetStatus.includes("concealedTotal") || (concealment === CONFIG.DND4E.CONCEALMENT.TOTAL)) && !closeOrArea) targetBonuses.concealTotal.shouldApply = true;
+					else if ((targetStatus.includes("concealed") || (concealment === CONFIG.DND4E.CONCEALMENT.PARTIAL)) && !closeOrArea) targetBonuses.conceal.shouldApply = true;
 
-					if (targetStatus.includes("cover")) targetBonuses.cover.shouldApply = true;		
 					if (targetStatus.includes("coverSup")) targetBonuses.coverSup.shouldApply = true;
+					else if (targetStatus.includes("cover")) targetBonuses.cover.shouldApply = true;	
 				}        
 				if (hasComAdv) targetBonuses.comAdv.shouldApply = true;
 			}

--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -1865,19 +1865,19 @@ export function computeConcealment(token, target) {
 	const targetLight = target.lightLevel;
 	switch (targetLight) {
 		case LIGHT_LEVEL.DARK:
-			if (token.actor.system.senses.special.dv.value && (CONCEALMENT.NONE > concealmentLevel)) {
+			if (token.actor.system.senses.special.dv.value && (CONCEALMENT.NONE >= concealmentLevel)) {
 				concealmentLevel = CONCEALMENT.NONE;
 			}
-			else if (CONCEALMENT.TOTAL > concealmentLevel) {
+			else if (CONCEALMENT.TOTAL >= concealmentLevel) {
 				concealmentLevel = CONCEALMENT.TOTAL;
 			}
 			break;
 		case LIGHT_LEVEL.DIM:
-			if (token.actor.system.senses.special.dv.value && (CONCEALMENT.NONE > concealmentLevel)) {
+			if (token.actor.system.senses.special.dv.value && (CONCEALMENT.NONE >= concealmentLevel)) {
 				concealmentLevel = CONCEALMENT.NONE;
-			} else if (token.actor.system.senses.special.lv.value && (CONCEALMENT.NONE > concealmentLevel)) {
+			} else if (token.actor.system.senses.special.lv.value && (CONCEALMENT.NONE >= concealmentLevel)) {
 				concealmentLevel = CONCEALMENT.NONE;
-			} else if (CONCEALMENT.PARTIAL > concealmentLevel) {
+			} else if (CONCEALMENT.PARTIAL >= concealmentLevel) {
 				concealmentLevel = CONCEALMENT.PARTIAL;
 			}
 			break;

--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -1882,7 +1882,7 @@ export function computeConcealment(token, target) {
 			}
 			break;
 		case LIGHT_LEVEL.BRIGHT:
-			if (CONCEALMENT.NONE > concealmentLevel) concealmentLevel = CONCEALMENT.NONE;
+			if (CONCEALMENT.NONE >= concealmentLevel) concealmentLevel = CONCEALMENT.NONE;
 			break;
 	}
 


### PR DESCRIPTION
This is something I absolutely should have done after Fox's commit that added the setting, mea culpa. Also fix a bug where normal vision was not behaving appropriately when token vision is disabled.

Also make a slight adjustment so that we only suggest either concealment or total concealment and not both. Make the same change for cover.