### PR TITLE
Small senses refactor

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1121,7 +1121,7 @@
 "DND4E.Trained": "Trained",
 "DND4E.TraitarmourProf": "Armour Proficiencies",
 "DND4E.TraitSave": "Update",
-"DND4E.TraitSelectorSpecial": "Special (Split with Semi-Colon)",
+"DND4E.TraitSelectorSpecial": "Custom (Split with Semi-Colon)",
 "DND4E.TraitWeaponProf": "Weapon Proficiencies",
 "DND4E.Transmutation": "Transmutation",
 "DND4E.Trigger": "Trigger",
@@ -1914,12 +1914,12 @@
 	"UnknownCondition.Label": "Unknown value",
 	"UnknownCondition.Tip": "No match was found for this id in the current status conditions configuration.",
   "NOTIFICATIONS": {
-    "ammoInsufficient": "The {resourceType} requires {quantity} of '{target}' but the character only has {ammoCount}",
-    "ammoMissing": "The {resourceType} requires ammunition, but none could be found on the character",
-    "ammoUncounted": "The {resourceType} requires ammunition, but the quantity ('{quantity}') was empty",
-    "ammoUntyped": "The {resourceType} requires ammunition, but the type ('{target}') was empty",
-    "cantAttack": "You may not make an Attack Roll with this Item.",
-    "cantDamage": "You may not make a Damage Roll with this Item."
+	"ammoInsufficient": "The {resourceType} requires {quantity} of '{target}' but the character only has {ammoCount}",
+	"ammoMissing": "The {resourceType} requires ammunition, but none could be found on the character",
+	"ammoUncounted": "The {resourceType} requires ammunition, but the quantity ('{quantity}') was empty",
+	"ammoUntyped": "The {resourceType} requires ammunition, but the type ('{target}') was empty",
+	"cantAttack": "You may not make an Attack Roll with this Item.",
+	"cantDamage": "You may not make a Damage Roll with this Item."
   },
 	"Yes": "Yes"
 },

--- a/lang/en.json
+++ b/lang/en.json
@@ -1121,7 +1121,7 @@
 "DND4E.Trained": "Trained",
 "DND4E.TraitarmourProf": "Armor Proficiencies",
 "DND4E.TraitSave": "Update",
-"DND4E.TraitSelectorSpecial": "Special (Split with Semi-Colon)",
+"DND4E.TraitSelectorSpecial": "Custom (Split with Semi-Colon)",
 "DND4E.TraitWeaponProf": "Weapon Proficiencies",
 "DND4E.Transmutation": "Transmutation",
 "DND4E.Trigger": "Trigger",
@@ -1914,12 +1914,12 @@
 	"UnknownCondition.Label": "Unknown value",
 	"UnknownCondition.Tip": "No match was found for this id in the current status conditions configuration.",
   "NOTIFICATIONS": {
-    "ammoInsufficient": "The {resourceType} requires {quantity} of '{target}' but the character only has {ammoCount}",
-    "ammoMissing": "The {resourceType} requires ammunition, but none could be found on the character",
-    "ammoUncounted": "The {resourceType} requires ammunition, but the quantity ('{quantity}') was empty",
-    "ammoUntyped": "The {resourceType} requires ammunition, but the type ('{target}') was empty",
-    "cantAttack": "You may not make an Attack Roll with this Item.",
-    "cantDamage": "You may not make a Damage Roll with this Item."
+	"ammoInsufficient": "The {resourceType} requires {quantity} of '{target}' but the character only has {ammoCount}",
+	"ammoMissing": "The {resourceType} requires ammunition, but none could be found on the character",
+	"ammoUncounted": "The {resourceType} requires ammunition, but the quantity ('{quantity}') was empty",
+	"ammoUntyped": "The {resourceType} requires ammunition, but the type ('{target}') was empty",
+	"cantAttack": "You may not make an Attack Roll with this Item.",
+	"cantDamage": "You may not make a Damage Roll with this Item."
   },
 	"Yes": "Yes"
 },

--- a/module/applications/apps/trait-selector-sense.mjs
+++ b/module/applications/apps/trait-selector-sense.mjs
@@ -32,11 +32,19 @@ export default class TraitSelectorValues extends foundry.applications.api.Handle
 	/* -------------------------------------------- */
 
 	/**
-     * Returns a reference to the target attribute
-     * @type {string}
-     */
+	 * Returns a reference to the target attribute
+	 * @type {string}
+	 */
 	get attribute() {
 		return this.options.name;
+	}
+
+	/**
+	 * Returns a reference to the target's custom path (or null)
+	 * @type {string}
+	 */
+	get custom() {
+		return this.options.custom ?? this.attribute.custom ?? null;
 	}
 
 	/** @inheritDoc */
