### PR TITLE
Add grid icons to Damage/Difficult Terrain/Obscured regions

### DIFF
--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -1492,7 +1492,7 @@
 				"label": "Types"
 			},
 			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will not be subject to its effects.",
 				"label": "Exclude Creator?"
 			}
 		}
@@ -1512,7 +1512,7 @@
 				"label": "Dispositions"
 			},
 			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will not be subject to its effects.",
 				"label": "Exclude Creator?"
 			},
 			"oncePerTurn": {
@@ -1530,6 +1530,10 @@
 			"types": {
 				"hint": "If set, only damage Tokens with these creature types.",
 				"label": "Types"
+			},
+			"showGridIcons": {
+				"hint": "Display an icon in each grid space covered by this damaging region.",
+				"label": "Show Grid Icons"
 			}
 		}
 	},
@@ -1544,8 +1548,12 @@
 				"label": "Types"
 			},
 			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will not be subject to its effects.",
 				"label": "Exclude Creator?"
+			},
+			"showGridIcons": {
+				"hint": "Display an icon in each grid space covered by this difficult terrain.",
+				"label": "Show Grid Icons"
 			}
 		},
 		"Type": {
@@ -1581,8 +1589,12 @@
 				"label": "Types"
 			},
 			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will not be subject to its effects.",
 				"label": "Exclude Creator?"
+			},
+			"showGridIcons": {
+				"hint": "Display an icon in each grid space covered by this obscured terrain. Icon is determined by obscurement level.",
+				"label": "Show Grid Icons"
 			}
 		}
 	}

--- a/lang/en.json
+++ b/lang/en.json
@@ -1492,7 +1492,7 @@
 				"label": "Types"
 			},
 			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will not be subject to its effects.",
 				"label": "Exclude Creator?"
 			}
 		}
@@ -1512,7 +1512,7 @@
 				"label": "Dispositions"
 			},
 			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will not be subject to its effects.",
 				"label": "Exclude Creator"
 			},
 			"oncePerTurn": {
@@ -1530,6 +1530,10 @@
 			"types": {
 				"hint": "If set, only damage Tokens with these creature types.",
 				"label": "Types"
+			},
+			"showGridIcons": {
+				"hint": "Display an icon in each grid space covered by this damaging region.",
+				"label": "Show Grid Icons"
 			}
 		}
 	},
@@ -1544,8 +1548,12 @@
 				"label": "Types"
 			},
 			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will not be subject to its effects.",
 				"label": "Exclude Creator?"
+			},
+			"showGridIcons": {
+				"hint": "Display an icon in each grid space covered by this difficult terrain.",
+				"label": "Show Grid Icons"
 			}
 		},
 		"Type": {
@@ -1581,8 +1589,12 @@
 				"label": "Types"
 			},
 			"excludeCreator": {
-				"hint": "If set, and if the region was created by an actor, the actor who created the region will be not be subject to its effects.",
+				"hint": "If set, and if the region was created by an actor, the actor who created the region will not be subject to its effects.",
 				"label": "Exclude Creator?"
+			},
+			"showGridIcons": {
+				"hint": "Display an icon in each grid space covered by this obscured terrain. Icon is determined by obscurement level.",
+				"label": "Show Grid Icons"
 			}
 		}
 	}

--- a/module/canvas/_module.mjs
+++ b/module/canvas/_module.mjs
@@ -1,1 +1,2 @@
+export { default as RegionBehaviorGridIcons } from "./region-behavior-grid-icons.mjs";
 export * as placeables from "./placeables/_module.mjs";

--- a/module/canvas/_types.mjs
+++ b/module/canvas/_types.mjs
@@ -1,0 +1,10 @@
+/**
+ * @typedef GridIconData
+ * @property {"fontAwesome"|"image"} type
+ * @property {string} source
+ * @property {string} key
+ * @property {number} tint
+ * @property {number} priority
+ * @property {number} order
+ * @property {string} textureKey
+ */

