### PR TITLE
Add Synced Sense notice to Token Config

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -2003,6 +2003,7 @@
 "SHEET.NPC": "NPC Sheet",
 "SHEET.Hazard": "Trap/Hazard Sheet",
 "SHEET.Item": "Item Sheet",
+"SHEET.Token": "Token Sheet",
 
 "TYPES": {
 	"Actor": {

--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1980,6 +1980,8 @@
 "SETTINGS.4eSaveRemindersL": "Each \"save ends\" effect on a creature prompts for a saving throw at the end of their turn, or rolls a save automatically if Fast-Forward is enabled.",
 "SETTINGS.4eSenseVisionN": "Sync Senses to Token Vision",
 "SETTINGS.4eSenseVisionL": "Automatically configure token vision range, vision mode, and detection modes based on the actor's senses.",
+"SETTINGS.4eSenseVisionNotice": "Vision and detection are synced from this actor's {senses}.",
+"SETTINGS.4eSenseVisionSenses": "senses",
 "SETTINGS.4eShowRollExpressionN": "Show Roll Formula",
 "SETTINGS.4eShowRollExpressionL": "Display the formula used to create a given d20 or damage roll. Useful to find out how a roll was calculate but may be confusing for novice users",
 "SETTINGS.4eShowDefencesN": "Show Defence Values",

--- a/lang/en.json
+++ b/lang/en.json
@@ -2003,6 +2003,7 @@
 "SHEET.NPC": "NPC Sheet",
 "SHEET.Hazard": "Trap/Hazard Sheet",
 "SHEET.Item": "Item Sheet",
+"SHEET.Token": "Token Sheet",
 
 "TYPES": {
 	"Actor": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -1980,6 +1980,8 @@
 "SETTINGS.4eSaveRemindersL": "Each \"save ends\" effect on a creature prompts for a saving throw at the end of their turn, or rolls a save automatically if Fast-Forward is enabled.",
 "SETTINGS.4eSenseVisionN": "Sync Senses to Token Vision",
 "SETTINGS.4eSenseVisionL": "Automatically configure token vision range, vision mode, and detection modes based on the actor's senses.",
+"SETTINGS.4eSenseVisionNotice": "Vision and detection are synced from this actor's {senses}.",
+"SETTINGS.4eSenseVisionSenses": "senses",
 "SETTINGS.4eShowRollExpressionN": "Show Roll Formula",
 "SETTINGS.4eShowRollExpressionL": "Display the formula used to create a given d20 or damage roll. Useful to find out how a roll was calculate but may be confusing for novice users",
 "SETTINGS.4eShowDefencesN": "Show Defense Values",

--- a/module/applications/sheets/_module.mjs
+++ b/module/applications/sheets/_module.mjs
@@ -4,3 +4,5 @@ export { default as ActorSheet4eHazard } from "./hazard-sheet.mjs";
 export { default as ActorSheet4eNPC } from "./npc-sheet.mjs";
 export { default as DifficultTerrainConfig } from "./difficult-terrain-config.mjs";
 export { default as ItemSheet4e } from "./item-sheet.mjs";
+
+export * as token from "./token/_module.mjs";

--- a/module/applications/sheets/token/_module.mjs
+++ b/module/applications/sheets/token/_module.mjs
@@ -1,0 +1,1 @@
+export { PrototypeTokenConfig4e, TokenConfig4e } from "./token-config.mjs";

--- a/module/applications/sheets/token/token-config.mjs
+++ b/module/applications/sheets/token/token-config.mjs
@@ -1,0 +1,65 @@
+import TraitSelectorValues from "../../apps/trait-selector-sense.mjs";
+
+/**
+ * Custom token configuration application for handling synced senses.
+ */
+export class TokenConfig4e extends foundry.applications.sheets.TokenConfig {
+
+	/** @inheritDoc */
+	async _onRender(context, options) {
+		await super._onRender(context, options);
+		if (!this.rendered) return;
+		this._applySenseSyncNotice(this.element);
+	}
+
+	/* -------------------------------------------- */
+
+	/**
+   * Lock the Vision tab fields that are derived from the actor's senses and surface a sync notice.
+   * @param {HTMLElement} html  The rendered markup.
+   * @protected
+   */
+	_applySenseSyncNotice(html) {
+		if (!game.settings.get("dnd4e", "senseVisionSync")) return;
+		const actor = this.actor ?? this.object?.actor;
+		const senses = actor?.system?.senses?.special;
+		if (!senses) return;
+
+		const { sight, detectionModes } = CONFIG.Token.documentClass.computeSenseOverrides(senses);
+		if (!sight.enabled && foundry.utils.isEmpty(detectionModes)) return;
+
+		// Lock sight to the derived values; these bind to source, so they would otherwise show stale, editable data.
+		if (sight.enabled) {
+			const range = html.querySelector("[name=\"sight.range\"]");
+			const mode = html.querySelector("[name=\"sight.visionMode\"]");
+			if (range) Object.assign(range, { value: sight.range, disabled: true });
+			if (mode) Object.assign(mode, { value: sight.visionMode, disabled: true });
+		}
+
+		// Surface a notice atop the Vision tab linking to the senses config.
+		const tab = html.querySelector("[data-application-part=\"vision\"]");
+		if (!tab || tab.querySelector(".sense-sync-notice")) return;
+		const link = `<a data-action="editSenses">${_loc("SETTINGS.4eSenseVisionSenses")}</a>`;
+		const notice = document.createElement("p");
+		notice.className = "hint sense-sync-notice";
+		notice.innerHTML = `<i class="fa-solid fa-circle-info"></i> ${
+			_loc("SETTINGS.4eSenseVisionNotice", { senses: link })}`;
+		notice.querySelector("[data-action=editSenses]")?.addEventListener("click", () => {
+			const options = { name: "system.senses.special", window: { title: _loc("DND4E.SpecialSenses") }, choices: CONFIG.DND4E["senses"] };
+			new TraitSelectorValues({ document: actor, ...options }).render(true, { force: true });
+		});
+		tab.prepend(notice);
+	}
+}
+
+/**
+ * Custom prototype token configuration application for handling synced senses.
+ */
+export class PrototypeTokenConfig4e extends foundry.applications.sheets.PrototypeTokenConfig {
+	/** @inheritDoc */
+	async _onRender(context, options) {
+		await super._onRender(context, options);
+		if (!this.rendered) return;
+		TokenConfig4e.prototype._applySenseSyncNotice.call(this, this.element);
+	}
+}

--- a/module/dnd4e.mjs
+++ b/module/dnd4e.mjs
@@ -155,6 +155,12 @@ Hooks.once("init", async function() {
 		makeDefault: true,
 	});
 
+	CONFIG.Token.prototypeSheetClass = applications.sheets.token.PrototypeTokenConfig4e;
+	foundry.applications.apps.DocumentSheetConfig.unregisterSheet(TokenDocument, "core", foundry.applications.sheets.TokenConfig);
+	foundry.applications.apps.DocumentSheetConfig.registerSheet(TokenDocument, "dnd4e", applications.sheets.token.TokenConfig4e, {
+		label: "DND4E.SheetClass.Token",
+	});
+
 	foundry.applications.apps.DocumentSheetConfig.unregisterSheet(RegionBehavior, "core", foundry.applications.sheets.RegionBehaviorConfig, {
 		types: ["difficultTerrain"],
 	});

--- a/module/dnd4e.mjs
+++ b/module/dnd4e.mjs
@@ -158,7 +158,7 @@ Hooks.once("init", async function() {
 	CONFIG.Token.prototypeSheetClass = applications.sheets.token.PrototypeTokenConfig4e;
 	foundry.applications.apps.DocumentSheetConfig.unregisterSheet(TokenDocument, "core", foundry.applications.sheets.TokenConfig);
 	foundry.applications.apps.DocumentSheetConfig.registerSheet(TokenDocument, "dnd4e", applications.sheets.token.TokenConfig4e, {
-		label: "DND4E.SheetClass.Token",
+		label: "SHEET.Token",
 	});
 
 	foundry.applications.apps.DocumentSheetConfig.unregisterSheet(RegionBehavior, "core", foundry.applications.sheets.RegionBehaviorConfig, {

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -98,7 +98,7 @@ export default class TokenDocument4e extends TokenDocument {
 		}
 
 		if (Object.keys(sight).length) {
-			Object.assign(target.sight, sight);
+			Object.assign(target.sight, { range: sight.range, visionMode: sight.visionMode });
 		}
 	}
 


### PR DESCRIPTION
When token vision is synced to actor senses, display a notice indicating as such, with a link to the actor's senses config. Disable the vision mode dropdown in this case, as it can't actually be overridden. Fix issue where disabling token vision wouldn't actually disable token vision when senses were synced.