### PR TITLE
Minor Fixes

### DIFF
--- a/module/applications/sheets/actor-sheet.mjs
+++ b/module/applications/sheets/actor-sheet.mjs
@@ -643,15 +643,10 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		if (data.system.movement.walk?.traits) data.moveTip += ` (${data.system.movement.walk.traits})`;
 		data.moveTip += `<br />+${parseInt(data.system.movement.run.value)} ${_loc("DND4E.Movement.Unit")} ${_loc("DND4E.Movement.Run")}`;
 		if (data.system.movement.run?.traits) data.moveTip += ` (${data.system.movement.run.traits})`;
-		data.moveTip += `<br />${parseInt(data.system.movement.charge.value)} ${_loc("DND4E.Movement.Unit")} ${_loc("DND4E.Movement.SpeedType", { mode: _loc("DND4E.Movement.Charge") })}`;
+		data.moveTip += `<br />${parseInt(data.system.movement.charge.value)} ${_loc("DND4E.Movement.Unit")} ${_loc("DND4E.Movement.Charge")}`;
 		if (data.system.movement.charge?.traits) data.moveTip += ` (${data.system.movement.charge.traits})`;
 		data.moveTip += `<br />${parseInt(data.system.movement.shift.value)} ${_loc("DND4E.Movement.Unit")} ${_loc("DND4E.Movement.SpeedType", { mode: _loc("DND4E.Movement.Shift") })}`;
 		if (data.system.movement.shift?.traits) data.moveTip += ` (${data.system.movement.shift.traits})`;
