### PR TITLE
Change Resource value/max into Numbers

### DIFF
--- a/module/data/actor/character.mjs
+++ b/module/data/actor/character.mjs
@@ -44,22 +44,22 @@ export default class CharacterData extends foundry.abstract.TypeDataModel {
 			resources: new SchemaField({
 				primary: new SchemaField({
 					label: new StringField({ initial: "" }),
-					value: new StringField({ initial: "" }),
-					max: new StringField({ initial: "", deterministic: true }),
+					value: new NumberField({ initial: 0 }),
+					max: new NumberField({ initial: null, nullable: true }),
 					sr: new BooleanField({ initial: false }),
 					lr: new BooleanField({ initial: false }),
 				}),
 				secondary: new SchemaField({
 					label: new StringField({ initial: "" }),
-					value: new StringField({ initial: "" }),
-					max: new StringField({ initial: "", deterministic: true }),
+					value: new NumberField({ initial: 0 }),
+					max: new NumberField({ initial: null, nullable: true }),
 					sr: new BooleanField({ initial: false }),
 					lr: new BooleanField({ initial: false }),
 				}),
 				tertiary: new SchemaField({
 					label: new StringField({ initial: "" }),
-					value: new StringField({ initial: "" }),
-					max: new StringField({ initial: "", deterministic: true }),
+					value: new NumberField({ initial: 0 }),
+					max: new NumberField({ initial: null, nullable: true }),
 					sr: new BooleanField({ initial: false }),
 					lr: new BooleanField({ initial: false }),
 				}),
@@ -102,6 +102,17 @@ export default class CharacterData extends foundry.abstract.TypeDataModel {
 
 		if ("defences" in source) {
 			CombatantTemplate.migrateDefences(source);
+		}
+
+		if ("resources" in source) {
+			for (let r of Object.entries(source.resources)) {
+				if ((source.resources[`${r[0]}`].value != null) && !parseInt(source.resources[`${r[0]}`].value)) {
+					source.resources[`${r[0]}`].value = 0;
+				}
+				if ((source.resources[`${r[0]}`].max != null) && !parseInt(source.resources[`${r[0]}`].max)) {
+					source.resources[`${r[0]}`].max = null;
+				}
+			}
 		}
 
 		return super.migrateData(source);

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -312,6 +312,11 @@ export default class Actor4e extends Actor {
 			system.encumbrance = this._computeEncumbrance(actorData.system);
 			this._prepareDerivedDataDeathThrow(actorData, system);
 			this._prepareDerivedDataMagicItemUse(actorData, system);
+			for (let r of Object.entries(this.system.resources)) {
+				if (r[1].label && (r[1].max != null)) {
+					system.resources[`${r[0]}`].value = Math.min(r[1].value, r[1].max);
+				}
+			}
 		} else {
 			SourceField.prepareData.call(this.system.source);
 		}

--- a/module/utils/utils.mjs
+++ b/module/utils/utils.mjs
@@ -2313,7 +2313,7 @@ const _attributeLabelCache = new Map();
  * Convert an attribute path to a human-readable label.
  * @param {string} attr							The attribute path.
  * @param {Object} [options]
- * @param {Actor5e} [options.actor]	An optional reference actor.
+ * @param {Actor4e} [options.actor]	An optional reference actor.
  * @returns {string|void}
  */
 export function getHumanReadableAttributeLabel(attr, { actor } = {}) {


### PR DESCRIPTION
This lets AE math work for resources. Roll data can't be entered directly into the sheet, but it can be used in AEs. `max` is now enforced in data prep, but only if `max` actually exists. It's nullable, so removing it will allow `value` to rise unbounded.

In the future, I'd like to make `max` a FormulaField, but that won't work nicely until we have separate edit/play modes for the sheets, which is a slightly larger undertaking than I want to undertake right now.