### PR TITLE
Fix Character Sheet Defense Check Tooltip

### DIFF
--- a/templates/actors/actor-sheet.hbs
+++ b/templates/actors/actor-sheet.hbs
@@ -67,7 +67,7 @@
             {{#each system.defences as | def d|}}
             <div class="attribute-sub" data-defence="{{d}}">
               <strong class="attribute-name defence-bonus rollable" data-action="defencesBonus" data-tooltip="{{localize 'DND4E.BonusesTo' thing=def.label}}">{{def.value}}</strong>
-              <div class="attribute-display def-name rollable" data-action="rollDefenceCheck" data-tooltip="{{localize 'DND4E.SavePromptTitle' thing=def.title}}">{{def.label}}</div>
+              <div class="attribute-display def-name rollable" data-action="rollDefenceCheck" data-tooltip="{{localize 'DND4E.SavePromptTitle' defence=def.title}}">{{def.label}}</div>
             </div>
             {{/each}}
           </div>


### PR DESCRIPTION
A mislabeled parameter was causing the localization to fail.