### PR TITLE
Level migration for non-power items

### DIFF
--- a/module/data/item/backpack.mjs
+++ b/module/data/item/backpack.mjs
@@ -32,6 +32,9 @@ export default class BackpackData extends foundry.abstract.TypeDataModel {
 
 	/** @inheritdoc */
 	static migrateData(source) {
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);

--- a/module/data/item/consumable.mjs
+++ b/module/data/item/consumable.mjs
@@ -81,6 +81,9 @@ export default class ConsumableData extends foundry.abstract.TypeDataModel {
 				source.damageCritImp.parts[partIndex] = processPart(source.damageCritImp.parts[partIndex]);
 			}
 		}
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -63,6 +63,9 @@ export default class EquipmentData extends foundry.abstract.TypeDataModel {
 			delete source.armour.subType;
 		}
 		if (source.armour?.subtype === "cloth") source.armour.subtype = "light";
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);

--- a/module/data/item/feature.mjs
+++ b/module/data/item/feature.mjs
@@ -37,6 +37,9 @@ export default class FeatureData extends foundry.abstract.TypeDataModel {
 
 	/** @inheritdoc */
 	static migrateData(source) {
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);

--- a/module/data/item/loot.mjs
+++ b/module/data/item/loot.mjs
@@ -24,6 +24,9 @@ export default class LootData extends foundry.abstract.TypeDataModel {
 
 	/** @inheritdoc */
 	static migrateData(source) {
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);

--- a/module/data/item/power.mjs
+++ b/module/data/item/power.mjs
@@ -90,7 +90,6 @@ export default class PowerData extends foundry.abstract.TypeDataModel {
 			}
 		}
 		// Used to be a string so may cause an item to fail validation.  Masterplan imports especially used a "B" for basic attacks.
-		// all powers /should/ have level, but paranoid check to be sure. 
 		if (("level" in source) && isNaN(source.level)) {
 			source.level = null;
 		}

--- a/module/data/item/ritual.mjs
+++ b/module/data/item/ritual.mjs
@@ -33,6 +33,9 @@ export default class RitualData extends foundry.abstract.TypeDataModel {
 
 	/** @inheritdoc */
 	static migrateData(source) {
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);

--- a/module/data/item/tool.mjs
+++ b/module/data/item/tool.mjs
@@ -28,6 +28,9 @@ export default class ToolData extends foundry.abstract.TypeDataModel {
 
 	/** @inheritdoc */
 	static migrateData(source) {
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -132,6 +132,9 @@ export default class WeaponData extends foundry.abstract.TypeDataModel {
 				};
 			}
 		}
+		if (("level" in source) && isNaN(source.level)) {
+			source.level = null;
+		}
 		ItemDescriptionTemplate.migrateSource(source);
 		ItemMacroTemplate.migrateMacro(source);
 		return super.migrateData(source);


### PR DESCRIPTION
All items had their level changed from string to number, so we should migrate all of them.