### PR TITLE
Add "applyBonuses" config option to roll enricher

### DIFF
--- a/module/applications/ux/enrichers/roll.mjs
+++ b/module/applications/ux/enrichers/roll.mjs
@@ -150,7 +150,7 @@ export async function enrichCheck(parsedConfig, label, options) {
  * @returns {HTMLElement|null}         An HTML link if the enricher could be built, otherwise null.
  */
 async function enrichAttack(parsedConfig, label, options) {
-	let { formula, ability, def, title, flavor } = parsedConfig;
+	let { formula, ability, def, applyBonuses, title, flavor } = parsedConfig;
 
 	const longAbilities = Object.fromEntries(Array.from(Object.entries(CONFIG.DND4E.abilities)).map((arr) => [arr[1].toLowerCase(), arr[0]]));
 	const longDefenses = Object.fromEntries(Array.from(Object.entries(CONFIG.DND4E.defensives)).map((arr) => [arr[1].labelShort.toLowerCase(), arr[0]]));
@@ -189,6 +189,7 @@ async function enrichAttack(parsedConfig, label, options) {
 		replacedFormula,
 		ability,
 		def,
+		applyBonuses,
 		title,
 		flavor,
 		itemUuid: options.rollData?.item?.uuid,
@@ -238,7 +239,7 @@ async function enrichAttack(parsedConfig, label, options) {
  * @returns {HTMLElement|null}         An HTML link if the enricher could be built, otherwise null.
  */
 async function enrichDamageHealing(parsedConfig, label, options) {
-	let { type, formula, critFormula, damageType, healingType, title, flavor } = parsedConfig;
+	let { type, formula, critFormula, applyBonuses, damageType, healingType, title, flavor } = parsedConfig;
 	damageType = damageType || "";
 	healingType = healingType || "healing";
 
@@ -270,6 +271,7 @@ async function enrichDamageHealing(parsedConfig, label, options) {
 		critFormula,
 		replacedFormula,
 		replacedCritFormula,
+		applyBonuses,
 		title,
 		flavor,
 		itemUuid: options.rollData?.item?.uuid,
@@ -394,6 +396,8 @@ async function rollAttack(config, event) {
 	let flavor = config.flavor;
 	if (!formula) throw new Error("Attack enricher must provide a formula");
 
+	const applyBonuses = config.applyBonuses ? config.applyBonuses.toLowerCase() === "true" : true;
+
 	const parts = [replacedFormula];
 	const partsExpressionReplacements = [{ value: formula, target: replacedFormula }];
 
@@ -429,7 +433,7 @@ async function rollAttack(config, event) {
 
 	const powerData = rollData.item;
 	const weaponData = utils.getWeaponUse(powerData, actor)?.getRollData().item;
-	await utils.applyEffects(rollData, actor, powerData, weaponData, "attack", null, null, options);
+	if (applyBonuses) await utils.applyEffects(rollData, actor, powerData, weaponData, "attack", null, null, options);
 
 	if (!flavor && item) {
 		flavor = `${_loc("DND4E.AttackRoll")}: ${item.name}`;
@@ -471,8 +475,8 @@ async function rollAttack(config, event) {
  * @param {PointerEvent} event
  */
 async function rollDamageHealing(config, event) {
-	let { type, formula, replacedFormula, critFormula, replacedCritFormula, damageType, title, itemUuid, actorUuid, messageId } = config;
-	damageType = damageType?.split(",") || [];
+	let { type, formula, replacedFormula, critFormula, replacedCritFormula, applyBonuses, damageType, title, itemUuid, actorUuid, messageId } = config;
+	damageType = damageType ? damageType.split(",") : [];
 	let flavor = config.flavor;
 	if (!formula) throw new Error("Attack enricher must provide a formula");
 
@@ -502,6 +506,8 @@ async function rollDamageHealing(config, event) {
 		}
 	}
 
+	applyBonuses = applyBonuses ? applyBonuses.toLowerCase() === "true" : (item ? !item.system.hit.damageBonusNull : true);
+
 	const rollData = item?.getRollData() || actor?.getRollData() || {};
 
 	const options = { formulaInnerData: { ...utils.getDataObject(formula, rollData), ...utils.getDataObject(critFormula, rollData) }, divisors: { normal: { value: 1, reason: [] }, miss: { value: 1, reason: [] }, crit: { value: 1, reason: [] } }, bonuses: foundry.utils.deepClone(Roll4e.DEFAULT_OPTIONS.bonuses) };
@@ -510,7 +516,7 @@ async function rollDamageHealing(config, event) {
 	const powerData = rollData.item;
 	const weaponData = utils.getWeaponUse(powerData, actor)?.getRollData().item;
 	let extraDamageParts = [];
-	await utils.applyEffects(rollData, actor, powerData, weaponData, "damage", extraDamageParts, null, options);
+	if (applyBonuses) await utils.applyEffects(rollData, actor, powerData, weaponData, "damage", extraDamageParts, null, options);
 	// Extra damage
 	if (extraDamageParts.length) {
 		for (const part of extraDamageParts) {

--- a/module/applications/ux/enrichers/utils.mjs
+++ b/module/applications/ux/enrichers/utils.mjs
@@ -61,6 +61,6 @@ export function createLink(label, dataset = {}, { classes = "roll-link", tag = "
  */
 export function addDataset(element, dataset) {
 	for (const [key, value] of Object.entries(dataset)) {
-		if (!key.startsWith("_") && (key !== "values") && value) element.dataset[key] = value;
+		if (!key.startsWith("_") && (key !== "values") && (value != null)) element.dataset[key] = value;
 	}
 }


### PR DESCRIPTION
This option is used in attack and damage roll enrichers; if false, custom modifiers will not be applied to the roll. For attack rolls, this defaults to `true` if no value is explicitly passed into the enricher; I can't imagine a case where bonuses wouldn't apply to an attack roll and included the capability only for completeness. For damage rolls, if no value is explicitly passed in, we first defer to the item and add bonuses if the item's damage roll adds bonuses and don't if it doesn't; if no item exists for the enricher, we default to true.