-		/*if(data.system.movement.burrow.value) data.moveTip += `<br>${parseInt(data.system.movement.burrow.value)} ${_loc("DND4E.MovementUnit")} ${_loc("DND4E.MovementSpeedBurrowing")}`;
-		if(data.system.movement.climb.value) data.moveTip += `<br>${parseInt(data.system.movement.climb.value)} ${_loc("DND4E.MovementUnit")} ${_loc("DND4E.MovementSpeedClimbing")}`;
-		if(data.system.movement.fly.value) data.moveTip += `<br>${parseInt(data.system.movement.fly.value)} ${_loc("DND4E.MovementUnit")} ${_loc("DND4E.MovementSpeedFlying")}`;
-		if(data.system.movement.swim.value) data.moveTip += `<br>${parseInt(data.system.movement.swim.value)} ${_loc("DND4E.MovementUnit")} ${_loc("DND4E.MovementSpeedSwimming")}`
-		if(data.system.movement.teleport.value) data.moveTip += `<br>${parseInt(data.system.movement.teleport.value)} ${_loc("DND4E.MovementUnit")} ${_loc("DND4E.MovementSpeedTeleporting")}`*/
 
 		const moveModes = ["burrow", "climb", "fly", "swim", "teleport"];
 		for (let m of moveModes) {

--- a/templates/apps/custom-skill-config.hbs
+++ b/templates/apps/custom-skill-config.hbs
@@ -36,19 +36,19 @@
         {{#each customSkills as |skill s|}}
         <tr class="custom-skill-line" data-row-id="{{s}}">
           <td class="custom-skill-label">
-            <input id="custom-skill-label-{{s}}" class="custom-skill-label" type="text" name="label" value="{{skill.label}}" data-dtype="String" {{disabled (contains skill.id ../originalIds)}} placeholder="{{localize 'DND4E.SkillLabel'}}" />
+            <input id="custom-skill-label-{{s}}" class="custom-skill-label" type="text" name="label" value="{{skill.label}}" data-dtype="String"placeholder="{{localize 'DND4E.SkillLabel'}}" />
           </td>
           <td class="custom-skill-id">
-            <input id="custom-skill-id-{{s}}" class="custom-skill-id" type="text" name="id" value="{{skill.id}}" data-dtype="String" {{disabled (contains skill.id ../originalIds)}} placeholder="{{localize 'DND4E.SkillID'}}" />
+            <input id="custom-skill-id-{{s}}" class="custom-skill-id" type="text" name="id" value="{{skill.id}}" data-dtype="String" placeholder="{{localize 'DND4E.SkillID'}}" />
           </td>
           <td class="custom-skill-ability">
-            <select id="custom-skill-attribute-{{s}}" class="custom-skill-ability" name="ability" {{disabled (contains skill.id ../originalIds)}}>
+            <select id="custom-skill-attribute-{{s}}" class="custom-skill-ability" name="ability">
               {{selectOptions ../abilities selected=skill.ability}}
               <option value="none" {{#if (eq skill.ability "none")}}selected{{/if}}>{{localize 'DND4E.None'}}</option>
             </select>
           </td>
           <td class="custom-skill-acp">
-            <input id="custom-skill-acp-{{s}}" class="custom-skill-acp" type="checkbox" name="armourCheck" {{checked skill.armourCheck}} data-dtype="Boolean"{{disabled (contains skill.id ../originalIds)}} data-tooltip="{{localize 'DND4E.Attribute'}}" />
+            <input id="custom-skill-acp-{{s}}" class="custom-skill-acp" type="checkbox" name="armourCheck" {{checked skill.armourCheck}} data-dtype="Boolean" data-tooltip="{{localize 'DND4E.Attribute'}}" />
           </td>
           <td class="custom-skill-control">
             <a class="custom-skill-control" data-action="deleteSkill" data-tooltip="{{localize 'DND4EUI.Delete'}}"><i class="fas fa-trash"></i></a>	

--- a/templates/apps/custom-status-config.hbs
+++ b/templates/apps/custom-status-config.hbs
@@ -37,16 +37,16 @@
         {{#each customStatuses as |status s|}}
         <tr class="custom-status-line" data-row-id="{{s}}">
           <td class="custom-status-image">
-            <img class="status-image" src="{{status.img}}" id="custom-status-img-{{s}}" type="checkbox" data-action="editImage" data-edit="img" alt="{{localize 'DND4E.StatusImage'}}" {{disabled (contains status.id ../originalIds)}} />
+            <img class="status-image" src="{{status.img}}" id="custom-status-img-{{s}}" type="checkbox" data-action="editImage" data-edit="img" alt="{{localize 'DND4E.StatusImage'}}" />
           </td>
           <td class="custom-status-name">
-            <input id="custom-status-name-{{s}}" class="custom-status-name" type="text" name="name" value="{{status.name}}" data-dtype="String" {{disabled (contains status.id ../originalIds)}} placeholder="{{localize 'DND4E.StatusName'}}" />
+            <input id="custom-status-name-{{s}}" class="custom-status-name" type="text" name="name" value="{{status.name}}" data-dtype="String" placeholder="{{localize 'DND4E.StatusName'}}" />
           </td>
           <td class="custom-status-id">
-            <input id="custom-status-id-{{s}}" class="custom-status-id" type="text" name="id" value="{{status.id}}" data-dtype="String" {{disabled (contains status.id ../originalIds)}} placeholder="{{localize 'DND4E.StatusId'}}" />
+            <input id="custom-status-id-{{s}}" class="custom-status-id" type="text" name="id" value="{{status.id}}" data-dtype="String" placeholder="{{localize 'DND4E.StatusId'}}" />
           </td>
           <td class="custom-status-description">
-            <textarea id="custom-status-description-{{s}}" class="custom-status-description" name="description" {{disabled (contains status.id ../originalIds)}} placeholder="{{localize 'DND4E.StatusDescription'}}">{{status.description}}</textarea>
+            <textarea id="custom-status-description-{{s}}" class="custom-status-description" name="description" placeholder="{{localize 'DND4E.StatusDescription'}}">{{status.description}}</textarea>
           </td>
           <td class="custom-status-control">
             <a class="custom-status-control" data-action="deleteStatus" data-tooltip="{{localize 'DND4EUI.Delete'}}"><i class="fas fa-trash"></i></a>	

--- a/templates/items/parts/details-power.hbs
+++ b/templates/items/parts/details-power.hbs
@@ -524,8 +524,7 @@
     {{{effectDetailHTML}}}
   </prose-mirror>
   {{else}}
-  <textarea class="no-mono" name="system.effect.detail" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">
-    {{system.effect.detail}}</textarea>
+  <textarea class="no-mono" name="system.effect.detail" placeholder="{{ localize 'DND4EUI.PowerTextFieldsPlaceholder'}}">{{system.effect.detail}}</textarea>
   {{/if}}
   <div class="form-group right">
     <label>{{ localize "DND4EUI.DisplayEffect" }}</label> 


### PR DESCRIPTION
Just a few things I noticed while updating my content packs.
- Removes an extra tab character that was being inserted into the "Effect" field of powers, due to HTML layout.
- Fixed the speed tooltip displaying "Charge Bonus Speed" after charge update
- Preventing custom skill/status config forms from disabling text fields on entries that match core IDs. There probably was a reason for this in the past, but now it seems like a bad idea when we want users to be able to override system defaults.