### PR TITLE
Reset resources with value but no max to 0

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -1996,8 +1996,8 @@ export default class Actor4e extends Actor {
 			}
 
 			for (let r of Object.entries(this.system.resources)) {
-				if (r[1].label && r[1].sr && (r[1].max != null)) {
-					updateData[`system.resources.${r[0]}.value`] = r[1].max;
+				if (r[1].label && r[1].sr && (r[1].value != null)) {
+					updateData[`system.resources.${r[0]}.value`] = r[1].max ?? 0;
 				}
 			}
 		}
@@ -2062,8 +2062,8 @@ export default class Actor4e extends Actor {
 			});
 
 			for (let r of Object.entries(this.system.resources)) {
-				if ((r[1].sr || r[1].lr) && r[1].label && (r[1].max != null)) {
-					updateData[`system.resources.${r[0]}.value`] = r[1].max;
+				if ((r[1].sr || r[1].lr) && r[1].label && (r[1].value != null)) {
+					updateData[`system.resources.${r[0]}.value`] = r[1].max ?? 0;
 				}
 			}
 		}


### PR DESCRIPTION
Mostly just correcting an oversight on my part; at present, the short/extended rest reset toggles do nothing if no max is set.