@@ -56,6 +64,8 @@ export default class TraitSelectorValues extends foundry.applications.api.Handle
 		const attr = foundry.utils.getProperty(this.document, this.attribute) || {};
 		let values = Object.keys(attr).map((key) => [key, attr[key]]);
 
+		context.valuelessTraits = this.options.valuelessTraits;
+
 		// Populate choices
 		let choices = foundry.utils.duplicate(this.options.choices);
 
@@ -69,7 +79,13 @@ export default class TraitSelectorValues extends foundry.applications.api.Handle
 
 		context.allowCustom = this.options.allowCustom;
 		context.choices = choices;
-		context.custom = attr ? attr.custom : "";
+		if (this.options.custom) {
+			context.custom = foundry.utils.getProperty(this.document, this.options.custom);
+		} else if (attr.custom) {
+			context.custom = attr.custom;
+		} else {
+			context.custom = "";
+		}
 		context.buttons = [{ type: "submit", icon: "far fa-save", label: "DND4E.Save" }];
 		context.heading = this.options.window.title;
 
@@ -87,12 +103,17 @@ export default class TraitSelectorValues extends foundry.applications.api.Handle
 
 		// Obtain choices
 		for (let [k, v] of Object.entries(formData)) {
-			if (k !== "custom") updateData[`${this.attribute}.${k}`] = { value: v[0], range: v[0] ? v[1] : "" };
+			if (k === "custom") continue;
+			if (Object.keys(this.options.valuelessTraits).includes(k)) {
+				updateData[this.options.valuelessTraits[k].path] = v;
+			} else {
+				updateData[`${this.attribute}.${k}`] = { value: v[0], range: v[0] ? v[1] : "" };
+			}
 		}
 
 		// Include custom
-		if (this.options.allowCustom) {
-			updateData[`${this.attribute}.custom`] = formData.custom;
+		if (this.options.allowCustom && this.custom) {
+			updateData[this.custom] = formData.custom;
 		}
 
 		return foundry.utils.expandObject(updateData);

--- a/module/applications/sheets/actor-sheet.mjs
+++ b/module/applications/sheets/actor-sheet.mjs
@@ -479,11 +479,18 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 				obj[l[0]] = (l[1].range && (l[1].range > 0)) ? `${choices[l[0]].label} ${l[1].range} sq` : choices[l[0]].label;
 				return obj;
 			}, {});
+			// Add all-around vision
+			if (senses.allAround) {
+				trait.selected["aa"] = _loc(this.actor.system.schema.getField("senses.allAround").label);
+			}
 			// Add custom entry
-			if (trait.custom) {
-				trait.custom.split(";").forEach((c, i) => trait.selected[`custom${i + 1}`] = c.trim());
+			if (senses.custom) {
+				senses.custom.split(";").forEach((c, i) => trait.selected[`custom${i + 1}`] = c.trim());
 			}
 			trait.cssClass = !foundry.utils.isEmpty(trait.selected) ? "" : "inactive";
+		}
+		if (!foundry.utils.isEmpty(senses.special.selected)) {
+			senses.special.selected = Object.values(senses.special.selected).sort();
 		}
 		return senses;
 	}
@@ -1777,8 +1784,22 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		if (!this.actor.isOwner) return;
 		event.preventDefault();
 		const label = target.getAttribute("data-app-title") || "Label error";
+		const valuelessTraits = {
+			allAround: {
+				label: _loc(this.actor.system.schema.getField("senses.allAround").label),
+				path: "system.senses.allAround",
+				chosen: this.actor.system.senses.allAround,
+				value: this.actor.system.senses.allAround,
+			},
+			blind: {
+				label: _loc(this.actor.system.schema.getField("senses.blind").label),
+				path: "system.senses.blind",
+				chosen: this.actor.system.senses.blind,
+				value: this.actor.system.senses.blind,
+			},
+		};
 		const choices = CONFIG.DND4E["senses"];
-		const options = { name: target.dataset.target, window: { title: label }, choices };
+		const options = { name: target.dataset.target, window: { title: label }, valuelessTraits, choices, custom: "system.senses.custom" };
 		new apps.TraitSelectorValues({ document: this.actor, ...options }).render(true);
 	}
 

