### PR TITLE
Fix weapon damage modifiers field

### DIFF
--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -51,7 +51,7 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
 				parts: new ArrayField(new SchemaField({
 					numDice: new FormulaField({ initial: "", determinitistic: true }),
 					numFaces: new FormulaField({ initial: "", determinitistic: true }),
-					modifier: new FormulaField({ initial: "" }),
+					modifier: new StringField({ initial: "" }),
 				})),
 			}),
 			damage: new SchemaField({


### PR DESCRIPTION
As mentioned by absolitude on Discord, this field had stopped working as intended (allowing user to append Foundry dice syntax to a damage roll). Looks like in v13 it was converted to a formula field, due to a its purpose being unclear. This update restores it to working order :)