### PR TITLE
Remove target check when propagating common attack bonuses from the roll dialog

### DIFF
--- a/module/helpers/dice.mjs
+++ b/module/helpers/dice.mjs
@@ -275,7 +275,7 @@ async function performD20RollAndCreateMessage(form, { parts, partsExpressionRepl
 						if (v.checked) {
 							targetBonuses.push(`@${bonusName}`);
 						}
-						if (targDataArray.hasTarget) targDataArray.targets[targetIndex].targetBonuses[bonusName].shouldApply = v.checked;
+						targDataArray.targets[targetIndex].targetBonuses[bonusName].shouldApply = v.checked;
 					}
 				}
 				if (!individualAttack && (k > 21)) {


### PR DESCRIPTION
I don't remember why I conditioned this on the presence of real targets.