### PR TITLE
Add option to 4e region behaviors to exclude the region's creator from its effects

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1489,6 +1489,10 @@
 			"types": {
 				"hint": "If set, only apply effects to Tokens with these creature types.",
 				"label": "Types"
+			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
 			}
 		}
 	},
@@ -1513,6 +1517,10 @@
 			"types": {
 				"hint": "If set, only damage Tokens with these creature types.",
 				"label": "Types"
+			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
 			}
 		}
 	},
@@ -1525,6 +1533,10 @@
 			"types": {
 				"hint": "Types that best describe the source of this difficult terrain, if any.",
 				"label": "Types"
+			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
 			}
 		},
 		"Type": {
@@ -1558,6 +1570,10 @@
 			"types": {
 				"hint": "If set, only Tokens with these creature types are affected by this terrain.",
 				"label": "Types"
+			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
 			}
 		}
 	}

--- a/lang/en.json
+++ b/lang/en.json
@@ -1489,6 +1489,10 @@
 			"types": {
 				"hint": "If set, only apply effects to Tokens with these creature types.",
 				"label": "Types"
+			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
 			}
 		}
 	},
@@ -1513,6 +1517,10 @@
 			"types": {
 				"hint": "If set, only damage Tokens with these creature types.",
 				"label": "Types"
+			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
 			}
 		}
 	},
@@ -1525,6 +1533,10 @@
 			"types": {
 				"hint": "Types that best describe the source of this difficult terrain, if any.",
 				"label": "Types"
+			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
 			}
 		},
 		"Type": {
@@ -1558,6 +1570,10 @@
 			"types": {
 				"hint": "If set, only Tokens with these creature types are affected by this terrain.",
 				"label": "Types"
+			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
 			}
 		}
 	}

--- a/module/data/region-behaviors/_types.mjs
+++ b/module/data/region-behaviors/_types.mjs
@@ -4,21 +4,24 @@
  * @property {Set<number>} dispositions  If not empty, only apply effects to tokens with these dispositions.
  * @property {Set<string>} origins       If not empty, only apply effects to tokens with these creature origins.
  * @property {Set<string>} types         If not empty, only apply effects to tokens with these creature types.
+ * @property {boolean} excludeCreator   If set, don't apply effects to the actor that created the region.
  */
 
 /**
  * @typedef DamagingRegionRegionBehaviorSystemData
  * @property {String} damage             Damage to be dealt to tokens within the region.
  * @property {Set<string>} damageTypes   Damage types this region behavior should deal.
- * @property {Set<number>} dispositions  If not empty, only apply effects to tokens with these dispositions.
- * @property {Set<string>} origins       If not empty, only apply effects to tokens with these creature origins.
- * @property {Set<string>} types         If not empty, only apply effects to tokens with these creature types.
+ * @property {Set<number>} dispositions  If not empty, only deal damage to tokens with these dispositions.
+ * @property {Set<string>} origins       If not empty, only deal damage to tokens with these creature origins.
+ * @property {Set<string>} types         If not empty, only deal damage to tokens with these creature types.
+ * @property {boolean} excludeCreator   If set, don't deal damage to the actor that created the region.
  */
 
 /**
  * @typedef DifficultTerrainRegionBehaviorSystemData
  * @property {Set<string>} types                Types of difficult terrain represented.
  * @property {Set<number>} ignoredDispositions  Token dispositions that won't be affected by this difficult terrain.
+ * @property {boolean} excludeCreator          If set, don't affect the actor that created the region.
  */
 
 /**
@@ -27,4 +30,5 @@
  * @property {Set<number>} dispositions  If not empty, only tokens with these dispositions are affected.
  * @property {Set<string>} origins       If not empty, only tokens with these creature origins are affected.
  * @property {Set<string>} types         If not empty, only tokens with these creature types are affected.
+ * @property {boolean} excludeCreator   If set, the actor that created the region is not affected.
  */

--- a/module/data/region-behaviors/_types.mjs
+++ b/module/data/region-behaviors/_types.mjs
@@ -4,7 +4,7 @@
  * @property {Set<number>} dispositions  If not empty, only apply effects to tokens with these dispositions.
  * @property {Set<string>} origins       If not empty, only apply effects to tokens with these creature origins.
  * @property {Set<string>} types         If not empty, only apply effects to tokens with these creature types.