--- a/module/canvas/region-behavior-grid-icons.mjs
+++ b/module/canvas/region-behavior-grid-icons.mjs
@@ -1,0 +1,515 @@
+const CONTAINER_NAME = "region-behavior-grid-icons";
+const ICON_SCALE = 0.2;
+const ICON_PADDING = 0.05;
+const ICON_ALPHA = 1;
+const FONT_AWESOME_TINT = 0x808080;
+const IMAGE_TINT = 0xffffff;
+const FONT_SIZE = 128;
+const GLYPH_OVERSCAN = 0.25;
+const TEXTURE_RESOLUTION = 2;
+
+/** @import { GridIconData } from "./_types.mjs" */
+
+/**
+ * Decode a CSS content value into a Unicode character.
+ * @param {string} content
+ * @returns {string}
+ */
+function decodeCssContent(content) {
+	const value = content
+		.split("/")[0]
+		.trim()
+		.replace(/^["']|["']$/g, "");
+
+	return value.replace(
+		/\\([0-9a-f]{1,6})\s?/gi,
+		(match, hex) => String.fromCodePoint(Number.parseInt(hex, 16)),
+	);
+}
+
+/**
+ * Create a reusable texture from a Font Awesome icon.
+ * @param {string} iconClass
+ * @returns {Promise<PIXI.RenderTexture|null>}
+ */
+async function createFontAwesomeTexture(iconClass) {
+	const element = document.createElement("i");
+
+	element.className = iconClass;
+	element.style.position = "fixed";
+	element.style.left = "-10000px";
+	element.style.top = "-10000px";
+
+	document.body.append(element);
+
+	const elementStyle = getComputedStyle(element);
+	const iconStyle = getComputedStyle(element, "::before");
+	const pseudoContent = iconStyle.content;
+	const useFallbackContent = (
+		!pseudoContent
+		|| ["none", "normal", "\"\"", "''"].includes(pseudoContent)
+		|| pseudoContent.includes("var(")
+	);
+	const content = useFallbackContent
+		? elementStyle.getPropertyValue("--fa")
+		: pseudoContent;
+	const character = decodeCssContent(content);
+	const fontFamily = iconStyle.fontFamily;
+	const fontStyle = iconStyle.fontStyle;
+	const fontWeight = iconStyle.fontWeight;
+
+	element.remove();
+
+	if (!character || ["none", "normal"].includes(character)) return null;
+
+	await document.fonts.load(
+		`${fontStyle} ${fontWeight} ${FONT_SIZE}px ${fontFamily}`,
+		character,
+	);
+
+	const text = new PIXI.Text(character, {
+		fontFamily,
+		fontStyle,
+		fontWeight,
+		fontSize: FONT_SIZE,
+		fill: 0xffffff,
+		padding: Math.ceil(FONT_SIZE * GLYPH_OVERSCAN),
+		trim: true,
+	});
+
+	text.resolution = TEXTURE_RESOLUTION;
+	text.updateText(true);
+
+	const texture = canvas.app.renderer.generateTexture(text, {
+		resolution: TEXTURE_RESOLUTION,
+	});
+
+	text.destroy({
+		texture: true,
+		baseTexture: true,
+	});
+
+	return texture;
+}
+
+/**
+ * Normalize grid icon data supplied by a Region Behavior.
+ * @param {object|null|undefined} data
+ * @returns {GridIconData|null}
+ */
+function normalizeGridIconData(data) {
+	if (!data || !["fontAwesome", "image"].includes(data.type)) return null;
+
+	const source = String(data.source ?? "").trim();
+
+	if (!source) return null;
+
+	const tint = Number.isInteger(data.tint)
+		? data.tint
+		: data.type === "fontAwesome"
+			? FONT_AWESOME_TINT
+			: IMAGE_TINT;
+	const key = String(data.key ?? `${data.type}:${source}:${tint}`).trim();
+
+	if (!key) return null;
+
+	return {
+		key,
+		type: data.type,
+		source,
+		tint,
+		priority: Number.isFinite(data.priority) ? data.priority : 0,
+		order: Number.isFinite(data.order) ? data.order : 0,
+		textureKey: `${data.type}:${source}`,
+	};
+}
+
+/**
+ * Load a texture for a Region Behavior grid icon.
+ * @param {GridIconData} iconData
+ * @returns {Promise<{texture: PIXI.Texture, owned: boolean}|null>}
+ */
+async function loadIconTexture(iconData) {
+	if (iconData.type === "fontAwesome") {
+		const texture = await createFontAwesomeTexture(iconData.source);
+
+		return texture ? { texture, owned: true } : null;
+	}
+
+	const texture = await foundry.canvas.loadTexture(iconData.source);
+
+	return texture instanceof PIXI.Texture
+		? { texture, owned: false }
+		: null;
+}
+
+/**
+ * Get grid spaces covered by a Region.
+ * @param {Region} region
+ * @returns {GridOffset2D[]}
+ */
+function getCoveredGridSpaceOffsets(region) {
+	const polygonTree = region.animationState.polygonTree;
+	const bounds = region.animationState.bounds
+		.clone()
+		.fit(canvas.dimensions.rect)
+		.pad(1);
+	const [i0, j0, i1, j1] = canvas.grid.getOffsetRange(bounds);
+	const dx = canvas.grid.sizeX / 2;
+	const dy = canvas.grid.sizeY / 2;
+	const offsets = [];
+
+	for (let i = i0; i < i1; i++) {
+		for (let j = j0; j < j1; j++) {
+			const offset = { i, j };
+			const center = canvas.grid.getCenterPoint(offset);
+
+			center.x = Math.round(center.x - dx) + dx;
+			center.y = Math.round(center.y - dy) + dy;
+
+			if (polygonTree.testPoint(center, 0.75)) offsets.push(offset);
+		}
+	}
+
+	return offsets;
+}
+
+/**
+ * Calculate a compact top-right icon layout for a grid cell.
+ * @param {number} count
+ * @returns {{rows: number, iconSize: number, gap: number, paddingX: number, paddingY: number}}
+ */
+function getCellIconLayout(count) {
+	const width = canvas.grid.sizeX;
+	const height = canvas.grid.sizeY;
+	const minimumDimension = Math.min(width, height);
+	const paddingX = width * ICON_PADDING;
+	const paddingY = height * ICON_PADDING;
+	const availableWidth = Math.max(1, width - (paddingX * 2));
+	const availableHeight = Math.max(1, height - (paddingY * 2));
+	const preferredSize = minimumDimension * ICON_SCALE;
+	const preferredGap = minimumDimension * ICON_PADDING;
+	const preferredColumns = Math.max(
+		1,
+		Math.floor((availableWidth + preferredGap) / (preferredSize + preferredGap)),
+	);
+	const preferredRows = Math.max(
+		1,
+		Math.floor((availableHeight + preferredGap) / (preferredSize + preferredGap)),
+	);
+
+	if (count <= preferredColumns * preferredRows) {
+		return {
+			rows: Math.min(count, preferredRows),
+			iconSize: preferredSize,
+			gap: preferredGap,
+			paddingX,
+			paddingY,
+		};
+	}
+
+	const aspectRatio = availableWidth / availableHeight;
+	const rows = Math.max(
+		1,
+		Math.min(count, Math.ceil(Math.sqrt(count / aspectRatio))),
+	);
+	const columns = Math.ceil(count / rows);
+	const gap = Math.min(
+		preferredGap,
+		availableWidth / Math.max(columns * 4, 1),
+		availableHeight / Math.max(rows * 4, 1),
+	);
+	const iconSize = Math.max(
+		1,
+		Math.min(
+			preferredSize,
+			(availableWidth - (gap * (columns - 1))) / columns,
+			(availableHeight - (gap * (rows - 1))) / rows,
+		),
+	);
+
+	return {
+		rows,
+		iconSize,
+		gap,
+		paddingX,
+		paddingY,
+	};
+}
+
+/**
+ * Render Region Behavior grid icons for the active Scene.
+ */
+export default class RegionBehaviorGridIcons {
+	static #container = null;
+
+	static #textures = new Map();
+
+	static #texturePromises = new Map();
+
+	static #refreshQueued = false;
+
+	static #refreshId = 0;
+
+	static #generation = 0;
+
+	/**
+	 * Register canvas and Region document lifecycle hooks.
+	 * @returns {void}
+	 */
+	static registerHooks() {
+		Hooks.on("canvasReady", () => this.draw());
+		Hooks.on("drawGridLayer", () => {
+			if (canvas.ready) this.draw();
+		});
+		Hooks.on("tearDownGridLayer", () => this.destroy());
+		Hooks.on("canvasTearDown", () => this.destroy());
+		Hooks.on("createRegion", () => this.queueRefresh());
+		Hooks.on("updateRegion", () => this.queueRefresh());
+		Hooks.on("deleteRegion", () => this.queueRefresh());
+		Hooks.on("createRegionBehavior", () => this.queueRefresh());
+		Hooks.on("updateRegionBehavior", () => this.queueRefresh());
+		Hooks.on("deleteRegionBehavior", () => this.queueRefresh());
+	}
+
+	/**
+	 * Draw the grid icon container for the active Scene.
+	 * @returns {void}
+	 */
+	static draw() {
+		this.destroy();
+
+		if (!canvas.ready || canvas.grid.isGridless) return;
+
+		const gridLayer = canvas.interface.grid;
+
+		if (!gridLayer?.mesh || (gridLayer.mesh.parent !== gridLayer)) return;
+
+		const container = new PIXI.Container();
+
+		container.name = CONTAINER_NAME;
+		container.alpha = ICON_ALPHA;
+		container.eventMode = "none";
+		container.interactiveChildren = false;
+
+		this.#container = container;
+
+		gridLayer.addChildAt(container, gridLayer.getChildIndex(gridLayer.mesh));
+		void this.refresh();
+	}
+
+	/**
+	 * Queue one grid icon refresh.
+	 * @returns {void}
+	 */
+	static queueRefresh() {
+		if (!canvas.ready || this.#refreshQueued) return;
+
+		this.#refreshQueued = true;
+
+		requestAnimationFrame(() => {
+			this.#refreshQueued = false;
+			void this.refresh();
+		});
+	}
+
+	/**
+	 * Get or load a texture for a grid icon.
+	 * @param {GridIconData} iconData
+	 * @returns {Promise<{texture: PIXI.Texture, owned: boolean}|null>}
+	 */
+	static async #getTexture(iconData) {
+		const cached = this.#textures.get(iconData.textureKey);
+
+		if (cached) return cached;
+
+		const pending = this.#texturePromises.get(iconData.textureKey);
+
+		if (pending) return pending;
+
+		const generation = this.#generation;
+		const promise = loadIconTexture(iconData)
+			.then(textureData => {
+				if (!textureData) return null;
+
+				if (generation !== this.#generation) {
+					if (textureData.owned) textureData.texture.destroy(true);
+					return null;
+				}
+
+				this.#textures.set(iconData.textureKey, textureData);
+				return textureData;
+			})
+			.finally(() => {
+				if (this.#texturePromises.get(iconData.textureKey) === promise) {
+					this.#texturePromises.delete(iconData.textureKey);
+				}
+			});
+
+		this.#texturePromises.set(iconData.textureKey, promise);
+		return promise;
+	}
+
+	/**
+	 * Rebuild the Region Behavior grid icon sprites.
+	 * @returns {Promise<void>}
+	 */
+	static async refresh() {
+		if (
+			!canvas.ready
+			|| !this.#container
+			|| this.#container.destroyed
+		) return;
+
+		const container = this.#container;
+		const scene = canvas.scene;
+		const refreshId = ++this.#refreshId;
+		const cells = new Map();
+
+		for (const region of canvas.regions.placeables) {
+			const relevantBehaviors = [];
+
+			for (const behavior of region.document.behaviors) {
+				if (!behavior.viewed) continue;
+
+				const iconData = normalizeGridIconData(
+					behavior.system.gridIconData,
+				);
+
+				if (!iconData) continue;
+
+				relevantBehaviors.push({ behavior, iconData });
+			}
+
+			if (!relevantBehaviors.length) continue;
+
+			const coveredGridSpaceOffsets = getCoveredGridSpaceOffsets(region);
+
+			for (const offset of coveredGridSpaceOffsets) {
+				const cellKey = `${offset.i},${offset.j}`;
+				let cell = cells.get(cellKey);
+
+				if (!cell) {
+					cell = {
+						offset,
+						behaviors: new Map(),
+					};
+
+					cells.set(cellKey, cell);
+				}
+
+				for (const behaviorData of relevantBehaviors) {
+					const behaviorKey = `${behaviorData.behavior.type}:${behaviorData.iconData.key}`;
+					const current = cell.behaviors.get(behaviorKey);
+					const replaceCurrent = (
+						!current
+						|| (behaviorData.iconData.priority > current.iconData.priority)
+						|| (
+							(behaviorData.iconData.priority === current.iconData.priority)
+							&& (behaviorData.behavior.uuid.localeCompare(current.behavior.uuid) < 0)
+						)
+					);
+
+					if (replaceCurrent) {
+						cell.behaviors.set(behaviorKey, behaviorData);
+					}
+				}
+			}
+		}
+
+		const requiredIcons = new Map();
+
+		for (const cell of cells.values()) {
+			for (const { iconData } of cell.behaviors.values()) {
+				requiredIcons.set(iconData.textureKey, iconData);
+			}
+		}
+
+		const textures = new Map();
+
+		await Promise.all(Array.from(requiredIcons.values(), async iconData => {
+			const textureData = await this.#getTexture(iconData);
+
+			if (textureData) textures.set(iconData.textureKey, textureData);
+		}));
+
+		if (
+			!canvas.ready
+			|| (canvas.scene !== scene)
+			|| (this.#container !== container)
+			|| container.destroyed
+			|| (refreshId !== this.#refreshId)
+		) return;
+
+		for (const sprite of container.removeChildren()) {
+			sprite.destroy();
+		}
+
+		for (const { offset, behaviors } of cells.values()) {
+			const icons = Array.from(behaviors.values())
+				.filter(({ iconData }) => textures.has(iconData.textureKey))
+				.sort((a, b) => (
+					a.iconData.order - b.iconData.order
+					|| a.behavior.type.localeCompare(b.behavior.type)
+					|| b.iconData.priority - a.iconData.priority
+					|| a.iconData.key.localeCompare(b.iconData.key)
+					|| a.behavior.uuid.localeCompare(b.behavior.uuid)
+				));
+
+			if (!icons.length) continue;
+
+			const topLeft = canvas.grid.getTopLeftPoint(offset);
+			const layout = getCellIconLayout(icons.length);
+
+			for (let index = 0; index < icons.length; index++) {
+				const { iconData } = icons[index];
+				const textureData = textures.get(iconData.textureKey);
+				const row = index % layout.rows;
+				const column = Math.floor(index / layout.rows);
+				const spriteScale = (
+					layout.iconSize
+					/ Math.max(textureData.texture.width, textureData.texture.height, 1)
+				);
+				const sprite = new PIXI.Sprite(textureData.texture);
+
+				sprite.anchor.set(1, 0);
+				sprite.position.set(
+					topLeft.x
+						+ canvas.grid.sizeX
+						- layout.paddingX
+						- (column * (layout.iconSize + layout.gap)),
+					topLeft.y
+						+ layout.paddingY
+						+ (row * (layout.iconSize + layout.gap)),
+				);
+				sprite.scale.set(spriteScale);
+				sprite.tint = iconData.tint;
+
+				container.addChild(sprite);
+			}
+		}
+	}
+
+	/**
+	 * Destroy the grid icon canvas resources.
+	 * @returns {void}
+	 */
+	static destroy() {
+		this.#generation++;
+		this.#refreshId++;
+
+		if (this.#container && !this.#container.destroyed) {
+			this.#container.parent?.removeChild(this.#container);
+			this.#container.destroy({ children: true });
+		}
+
+		for (const { texture, owned } of this.#textures.values()) {
+			if (owned) texture.destroy(true);
+		}
+
+		this.#textures.clear();
+		this.#texturePromises.clear();
+		this.#container = null;
+		this.#refreshQueued = false;
+	}
+}

--- a/module/data/region-behaviors/_types.mjs
+++ b/module/data/region-behaviors/_types.mjs
@@ -17,6 +17,7 @@
  * @property {boolean} oncePerTurn       If set, only deal damage to a give token once per turn.
  * @property {boolean} onlyInCombat      If set, don't deal damage outside of combat.
  * @property {boolean} excludeCreator    If set, don't deal damage to the actor that created the region.
+ * @property {boolean} showGridIcons     Whether to display grid icons for this damaging region.
  */
 
 /**
@@ -24,6 +25,7 @@
  * @property {Set<string>} types                Types of difficult terrain represented.
  * @property {Set<number>} ignoredDispositions  Token dispositions that won't be affected by this difficult terrain.
  * @property {boolean} excludeCreator           If set, don't affect the actor that created the region.
+ * @property {boolean} showGridIcons            Whether to display grid icons for this difficult terrain.
  */
 
 /**
@@ -33,4 +35,5 @@
  * @property {Set<string>} origins       If not empty, only tokens with these creature origins are affected.
  * @property {Set<string>} types         If not empty, only tokens with these creature types are affected.
  * @property {boolean} excludeCreator    If set, the actor that created the region is not affected.
+ * @property {boolean} showGridIcons     Whether to display grid icons for this obscured terrain.
  */

--- a/module/data/region-behaviors/damaging-region.mjs
+++ b/module/data/region-behaviors/damaging-region.mjs
@@ -1,12 +1,21 @@
-// Adapted from the Foundry Virtual Tabletop - Dungeons & Dragons Fifth Edition Game System licensed under the MIT license
-
-const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
 import { FormulaField } from "../fields/_module.mjs";
 import * as utils from "../../utils/utils.mjs";
 
+const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
+
 /**
  * @import { DamagingRegionRegionBehaviorSystemData } from "./_types.mjs";
+ * @import { GridIconData } from "../../canvas/_types.mjs";
  */
+
+/** @type { GridIconData } */
+const GRID_ICON = {
+	key: "default",
+	type: "fontAwesome",
+	source: "fa-solid fa-burst",
+	tint: 0x808080,
+	order: 0,
+};
 
 /**
  * The data model for a region behavior that deals damage to certain tokens.
@@ -37,7 +46,19 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 			oncePerTurn: new BooleanField(),
 			onlyInCombat: new BooleanField(),
 			excludeCreator: new BooleanField(),
+			showGridIcons: new BooleanField({ initial: false }),
 		};
+	}
+
+	/* ---------------------------------------- */
+
+	/**
+	 * Get the difficult terrain grid icon configuration.
+	 * @returns {GridIconData|null}
+	 */
+	get gridIconData() {
+		if (!this.showGridIcons) return null;
+		return GRID_ICON;
 	}
 
 	/* ---------------------------------------- */

--- a/module/data/region-behaviors/difficult-terrain.mjs
+++ b/module/data/region-behaviors/difficult-terrain.mjs
@@ -1,14 +1,25 @@
 // Adapted from the Foundry Virtual Tabletop - Dungeons & Dragons Fifth Edition Game System licensed under the MIT license
+import RegionBehaviorGridIcons from "../../canvas/region-behavior-grid-icons.mjs";
 
 const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { DifficultTerrainRegionBehaviorSystemData } from "./_types.mjs";
+ * @import { GridIconData } from "../../canvas/_types.mjs";
  */
+
+/** @type { GridIconData } */
+const GRID_ICON = {
+	key: "default",
+	type: "image",
+	source: "systems/dnd4e/icons/ui/difficultTerrain.svg",
+	tint: 0x808080,
+	order: 0,
+};
 
 /**
  * The data model for a region behavior that represents an area of difficult terrain.
- * * @extends {foundry.data.regionBehaviors.RegionBehaviorType<DifficultTerrainRegionBehaviorSystemData>}
+ * @extends {foundry.data.regionBehaviors.RegionBehaviorType<DifficultTerrainRegionBehaviorSystemData>}
  * @mixes DifficultTerrainRegionBehaviorSystemData
  */
 export default class DifficultTerrainRegionBehaviorType extends foundry.data.regionBehaviors.RegionBehaviorType {
@@ -26,41 +37,56 @@ export default class DifficultTerrainRegionBehaviorType extends foundry.data.reg
 			types: new SetField(new StringField()),
 			ignoredDispositions: new SetField(new NumberField({ choices: dispositions })),
 			excludeCreator: new BooleanField(),
+			showGridIcons: new BooleanField({ initial: false }),
 		};
 	}
 
 	/* ---------------------------------------- */
 
 	/**
-   * Called when the difficult terrain behavior is viewed.
-   * @this {DifficultTerrainRegionBehaviorType}
-   * @param {RegionBehaviorViewedEvent} event
-   */
+	 * Get the difficult terrain grid icon configuration.
+	 * @returns {GridIconData|null}
+	 */
+	get gridIconData() {
+		if (!this.showGridIcons) return null;
+		return GRID_ICON;
+	}
+
+	/* ---------------------------------------- */
+
+	/**
+	 * Called when the difficult terrain behavior is viewed.
+	 * @this {DifficultTerrainRegionBehaviorType}
+	 * @param {RegionBehaviorViewedEvent} event
+	 */
 	static async #onBehaviorViewed(event) {
 		canvas.tokens.recalculatePlannedMovementPaths();
+		RegionBehaviorGridIcons.queueRefresh();
 	}
 
 	/* ---------------------------------------- */
 
 	/**
-   * Called when the difficult terrain behavior is unviewed.
-   * @this {DifficultTerrainRegionBehaviorType}
-   * @param {RegionBehaviorUnviewedEvent} event
-   */
+	 * Called when the difficult terrain behavior is unviewed.
+	 * @this {DifficultTerrainRegionBehaviorType}
+	 * @param {RegionBehaviorUnviewedEvent} event
+	 */
 	static async #onBehaviorUnviewed(event) {
 		canvas.tokens.recalculatePlannedMovementPaths();
+		RegionBehaviorGridIcons.queueRefresh();
 	}
 
 	/* ---------------------------------------- */
 
 	/**
-   * Called when the boundary of an event has changed.
-   * @this {DifficultTerrainRegionBehaviorType}
-   * @param {RegionRegionBoundryEvent} event
-   */
+	 * Called when the boundary of a Region has changed.
+	 * @this {DifficultTerrainRegionBehaviorType}
+	 * @param {RegionRegionBoundaryEvent} event
+	 */
 	static async #onRegionBoundary(event) {
 		if (!this.behavior.viewed) return;
 		canvas.tokens.recalculatePlannedMovementPaths();
+		RegionBehaviorGridIcons.queueRefresh();
 	}
 
 	/* ---------------------------------------- */
