### PR TITLE
Change damage region GM check to align with pattern established by Apply Active Effect

### DIFF
--- a/module/data/region-behaviors/damaging-region.mjs
+++ b/module/data/region-behaviors/damaging-region.mjs
@@ -67,7 +67,7 @@ export default class DamagingRegionRegionBehaviorType extends foundry.data.regio
 
 	/** @inheritDoc */
 	async _handleRegionEvent(event) {
-		if (!game.user.isActiveGM) return;
+		if (!event.user.isSelf) return;
 
 		if (!this.damage) return;
 


### PR DESCRIPTION
Rather than running on the GM client this ensures we run on the client controlling the token.