### PR TITLE
Fix two senses issues

### DIFF
--- a/module/data/actor/templates/senses.mjs
+++ b/module/data/actor/templates/senses.mjs
@@ -56,7 +56,7 @@ export default class SensesTemplate extends foundry.abstract.DataModel {
 			delete source.senses.special.bv;
 		}
 
-		if (source.senses?.special?.custom) {
+		if (source.senses?.special && ("custom" in source.senses.special)) {
 			source.senses.custom = source.senses.special.custom;
 			delete source.senses.special.custom;
 		}

--- a/templates/actors/npc-sheet.hbs
+++ b/templates/actors/npc-sheet.hbs
@@ -162,7 +162,7 @@
         </div>
 
         <div>
-          <a class="trait-selector-senses" data-action="traitSelectorSenses" data-options="senses" data-target="system.senses.special">
+          <a class="trait-selector-senses" data-action="traitSelectorSenses" data-options="senses" data-target="system.senses.special" data-app-title="{{ localize 'DND4E.SpecialSenses' }}">
             <span class="subgroup-header list-label label">{{ localize 'DND4E.Senses' }}</span>
             <i class="fas fa-edit"></i>
           </a>


### PR DESCRIPTION
NPC sense app didn't have a title; now it does.
Sense migration was missing `custom` field due to `""` being falsey 🙃; now it isn't.