@@ -75,10 +101,29 @@ export default class DifficultTerrainRegionBehaviorType extends foundry.data.reg
 	/* ---------------------------------------- */
 
 	/** @inheritDoc */
+	_onCreate(data, options, userId) {
+		super._onCreate(data, options, userId);
+		RegionBehaviorGridIcons.queueRefresh();
+	}
+
+	/* ---------------------------------------- */
+
+	/** @inheritDoc */
 	_onUpdate(changed, options, userId) {
 		super._onUpdate(changed, options, userId);
+		RegionBehaviorGridIcons.queueRefresh();
+
 		if (("system" in changed) && !this.behavior.viewed) return;
+
 		canvas.tokens.recalculatePlannedMovementPaths();
+	}
+
+	/* ---------------------------------------- */
+
+	/** @inheritDoc */
+	_onDelete(options, userId) {
+		super._onDelete(options, userId);
+		RegionBehaviorGridIcons.queueRefresh();
 	}
 
 	/* ---------------------------------------- */

--- a/module/data/region-behaviors/obscured-terrain.mjs
+++ b/module/data/region-behaviors/obscured-terrain.mjs
@@ -1,12 +1,15 @@
+import RegionBehaviorGridIcons from "../../canvas/region-behavior-grid-icons.mjs";
+
 const { BooleanField, NumberField, SetField, StringField } = foundry.data.fields;
 
 /**
  * @import { ObscuredTerrainRegionBehaviorSystemData } from "./_types.mjs";
+ * @import { GridIconData } from "../../canvas/_types.mjs";
  */
 
 /**
- * The data model for a region behavior that represents an area of difficult terrain.
- * * @extends {foundry.data.regionBehaviors.RegionBehaviorType<ObscuredTerrainRegionBehaviorSystemData>}
+ * The data model for a region behavior that represents an area of obscured terrain.
+ * @extends {foundry.data.regionBehaviors.RegionBehaviorType<ObscuredTerrainRegionBehaviorSystemData>}
  * @mixes ObscuredTerrainRegionBehaviorSystemData
  */
 export default class ObscuredTerrainRegionBehaviorType extends foundry.data.regionBehaviors.RegionBehaviorType {
@@ -32,16 +35,95 @@ export default class ObscuredTerrainRegionBehaviorType extends foundry.data.regi
 			origins: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureOrigin })),
 			types: new SetField(new StringField({ choices: () => CONFIG.DND4E.creatureType })),
 			excludeCreator: new BooleanField(),