--- a/module/applications/sheets/token/token-config.mjs
+++ b/module/applications/sheets/token/token-config.mjs
@@ -22,7 +22,7 @@ export class TokenConfig4e extends foundry.applications.sheets.TokenConfig {
 	_applySenseSyncNotice(html) {
 		if (!game.settings.get("dnd4e", "senseVisionSync")) return;
 		const actor = this.actor ?? this.object?.actor;
-		const senses = actor?.system?.senses?.special;
+		const senses = actor?.system?.senses;
 		if (!senses) return;
 
 		const { sight, detectionModes } = CONFIG.Token.documentClass.computeSenseOverrides(senses);
@@ -45,7 +45,21 @@ export class TokenConfig4e extends foundry.applications.sheets.TokenConfig {
 		notice.innerHTML = `<i class="fa-solid fa-circle-info"></i> ${
 			_loc("SETTINGS.4eSenseVisionNotice", { senses: link })}`;
 		notice.querySelector("[data-action=editSenses]")?.addEventListener("click", () => {
-			const options = { name: "system.senses.special", window: { title: _loc("DND4E.SpecialSenses") }, choices: CONFIG.DND4E["senses"] };
+			const valuelessTraits = {
+				allAround: {
+					label: _loc("DND4E.SpecialSensesAA"),
+					path: "system.senses.allAround",
+					chosen: this.actor.system.senses.allAround,
+					value: this.actor.system.senses.allAround,
+				},
+				blind: {
+					label: _loc("DND4E.VisionBlind"),
+					path: "system.senses.blind",
+					chosen: this.actor.system.senses.blind,
+					value: this.actor.system.senses.blind,
+				},
+			};
+			const options = { name: "system.senses.special", window: { title: _loc("DND4E.SpecialSenses") }, valuelessTraits, choices: CONFIG.DND4E["senses"], custom: "system.senses.custom" };
 			new TraitSelectorValues({ document: actor, ...options }).render(true, { force: true });
 		});
 		tab.prepend(notice);

--- a/module/canvas/placeables/token.mjs
+++ b/module/canvas/placeables/token.mjs
@@ -22,8 +22,8 @@ export default class Token4e extends foundry.canvas.placeables.Token {
 
 	/**
 	 * Getter for the degree of environmental light the token is subject to.
-     * @type {Number}
-     */
+	 * @type {Number}
+	 */
 	get lightLevel() {
 		if (this.document.parent.environment.globalLight.enabled) return CONFIG.DND4E.LIGHT_LEVEL.BRIGHT;
 		let c = Object.values(this.center);
@@ -80,8 +80,7 @@ export default class Token4e extends foundry.canvas.placeables.Token {
 				range: 0,
 			},
 		}, {
-			insertKeys: true,
-			insertValues: true,
+			inplace: false,
 			overwrite: false,
 		});
 		const detected = Object.entries(detectionModes).some(([id, mode]) => {
@@ -121,11 +120,11 @@ export default class Token4e extends foundry.canvas.placeables.Token {
 		const colorPct = Math.clamp(value, 0, max) / max;
 
 		/**
-         * Helper function to get the color the HP bar should be.
-         * @param {number} current
-         * @param {number} max
-         * @returns
-         */
+		 * Helper function to get the color the HP bar should be.
+		 * @param {number} current
+		 * @param {number} max
+		 * @returns
+		 */
 		function getHPColor(current, max) {
 			const pct = Math.clamp(current, 0, max) / max;
 			return Color.fromRGB([(1 - (pct / 2)), pct, 0]);

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1367,6 +1367,10 @@ preLocalize("autoTargetModes");
 DND4E.senses = {
 	nv: {
 		label: "DND4E.VisionNormal",
+		detectionMode: "basicSight",
+		grantsSight: true,
+		range: 0,
+		visionMode: "basic",
 	},
 	lv: {
 		label: "DND4E.VisionLowLight",
@@ -1374,12 +1378,6 @@ DND4E.senses = {
 		grantsSight: true,
 		range: 0,
 		visionMode: "darkvision",
-	},
-	bv: {
-		label: "DND4E.VisionBlind",
-	},
-	aa: {
-		label: "DND4E.SpecialSensesAA",
 	},
 	bs: {
 		label: "DND4E.SpecialSensesBS",

--- a/module/data/actor/templates/senses.mjs
+++ b/module/data/actor/templates/senses.mjs
@@ -1,44 +1,21 @@
 const { BooleanField, SchemaField, NumberField, StringField } = foundry.data.fields;
+import { default as MappingField } from "../../fields/mapping-field.mjs";
 
 export default class SensesTemplate extends foundry.abstract.DataModel {
 	/** Getter for sense data. */
 	static get common() {
 		return {
-			special: new SchemaField({
-				aa: new SchemaField({
-					value: new BooleanField({ initial: false }),
-					range: new NumberField({ required: true, nullable: true, initial: null }),
-				}, { label: "DND4E.SpecialSensesAA" }),
-				bs: new SchemaField({
-					value: new BooleanField({ initial: false }),
-					range: new NumberField({ required: true, nullable: true, initial: null }),
-				}, { label: "DND4E.SpecialSensesBS" }),
-				bv: new SchemaField({
-					value: new BooleanField({ initial: false }),
-					range: new NumberField({ required: true, nullable: true, initial: null }),
-				}, { label: "DND4E.VisionBlind" }),
-				dv: new SchemaField({
-					value: new BooleanField({ initial: false }),
-					range: new NumberField({ required: true, nullable: true, initial: null }),
-				}, { label: "DND4E.SpecialSensesDV" }),
-				lv: new SchemaField({
-					value: new BooleanField({ initial: false }),
-					range: new NumberField({ required: true, nullable: true, initial: null }),
-				}, { label: "DND4E.VisionLowLight" }),
-				nv: new SchemaField({
-					value: new BooleanField({ initial: false }),
-					range: new NumberField({ required: true, nullable: true, initial: null }),
-				}, { label: "DND4E.VisionNormal" }),
-				tr: new SchemaField({
-					value: new BooleanField({ initial: false }),
-					range: new NumberField({ required: true, nullable: true, initial: null }),
-				}, { label: "DND4E.SpecialSensesTR" }),
-				ts: new SchemaField({
-					value: new BooleanField({ initial: false }),
-					range: new NumberField({ required: true, nullable: true, initial: null }),
-				}, { label: "DND4E.SpecialSensesTS" }),
-				custom: new StringField({ initial: "" }),
+			special: new MappingField(new SchemaField({
+				value: new BooleanField({ initial: false }),
+				range: new NumberField({ required: true, nullable: true, initial: null }),
+			}), {
+				initialKeys: CONFIG.DND4E.senses,
+				initialKeysOnly: true,
+				label: "DND4E.SpecialSenses",
 			}),
+			allAround: new BooleanField({ initial: false, label: "DND4E.SpecialSensesAA" }),
+			blind: new BooleanField({ initial: false, label: "DND4E.VisionBlind" }),
+			custom: new StringField({ initial: "" }),
 			notes: new StringField({ initial: "" }),
 		};
 	}
@@ -55,9 +32,9 @@ export default class SensesTemplate extends foundry.abstract.DataModel {
 	/* -------------------------------------------- */
 
 	/**
-     * Convert single macro into macro array.
-     * @param {Object} source  The candidate source data from which the model will be constructed.
-     */
+	 * Convert single macro into macro array.
+	 * @param {Object} source  The candidate source data from which the model will be constructed.
+	 */
 	static migrateSenses(source) {
 		if (source.senses?.special?.value) {
 			const oldSenses = Array.from(source.senses?.special?.value);
@@ -67,6 +44,21 @@ export default class SensesTemplate extends foundry.abstract.DataModel {
 					source.senses.special[`${sense[0]}`] = { value: true, range: sense[1] };
 				}
 			}
+		}
+
+		if (source.senses?.special?.aa) {
+			source.senses.allAround = source.senses.special.aa.value;
+			delete source.senses.special.aa;
+		}
+
+		if (source.senses?.special?.bv) {
+			source.senses.blind = source.senses.special.bv.value;
+			delete source.senses.special.bv;
+		}
+
+		if (source.senses?.special?.custom) {
+			source.senses.custom = source.senses.special.custom;
+			delete source.senses.special.custom;
 		}
 	}
 }

--- a/module/data/migration.mjs
+++ b/module/data/migration.mjs
@@ -7,7 +7,7 @@ export const migrateWorld = async function(migrationVersion) {
 	migrationVersion = migrationVersion || game.settings.get("dnd4e", "systemMigrationVersion");
 	// Update these versions whenever we make data model changes that require immediately saving the changes to the DB.
 	const migrateActiveEffects = foundry.utils.isNewerVersion("0.8.9", migrationVersion);
-	const migrateActors = foundry.utils.isNewerVersion("0.8.9", migrationVersion);
+	const migrateActors = foundry.utils.isNewerVersion("0.9.1", migrationVersion);
 	const migrateItems = foundry.utils.isNewerVersion("0.8.9", migrationVersion);
 	ui.notifications.info(_loc("MIGRATION.4eBegin", { version }), { permanent: true });
 
@@ -111,7 +111,6 @@ export const migrateWorld = async function(migrationVersion) {
 	// Set the migration as complete
 	game.settings.set("dnd4e", "systemMigrationVersion", game.system.version);
 	ui.notifications.info(_loc("MIGRATION.4eComplete", { version }), { permanent: true });
-
 };
 
 /* -------------------------------------------- */
@@ -156,8 +155,8 @@ export const migrateCompendium = async function(pack, migrateActiveEffects, migr
 			const diff = foundry.utils.getProperty(updateData, "flags.dnd4e.migrateType") !== null;
 			await doc.update(updateData, { diff });
 			if (((documentName === "ActiveEffect") && migrateActiveEffects)
-                || ((documentName === "Actor") && migrateActors)
-                || ((documentName === "Item") && migrateItems)) await doc.update({ system: _replace(doc.system?.toObject()) });
+				|| ((documentName === "Actor") && migrateActors)
+				|| ((documentName === "Item") && migrateItems)) await doc.update({ system: _replace(doc.system?.toObject()) });
 			console.log(`Migrated ${documentName} document ${doc.name} in Compendium ${pack.collection}`);
 		}
 
@@ -386,8 +385,8 @@ function _migrateActorSkills(actorData, updateData) {
 	}
 
 	if ((foundry.utils.getType(actorData?.system?.skillTraining?.untrained) !== "Object")
-        || (foundry.utils.getType(actorData?.system?.skillTraining?.trained) !== "Object")
-        || (foundry.utils.getType(actorData?.system?.skillTraining?.expertise) !== "Object")) {
+		|| (foundry.utils.getType(actorData?.system?.skillTraining?.trained) !== "Object")
+		|| (foundry.utils.getType(actorData?.system?.skillTraining?.expertise) !== "Object")) {
 		updateData["system.skillTraining"] = {
 			untrained: {
 				value: 0,

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -46,7 +46,7 @@ export default class TokenDocument4e extends TokenDocument {
 	 */
 	_applySenseVision() {
 		if (!game.settings.get("dnd4e", "senseVisionSync")) return;
-		const senses = this.actor?.system?.senses?.special;
+		const senses = this.actor?.system?.senses;
 		if (senses) TokenDocument4e.applySenseOverrides(senses, this);
 	}
 
@@ -62,9 +62,16 @@ export default class TokenDocument4e extends TokenDocument {
 		let maxSightRange = -Infinity;
 		let sightVisionMode = null;
 
+		if (senses.blind) detectionModes["lightPerception"] = 0;
+
 		for (const [key, config] of Object.entries(CONFIG.DND4E.senses)) {
-			if (!senses[key]?.value) continue;
-			const range = config.range ?? senses[key]?.range ?? Infinity;
+			if (!senses.special[key]?.value) continue;
+			let range;
+			if (senses.blind && ["nv", "lv", "dv"].includes(key)) {
+				range = 0;
+			} else {
+				range = config.range ?? senses.special[key]?.range ?? Infinity;
+			}
 
 			if (config.detectionMode) detectionModes[config.detectionMode] = range;
 
@@ -207,7 +214,7 @@ export default class TokenDocument4e extends TokenDocument {
 	_onRelatedUpdate(update = {}, operation = {}) {
 		super._onRelatedUpdate(update, operation);
 		if (!game.settings.get("dnd4e", "senseVisionSync")) return;
-		const senses = this.actor?.system?.senses?.special;
+		const senses = this.actor?.system?.senses;
 		if (!senses) return;
 
 		// Re-derive vision whenever sense-granting data changes, covering direct edits and item/effect-granted senses.

--- a/templates/apps/trait-selector-values.hbs
+++ b/templates/apps/trait-selector-values.hbs
@@ -1,6 +1,21 @@
 <div class="dialogue-content">
   <h1 class="form-title">{{heading}}</h1>
 
+  {{#if valuelessTraits}}
+  <div class="form-group vertical">
+    <ol class="trait-list">
+      {{#each valuelessTraits as |trait key|}}
+      <li>
+        <label class="checkbox">
+          <input type="checkbox" name="{{key}}" data-dtype="Boolean" {{checked trait.chosen}}>
+          {{trait.label}}
+        </label>
+      </li>
+      {{/each}}
+    </ol>
+  </div>
+  {{/if}}
+
   <div class="form-group vertical">
     <ol class="trait-list">
       {{#each choices as |choice key|}}


### PR DESCRIPTION
"Blind" and "All-Around Vision" are pulled out into their own section of the senses config, since they do not have ranges (and ranges are in fact nonsensical for them). Additionally, they are pulled out of `system.senses.special` and placed directly under `system.senses`. `system.senses.special.custom` is likewise pulled out into `system.senses.custom`, allowing `system.senses.special` to become a MappingField. This lets us pull its values directly from CONFIG.DND4E.senses, rather than hardcoding them, allowing for homebrew senses.

"Blind" is accounted for when syncing token vision.