- * @property {boolean} excludeCreator   If set, don't apply effects to the actor that created the region.
+ * @property {boolean} excludeCreator    If set, don't apply effects to the actor that created the region.
  */
 
 /**
@@ -14,14 +14,14 @@
  * @property {Set<number>} dispositions  If not empty, only deal damage to tokens with these dispositions.
  * @property {Set<string>} origins       If not empty, only deal damage to tokens with these creature origins.
  * @property {Set<string>} types         If not empty, only deal damage to tokens with these creature types.
- * @property {boolean} excludeCreator   If set, don't deal damage to the actor that created the region.
+ * @property {boolean} excludeCreator    If set, don't deal damage to the actor that created the region.
  */
 
 /**
  * @typedef DifficultTerrainRegionBehaviorSystemData
  * @property {Set<string>} types                Types of difficult terrain represented.
  * @property {Set<number>} ignoredDispositions  Token dispositions that won't be affected by this difficult terrain.
- * @property {boolean} excludeCreator          If set, don't affect the actor that created the region.
+ * @property {boolean} excludeCreator           If set, don't affect the actor that created the region.
  */
 
 /**
@@ -30,5 +30,5 @@
  * @property {Set<number>} dispositions  If not empty, only tokens with these dispositions are affected.
  * @property {Set<string>} origins       If not empty, only tokens with these creature origins are affected.
  * @property {Set<string>} types         If not empty, only tokens with these creature types are affected.
- * @property {boolean} excludeCreator   If set, the actor that created the region is not affected.
+ * @property {boolean} excludeCreator    If set, the actor that created the region is not affected.
  */

--- a/module/data/region-behaviors/apply-active-effect.mjs
+++ b/module/data/region-behaviors/apply-active-effect.mjs
@@ -46,7 +46,7 @@ export default class ApplyActiveEffect4eRegionBehaviorType extends foundry.data.
 		if (this.dispositions.size && !this.dispositions.has(token.disposition)) return false;
 		if (this.origins.size && !this.origins.has(token.actor.system.details?.origin)) return false;
 		if (this.types.size && !this.types.has(token.actor.system.details?.type)) return false;
-		if (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid)) return false;
+		if (this.excludeCreator && (this.parent.parent.flags?.dnd4e?.actorUuid === token.actor.uuid)) return false;
 		return true;
 	}
 

--- a/module/data/region-behaviors/apply-active-effect.mjs
+++ b/module/data/region-behaviors/apply-active-effect.mjs
@@ -1,6 +1,6 @@
 // Adapted from the Foundry Virtual Tabletop - Dungeons & Dragons Fifth Edition Game System licensed under the MIT license
 
-const { DocumentUUIDField, NumberField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, DocumentUUIDField, NumberField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { ActiveEffect4e, Actor4e } from "../../documents/_module.mjs";
@@ -29,6 +29,7 @@ export default class ApplyActiveEffect4eRegionBehaviorType extends foundry.data.
 			dispositions: new SetField(new NumberField({ choices: dispositions })),
 			origins: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureOrigin })),
 			types: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureType })),
+			excludeCreator: new BooleanField(),
 		};
 	}
 
@@ -45,6 +46,7 @@ export default class ApplyActiveEffect4eRegionBehaviorType extends foundry.data.
 		if (this.dispositions.size && !this.dispositions.has(token.disposition)) return false;
 		if (this.origins.size && !this.origins.has(token.actor.system.details?.origin)) return false;
 		if (this.types.size && !this.types.has(token.actor.system.details?.type)) return false;
+		if (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid)) return false;
 		return true;
 	}
 

--- a/module/data/region-behaviors/damaging-region.mjs
+++ b/module/data/region-behaviors/damaging-region.mjs
@@ -130,7 +130,7 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 		if (this.dispositions.size && !this.dispositions.has(token.disposition)) return false;
 		if (this.origins.size && !this.origins.has(token.actor.system.details?.origin)) return false;
 		if (this.types.size && !this.types.has(token.actor.system.details?.type)) return false;
-		if (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid)) return false;
+		if (this.excludeCreator && (this.parent.parent.flags?.dnd4e?.actorUuid === token.actor.uuid)) return false;
 		return true;
 	}
 }

--- a/module/data/region-behaviors/damaging-region.mjs
+++ b/module/data/region-behaviors/damaging-region.mjs
@@ -1,6 +1,6 @@
 // Adapted from the Foundry Virtual Tabletop - Dungeons & Dragons Fifth Edition Game System licensed under the MIT license
 
-const { NumberField, SetField, StringField } = foundry.data.fields;
+const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
 import { FormulaField } from "../fields/_module.mjs";
 import * as utils from "../../utils/utils.mjs";
 
@@ -34,6 +34,7 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 			dispositions: new SetField(new NumberField({ choices: dispositions })),
 			origins: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureOrigin })),
 			types: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureType })),
+			excludeCreator: new BooleanField(),
 		};
 	}
 