+			showGridIcons: new BooleanField({ initial: false }),
 		};
 	}
 
 	/* ---------------------------------------- */
 
 	/**
-     * Check the conditions to decide if this token should be affected by the obscured terrain.
-     * @param {TokenDocument4e} token  The token to check.
-     * @returns {boolean}
-     */
+	 * Get the grid icon configuration for this obscurement level.
+	 * @returns {GridIconData|null}
+	 */
+	get gridIconData() {
+		if (!this.showGridIcons) return null;
+
+		let source;
+
+		switch (this.level) {
+			case CONFIG.DND4E.OBSCUREMENT.LIGHT:
+				source = "fa-regular fa-circle";
+				break;
+			case CONFIG.DND4E.OBSCUREMENT.HEAVY:
+				source = "fa-solid fa-circle-half-stroke";
+				break;
+			case CONFIG.DND4E.OBSCUREMENT.TOTAL:
+				source = "fa-solid fa-circle";
+				break;
+			default:
+				return null;
+		}
+
+		return {
+			key: "obscurement",
+			type: "fontAwesome",
+			source,
+			tint: 0x808080,
+			priority: this.level,
+			order: 10,
+		};
+	}
+
+	/* ---------------------------------------- */
+
+	/**
+	 * Called when the obscured terrain behavior is viewed.
+	 * @this {ObscuredTerrainRegionBehaviorType}
+	 * @param {RegionBehaviorViewedEvent} event
+	 */
+	static async #onBehaviorViewed(event) {
+		RegionBehaviorGridIcons.queueRefresh();
+	}
+
+	/* ---------------------------------------- */
+
+	/**
+	 * Called when the obscured terrain behavior is unviewed.
+	 * @this {ObscuredTerrainRegionBehaviorType}
+	 * @param {RegionBehaviorUnviewedEvent} event
+	 */
+	static async #onBehaviorUnviewed(event) {
+		RegionBehaviorGridIcons.queueRefresh();
+	}
+
+	/* ---------------------------------------- */
+
+	/**
+	 * Called when the Region boundary changes.
+	 * @this {ObscuredTerrainRegionBehaviorType}
+	 * @param {RegionRegionBoundaryEvent} event
+	 */
+	static async #onRegionBoundary(event) {
+		if (!this.behavior.viewed) return;
+		RegionBehaviorGridIcons.queueRefresh();
+	}
+
+	/* ---------------------------------------- */
+
+	/** @inheritDoc */
+	static events = {
+		[CONST.REGION_EVENTS.BEHAVIOR_VIEWED]: this.#onBehaviorViewed,
+		[CONST.REGION_EVENTS.BEHAVIOR_UNVIEWED]: this.#onBehaviorUnviewed,
+		[CONST.REGION_EVENTS.REGION_BOUNDARY]: this.#onRegionBoundary,
+	};
+
+	/* ---------------------------------------- */
+
+	/**
+	 * Check the conditions to decide if this token should be affected by the obscured terrain.
+	 * @param {TokenDocument4e} token  The token to check.
+	 * @returns {boolean}
+	 */
 	evaluateConditions(token) {
 		if (this.dispositions.size && !this.dispositions.has(token.disposition)) return false;
 		if (this.origins.size && !this.origins.has(token.actor.system.details?.origin)) return false;

--- a/module/dnd4e.mjs
+++ b/module/dnd4e.mjs
@@ -134,6 +134,8 @@ Hooks.once("init", async function() {
 	CONFIG.RegionBehavior.typeLabels.obscuredTerrain = "DND4E.obscuredTerrain.Label";
 	CONFIG.RegionBehavior.typeIcons.obscuredTerrain = "fa-solid fa-smog";
 
+	canvas.RegionBehaviorGridIcons.registerHooks();
+
 	helpers.settings.registerSystemSettings();
 
 	CONFIG.Combat.initiative.formula = "1d20 + @attributes.init.value";


### PR DESCRIPTION
Super special thanks to @gambit07 who did most of the work here.

Adds a new setting to the Damaging Region, Difficult Terrain, and Obscured Terrain region behaviors, "Show Grid Icons." When enabled, a small icon will render in the top right of each square affected by the region behavior.

<img width="705" height="718" alt="image" src="https://github.com/user-attachments/assets/d5990c60-1dbb-4be7-a5ab-9d394bc6da55" />