### PR TITLE
Migrator handles Masterplan Imported Basic Attacks

### DIFF
--- a/module/data/item/power.mjs
+++ b/module/data/item/power.mjs
@@ -89,6 +89,11 @@ export default class PowerData extends foundry.abstract.TypeDataModel {
 				source.damageCritImp.parts[partIndex] = processPart(source.damageCritImp.parts[partIndex]);
 			}
 		}
+		// Used to be a string so may cause an item to fail validation.  Masterplan imports especially used a "B" for basic attacks.
+		// all powers /should/ have level, but paranoid check to be sure. 
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);

--- a/module/data/migration.mjs
+++ b/module/data/migration.mjs
@@ -219,6 +219,7 @@ export const migrateItemData = function(item) {
 	_migrateFeature(item, updateData);
 	_migrateRitualCategory(item, updateData);
 	_migrateFlavourText(item, updateData);
+	_migrateInvalidMasterplanLevel(item, updateData);
 	// Always do this last, as it clobbers `system` updates
 	_migrateType(item, updateData);
 	return updateData;
@@ -706,6 +707,22 @@ function _migrateItemsGMDescriptions(itemData, updateData) {
 
 	if (!("gm" in itemData.system.description)) {
 		updateData["system.description.gm"] = "";
+	}
+
+	return updateData;
+}
+
+/**
+ * Migrate the "B" level that was used by old Masterplan imported monsters to indicate basic attacks 
+ * @param {Object} itemData   Item data being migrated.
+ * @param {Object} updateData  Existing updates being applied to item. *Will be mutated.*
+ * @returns {Object}           Modified version of update data.
+ * @private
+ */
+function _migrateInvalidMasterplanLevel(itemData, updateData) {
+
+	if (itemData.system.level === "B") {
+		updateData["system.level"] = 0;
 	}
 
 	return updateData;

--- a/module/data/migration.mjs
+++ b/module/data/migration.mjs
@@ -219,7 +219,6 @@ export const migrateItemData = function(item) {
 	_migrateFeature(item, updateData);
 	_migrateRitualCategory(item, updateData);
 	_migrateFlavourText(item, updateData);
-	_migrateInvalidMasterplanLevel(item, updateData);
 	// Always do this last, as it clobbers `system` updates
 	_migrateType(item, updateData);
 	return updateData;
@@ -707,22 +706,6 @@ function _migrateItemsGMDescriptions(itemData, updateData) {
 
 	if (!("gm" in itemData.system.description)) {
 		updateData["system.description.gm"] = "";
-	}
-
-	return updateData;
-}
-
-/**
- * Migrate the "B" level that was used by old Masterplan imported monsters to indicate basic attacks 
- * @param {Object} itemData   Item data being migrated.
- * @param {Object} updateData  Existing updates being applied to item. *Will be mutated.*
- * @returns {Object}           Modified version of update data.
- * @private
- */
-function _migrateInvalidMasterplanLevel(itemData, updateData) {
-
-	if (itemData.system.level === "B") {
-		updateData["system.level"] = 0;
 	}
 
 	return updateData;


### PR DESCRIPTION
Masterplan imported monsters have a B in the level field for basic attacks.  

This failed numeric validation in modern systems and makes all their basic attacks vanish.  Item migrator now sets these to level 0.