@@ -129,6 +130,7 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 		if (this.dispositions.size && !this.dispositions.has(token.disposition)) return false;
 		if (this.origins.size && !this.origins.has(token.actor.system.details?.origin)) return false;
 		if (this.types.size && !this.types.has(token.actor.system.details?.type)) return false;
+		if (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid)) return false;
 		return true;
 	}
 }

--- a/module/data/region-behaviors/difficult-terrain.mjs
+++ b/module/data/region-behaviors/difficult-terrain.mjs
@@ -90,7 +90,7 @@ export default class DifficultTerrainRegionBehaviorType extends foundry.data.reg
 			|| this.ignoredDispositions.has(token.disposition)
 			|| ignoredTypes.has("all")
 			|| (this.types.size && !this.types.difference(ignoredTypes).size)
-			|| (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid))) return [];
+			|| (this.excludeCreator && (this.parent.parent.flags?.dnd4e?.actorUuid === token.actor.uuid))) return [];
 		return [{ name: "difficultTerrain" }];
 	}
 }

--- a/module/data/region-behaviors/difficult-terrain.mjs
+++ b/module/data/region-behaviors/difficult-terrain.mjs
@@ -89,7 +89,7 @@ export default class DifficultTerrainRegionBehaviorType extends foundry.data.reg
 		if ((segment.action === "blink")
 			|| this.ignoredDispositions.has(token.disposition)
 			|| ignoredTypes.has("all")
-      		|| (this.types.size && !this.types.difference(ignoredTypes).size)
+			|| (this.types.size && !this.types.difference(ignoredTypes).size)
 			|| (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid))) return [];
 		return [{ name: "difficultTerrain" }];
 	}

--- a/module/data/region-behaviors/difficult-terrain.mjs
+++ b/module/data/region-behaviors/difficult-terrain.mjs
@@ -25,6 +25,7 @@ export default class DifficultTerrainRegionBehaviorType extends foundry.data.reg
 		return {
 			types: new SetField(new StringField()),
 			ignoredDispositions: new SetField(new NumberField({ choices: dispositions })),
+			excludeCreator: new BooleanField(),
 		};
 	}
 
@@ -85,8 +86,11 @@ export default class DifficultTerrainRegionBehaviorType extends foundry.data.reg
 	/** @inheritDoc */
 	_getTerrainEffects(token, segment) {
 		const ignoredTypes = token.actor?.system.movement?.ignoredDifficultTerrain;
-		if ((segment.action === "blink") || this.ignoredDispositions.has(token.disposition) || ignoredTypes.has("all")
-      || (this.types.size && !this.types.difference(ignoredTypes).size)) return [];
+		if ((segment.action === "blink")
+			|| this.ignoredDispositions.has(token.disposition)
+			|| ignoredTypes.has("all")
+      		|| (this.types.size && !this.types.difference(ignoredTypes).size)
+			|| (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid))) return [];
 		return [{ name: "difficultTerrain" }];
 	}
 }

--- a/module/data/region-behaviors/obscured-terrain.mjs
+++ b/module/data/region-behaviors/obscured-terrain.mjs
@@ -31,6 +31,7 @@ export default class ObscuredTerrainRegionBehaviorType extends foundry.data.regi
 			dispositions: new SetField(new NumberField({ choices: dispositions })),
 			origins: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureOrigin })),
 			types: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureType })),
+			excludeCreator: new BooleanField(),
 		};
 	}
 
@@ -45,6 +46,7 @@ export default class ObscuredTerrainRegionBehaviorType extends foundry.data.regi
 		if (this.dispositions.size && !this.dispositions.has(token.disposition)) return false;
 		if (this.origins.size && !this.origins.has(token.actor.system.details?.origin)) return false;
 		if (this.types.size && !this.types.has(token.actor.system.details?.type)) return false;
+		if (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid)) return false;
 		return true;
 	}
 }

--- a/module/data/region-behaviors/obscured-terrain.mjs
+++ b/module/data/region-behaviors/obscured-terrain.mjs
@@ -46,7 +46,7 @@ export default class ObscuredTerrainRegionBehaviorType extends foundry.data.regi
 		if (this.dispositions.size && !this.dispositions.has(token.disposition)) return false;
 		if (this.origins.size && !this.origins.has(token.actor.system.details?.origin)) return false;
 		if (this.types.size && !this.types.has(token.actor.system.details?.type)) return false;
-		if (this.excludeCreator && (this.parent?.parent?.flags?.dnd4e?.actorUuid === token.actor?.uuid)) return false;
+		if (this.excludeCreator && (this.parent.parent.flags?.dnd4e?.actorUuid === token.actor.uuid)) return false;
 		return true;
 	}
 }


### PR DESCRIPTION
This option only has an impact if the region was created by an actor, such as via use of a power.

Closes #739 (?)