### PR TITLE
Gate Damaging Region events behind an active GM check

### DIFF
--- a/module/data/region-behaviors/damaging-region.mjs
+++ b/module/data/region-behaviors/damaging-region.mjs
@@ -67,6 +67,8 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 
 	/** @inheritDoc */
 	async _handleRegionEvent(event) {
+		if (!game.user.isActiveGM) return;
+
 		if (!this.damage) return;
 
 		if (this.onlyInCombat && !game.combat) return;


### PR DESCRIPTION
This prevents additional damage chat cards from being created.

Closes #808