### PR TITLE
Expand Damaging Region options

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1510,6 +1510,18 @@
 				"hint": "If set, only damage Tokens with these dispositions.",
 				"label": "Dispositions"
 			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator?"
+			},
+			"oncePerTurn": {
+				"hint": "If set, a token will only take this region's damage once per turn.",
+				"label": "Once Per Turn"
+			},
+			"onlyInCombat": {
+				"hint": "If set, this region will only deal damage during combat.",
+				"label": "Only In Combat"
+			},
 			"origins": {
 				"hint": "If set, only damage Tokens with these creature origins.",
 				"label": "Origins"
@@ -1517,10 +1529,6 @@
 			"types": {
 				"hint": "If set, only damage Tokens with these creature types.",
 				"label": "Types"
-			},
-			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
-				"label": "Exclude Creator?"
 			}
 		}
 	},

--- a/lang/en.json
+++ b/lang/en.json
@@ -1510,6 +1510,18 @@
 				"hint": "If set, only damage Tokens with these dispositions.",
 				"label": "Dispositions"
 			},
+			"excludeCreator": {
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"label": "Exclude Creator"
+			},
+			"oncePerTurn": {
+				"hint": "If set, a token will only take this region's damage once per turn.",
+				"label": "Once Per Turn"
+			},
+			"onlyInCombat": {
+				"hint": "If set, this region will only deal damage during combat.",
+				"label": "Only In Combat"
+			},
 			"origins": {
 				"hint": "If set, only damage Tokens with these creature origins.",
 				"label": "Origins"
@@ -1517,10 +1529,6 @@
 			"types": {
 				"hint": "If set, only damage Tokens with these creature types.",
 				"label": "Types"
-			},
-			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
-				"label": "Exclude Creator?"
 			}
 		}
 	},

--- a/module/data/region-behaviors/_types.mjs
+++ b/module/data/region-behaviors/_types.mjs
@@ -14,6 +14,8 @@
  * @property {Set<number>} dispositions  If not empty, only deal damage to tokens with these dispositions.
  * @property {Set<string>} origins       If not empty, only deal damage to tokens with these creature origins.
  * @property {Set<string>} types         If not empty, only deal damage to tokens with these creature types.
+ * @property {boolean} oncePerTurn       If set, only deal damage to a give token once per turn.
+ * @property {boolean} onlyInCombat      If set, don't deal damage outside of combat.
  * @property {boolean} excludeCreator    If set, don't deal damage to the actor that created the region.
  */
 

--- a/module/data/region-behaviors/damaging-region.mjs
+++ b/module/data/region-behaviors/damaging-region.mjs
@@ -34,6 +34,8 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 			dispositions: new SetField(new NumberField({ choices: dispositions })),
 			origins: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureOrigin })),
 			types: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureType })),
+			oncePerTurn: new BooleanField(),
+			onlyInCombat: new BooleanField(),
 			excludeCreator: new BooleanField(),
 		};
 	}
@@ -45,6 +47,8 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 	/** @inheritDoc */
 	async _handleRegionEvent(event) {
 		if (!this.damage) return;
+
+		if (this.onlyInCombat && !game.combat) return;
 
 		const { token } = event.data;
 		if (!this.#evaluateConditions(token)) return;
@@ -117,6 +121,12 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 				await actor.applyDamage(damageTaken);
 			}
 		}
+
+		if (this.oncePerTurn && game.combat) {
+			const perTurnArray = actor.getFlag("dnd4e", "damagingRegionPerTurn") ?? [];
+			perTurnArray.push(this.behavior.uuid);
+			await actor.setFlag("dnd4e", "damagingRegionPerTurn", perTurnArray);
+		}
 	}
 
 	/* ---------------------------------------- */
@@ -131,6 +141,7 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 		if (this.origins.size && !this.origins.has(token.actor.system.details?.origin)) return false;
 		if (this.types.size && !this.types.has(token.actor.system.details?.type)) return false;
 		if (this.excludeCreator && (this.parent.parent.flags?.dnd4e?.actorUuid === token.actor.uuid)) return false;
+		if (game.combat && token.actor.getFlag("dnd4e", "damagingRegionPerTurn")?.includes(this.behavior.uuid)) return false;
 		return true;
 	}
 }

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -2006,6 +2006,7 @@ export default class Actor4e extends Actor {
 		updateData["system.actionpoints.encounteruse"] = false;
 		
 		utils.rechargeItems(this, ["enc", "round", "turn"]);
+		await this.unsetFlag("dnd4e", "damagingRegionPerTurn");
 		utils.endEffects(this, ["endOfTargetTurn", "endOfUserTurn", "startOfTargetTurn", "startOfUserTurn", "endOfEncounter", "endOfUserCurrent", "attack", "check", "defence", "save", "damage"]);
 		
 		if (this.type === "Player Character") {
@@ -2075,6 +2076,7 @@ export default class Actor4e extends Actor {
 		updateData["system.actionpoints.encounteruse"] = false;
 		
 		utils.rechargeItems(this, ["enc", "day", "round", "turn"]);
+		await this.unsetFlag("dnd4e", "damagingRegionPerTurn");
 		utils.endEffects(this, ["endOfTargetTurn", "endOfUserTurn", "startOfTargetTurn", "startOfUserTurn", "endOfEncounter", "endOfDay", "endOfUserCurrent", "attack", "check", "defence", "save", "damage"]);
 
 		if (this.type === "Player Character") {

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -71,8 +71,18 @@ export default class Combat4e extends Combat {
 	/** @inheritDoc */
 	async _onEnter(combatant) {
 		const actor = combatant.actor;
-		if (!actor) return parent._onEnter(combatant);
-		await actor.unsetFlag("dnd4e", "damagingRegionPerTurn");
+		if (actor) {
+			await actor.unsetFlag("dnd4e", "damagingRegionPerTurn");
+		}
+		return super._onEnter(combatant);
+	}
+
+	/** @inheritDoc */
+	async _onExit(combatant) {
+		const actor = combatant.actor;
+		if (actor) {
+			await actor.unsetFlag("dnd4e", "damagingRegionPerTurn");
+		}
 		return super._onEnter(combatant);
 	}
 }

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -9,6 +9,7 @@ export default class Combat4e extends Combat {
 		//t current turn
 		for (let t of this.turns) {
 			utils.rechargeItems(t.token?.actor, ["turn"]);
+			await t.token?.actor?.unsetFlag("dnd4e", "damagingRegionPerTurn");
 		}
 		
 		// Signal the current actor to check end-of-turn saves
@@ -65,5 +66,13 @@ export default class Combat4e extends Combat {
 		}
 
 		return super.nextTurn(); 
+	}
+
+	/** @inheritDoc */
+	async _onEnter(combatant) {
+		const actor = combatant.actor;
+		if (!actor) return parent._onEnter(combatant);
+		await actor.unsetFlag("dnd4e", "damagingRegionPerTurn")
+		return super._onEnter(combatant);
 	}
 }

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -72,7 +72,7 @@ export default class Combat4e extends Combat {
 	async _onEnter(combatant) {
 		const actor = combatant.actor;
 		if (!actor) return parent._onEnter(combatant);
-		await actor.unsetFlag("dnd4e", "damagingRegionPerTurn")
+		await actor.unsetFlag("dnd4e", "damagingRegionPerTurn");
 		return super._onEnter(combatant);
 	}
 }


### PR DESCRIPTION
Add two new options to the Damaging Region behavior:
Once Per Turn, which causes a region to only deal its damage one per turn per actor
and
Only In Combat, which causes a region to only deal its damage during combat