### PR TITLE
Basic Sight Dropdown

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -156,6 +156,7 @@ export default defineConfig([
 			}],
 
 			"@html-eslint/indent": ["error", 2],
+			"@html-eslint/no-multiple-h1": "off",
 		},
 	},
 	{

--- a/lang/en-au.json
+++ b/lang/en-au.json
@@ -154,6 +154,7 @@
 "DND4E.available": "available",
 "DND4E.Background": "Background",
 "DND4E.Base": "Base",
+"DND4E.BasicSightMode": "Basic Sight Mode",
 "DND4E.Beast": "Beast",
 "DND4E.BeastForm": "Beast Form",
 "DND4E.Biography": "Biography",

--- a/lang/en.json
+++ b/lang/en.json
@@ -154,6 +154,7 @@
 "DND4E.available": "available",
 "DND4E.Background": "Background",
 "DND4E.Base": "Base",
+"DND4E.BasicSightMode": "Basic Sight Mode",
 "DND4E.Beast": "Beast",
 "DND4E.BeastForm": "Beast Form",
 "DND4E.Biography": "Biography",

--- a/module/applications/apps/trait-selector-sense.mjs
+++ b/module/applications/apps/trait-selector-sense.mjs
@@ -93,7 +93,7 @@ export default class TraitSelectorValues extends foundry.applications.api.Handle
 			context.custom = "";
 		}
 		context.buttons = [{ type: "submit", icon: "far fa-save", label: "DND4E.Save" }];
-		context.heading = this.options.window.title;
+		context.heading = _loc("DND4E.SpecialSenses");
 
 		// Return data
 		return context;

--- a/module/applications/apps/trait-selector-sense.mjs
+++ b/module/applications/apps/trait-selector-sense.mjs
@@ -64,6 +64,12 @@ export default class TraitSelectorValues extends foundry.applications.api.Handle
 		const attr = foundry.utils.getProperty(this.document, this.attribute) || {};
 		let values = Object.keys(attr).map((key) => [key, attr[key]]);
 
+		let dropdownTraits = foundry.utils.duplicate(this.options.dropdownTraits);
+		for (let [k, v] of Object.entries(dropdownTraits)) {
+			dropdownTraits[k].chosen = foundry.utils.getProperty(this.document, v.path);
+		}
+		context.dropdownTraits = dropdownTraits;
+
 		context.valuelessTraits = this.options.valuelessTraits;
 
 		// Populate choices
@@ -104,10 +110,13 @@ export default class TraitSelectorValues extends foundry.applications.api.Handle
 		// Obtain choices
 		for (let [k, v] of Object.entries(formData)) {
 			if (k === "custom") continue;
-			if (Object.keys(this.options.valuelessTraits).includes(k)) {
+			if (Object.keys(this.options.dropdownTraits).includes(k)) {
+				updateData[this.options.dropdownTraits[k].path] = v;
+			}
+			else if (Object.keys(this.options.valuelessTraits).includes(k)) {
 				updateData[this.options.valuelessTraits[k].path] = v;
 			} else {
-				updateData[`${this.attribute}.${k}`] = { value: v[0], range: v[0] ? v[1] : "" };
+				updateData[`${this.attribute}.${k}`] = { value: v[0], range: v[0] ? v[1] : null };
 			}
 		}
 

--- a/module/applications/sheets/actor-sheet.mjs
+++ b/module/applications/sheets/actor-sheet.mjs
@@ -479,6 +479,9 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 				obj[l[0]] = (l[1].range && (l[1].range > 0)) ? `${choices[l[0]].label} ${l[1].range} sq` : choices[l[0]].label;
 				return obj;
 			}, {});
+			// Add basic sight mode
+			const basicSight = this.actor.system.senses.basic;
+			if (CONFIG.DND4E.senses[basicSight]) trait.selected[basicSight] = CONFIG.DND4E.senses[basicSight].label;
 			// Add all-around vision
 			if (senses.allAround) {
 				trait.selected["aa"] = _loc(this.actor.system.schema.getField("senses.allAround").label);
@@ -1784,6 +1787,20 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 		if (!this.actor.isOwner) return;
 		event.preventDefault();
 		const label = target.getAttribute("data-app-title") || "Label error";
+		const dropdownTraits = {
+			basic: {
+				label: _loc("DND4E.BasicSightMode"),
+				path: "system.senses.basic",
+				choices: {
+					nv: CONFIG.DND4E.senses.nv,
+					lv: CONFIG.DND4E.senses.lv,
+					dv: CONFIG.DND4E.senses.dv,
+					blind: {
+						label: _loc("DND4E.VisionBlind"),
+					},
+				},
+			},
+		};
 		const valuelessTraits = {
 			allAround: {
 				label: _loc(this.actor.system.schema.getField("senses.allAround").label),
@@ -1791,15 +1808,12 @@ export default class ActorSheet4e extends foundry.applications.api.HandlebarsApp
 				chosen: this.actor.system.senses.allAround,
 				value: this.actor.system.senses.allAround,
 			},
-			blind: {
-				label: _loc(this.actor.system.schema.getField("senses.blind").label),
-				path: "system.senses.blind",
-				chosen: this.actor.system.senses.blind,
-				value: this.actor.system.senses.blind,
-			},
 		};
-		const choices = CONFIG.DND4E["senses"];
-		const options = { name: target.dataset.target, window: { title: label }, valuelessTraits, choices, custom: "system.senses.custom" };
+		const choices = foundry.utils.duplicate(CONFIG.DND4E.senses);
+		delete choices.nv;
+		delete choices.lv;
+		delete choices.dv;
+		const options = { name: target.dataset.target, window: { title: label }, dropdownTraits, valuelessTraits, choices, custom: "system.senses.custom" };
 		new apps.TraitSelectorValues({ document: this.actor, ...options }).render(true);
 	}
 

--- a/module/applications/sheets/token/token-config.mjs
+++ b/module/applications/sheets/token/token-config.mjs
@@ -45,21 +45,33 @@ export class TokenConfig4e extends foundry.applications.sheets.TokenConfig {
 		notice.innerHTML = `<i class="fa-solid fa-circle-info"></i> ${
 			_loc("SETTINGS.4eSenseVisionNotice", { senses: link })}`;
 		notice.querySelector("[data-action=editSenses]")?.addEventListener("click", () => {
+			const dropdownTraits = {
+				basic: {
+					label: _loc("DND4E.BasicSightMode"),
+					path: "system.senses.basic",
+					choices: {
+						nv: CONFIG.DND4E.senses.nv,
+						lv: CONFIG.DND4E.senses.lv,
+						dv: CONFIG.DND4E.senses.dv,
+						blind: {
+							label: _loc("DND4E.VisionBlind"),
+						},
+					},
+				},
+			};
 			const valuelessTraits = {
 				allAround: {
-					label: _loc("DND4E.SpecialSensesAA"),
+					label: _loc(actor.system.schema.getField("senses.allAround").label),
 					path: "system.senses.allAround",
 					chosen: this.actor.system.senses.allAround,
 					value: this.actor.system.senses.allAround,
 				},
-				blind: {
-					label: _loc("DND4E.VisionBlind"),
-					path: "system.senses.blind",
-					chosen: this.actor.system.senses.blind,
-					value: this.actor.system.senses.blind,
-				},
 			};
-			const options = { name: "system.senses.special", window: { title: _loc("DND4E.SpecialSenses") }, valuelessTraits, choices: CONFIG.DND4E["senses"], custom: "system.senses.custom" };
+			const choices = foundry.utils.duplicate(CONFIG.DND4E.senses);
+			delete choices.nv;
+			delete choices.lv;
+			delete choices.dv;
+			const options = { name: "system.senses.special", window: { title: _loc("DND4E.SpecialSenses") }, dropdownTraits, valuelessTraits, choices, custom: "system.senses.custom" };
 			new TraitSelectorValues({ document: actor, ...options }).render(true, { force: true });
 		});
 		tab.prepend(notice);

--- a/module/data/actor/templates/senses.mjs
+++ b/module/data/actor/templates/senses.mjs
@@ -71,15 +71,15 @@ export default class SensesTemplate extends foundry.abstract.DataModel {
 			delete source.senses.special.custom;
 		}
 
-		if (source.senses?.special?.nv.value) {
+		if (source.senses?.special?.nv?.value) {
 			source.senses.basic = "nv";
 			delete source.senses.special.nv;
 		}
-		if (source.senses?.special?.lv.value) {
+		if (source.senses?.special?.lv?.value) {
 			source.senses.basic = "lv";
 			delete source.senses.special.lv;
 		}
-		if (source.senses?.special?.dv.value) {
+		if (source.senses?.special?.dv?.value) {
 			source.senses.basic = "dv";
 			delete source.senses.special.dv;
 		}

--- a/module/data/actor/templates/senses.mjs
+++ b/module/data/actor/templates/senses.mjs
@@ -4,7 +4,18 @@ import { default as MappingField } from "../../fields/mapping-field.mjs";
 export default class SensesTemplate extends foundry.abstract.DataModel {
 	/** Getter for sense data. */
 	static get common() {
+		const basicSight = {
+			nv: CONFIG.DND4E.senses.nv,
+			lv: CONFIG.DND4E.senses.lv,
+			dv: CONFIG.DND4E.senses.dv,
+			blind: { label: "DND4E.VisionBlind" },
+		};
+		const specialSenses = foundry.utils.duplicate(CONFIG.DND4E.senses);
+		delete specialSenses.nv;
+		delete specialSenses.lv;
+		delete specialSenses.dv;
 		return {
+			basic: new StringField({ required: true, initial: "nv", choices: basicSight }),
 			special: new MappingField(new SchemaField({
 				value: new BooleanField({ initial: false }),
 				range: new NumberField({ required: true, nullable: true, initial: null }),
@@ -14,7 +25,6 @@ export default class SensesTemplate extends foundry.abstract.DataModel {
 				label: "DND4E.SpecialSenses",
 			}),
 			allAround: new BooleanField({ initial: false, label: "DND4E.SpecialSensesAA" }),
-			blind: new BooleanField({ initial: false, label: "DND4E.VisionBlind" }),
 			custom: new StringField({ initial: "" }),
 			notes: new StringField({ initial: "" }),
 		};
@@ -59,6 +69,23 @@ export default class SensesTemplate extends foundry.abstract.DataModel {
 		if (source.senses?.special && ("custom" in source.senses.special)) {
 			source.senses.custom = source.senses.special.custom;
 			delete source.senses.special.custom;
+		}
+
+		if (source.senses?.special?.nv) {
+			source.senses.basic = "nv";
+			delete source.senses.special.nv;
+		}
+		if (source.senses?.special?.lv) {
+			source.senses.basic = "lv";
+			delete source.senses.special.lv;
+		}
+		if (source.senses?.special?.dv) {
+			source.senses.basic = "dv";
+			delete source.senses.special.dv;
+		}
+		if (source.senses?.blind) {
+			source.senses.basic = "blind";
+			delete source.senses.blind;
 		}
 	}
 }

--- a/module/data/actor/templates/senses.mjs
+++ b/module/data/actor/templates/senses.mjs
@@ -71,15 +71,15 @@ export default class SensesTemplate extends foundry.abstract.DataModel {
 			delete source.senses.special.custom;
 		}
 
-		if (source.senses?.special?.nv) {
+		if (source.senses?.special?.nv.value) {
 			source.senses.basic = "nv";
 			delete source.senses.special.nv;
 		}
-		if (source.senses?.special?.lv) {
+		if (source.senses?.special?.lv.value) {
 			source.senses.basic = "lv";
 			delete source.senses.special.lv;
 		}
-		if (source.senses?.special?.dv) {
+		if (source.senses?.special?.dv.value) {
 			source.senses.basic = "dv";
 			delete source.senses.special.dv;
 		}

--- a/module/data/migration.mjs
+++ b/module/data/migration.mjs
@@ -7,7 +7,7 @@ export const migrateWorld = async function(migrationVersion) {
 	migrationVersion = migrationVersion || game.settings.get("dnd4e", "systemMigrationVersion");
 	// Update these versions whenever we make data model changes that require immediately saving the changes to the DB.
 	const migrateActiveEffects = foundry.utils.isNewerVersion("0.8.9", migrationVersion);
-	const migrateActors = foundry.utils.isNewerVersion("0.9.1", migrationVersion);
+	const migrateActors = foundry.utils.isNewerVersion("0.9.3", migrationVersion);
 	const migrateItems = foundry.utils.isNewerVersion("0.8.9", migrationVersion);
 	ui.notifications.info(_loc("MIGRATION.4eBegin", { version }), { permanent: true });
 

--- a/module/documents/active-effect.mjs
+++ b/module/documents/active-effect.mjs
@@ -74,7 +74,7 @@ export default class ActiveEffect4e extends ActiveEffect {
 	/* --------------------------------------------- */
 
 	/** @inheritdoc */
-	async _preCreate(data, options, user) {    
+	async _preCreate(data, options, user) {
 		await super._preCreate(data, options, user);
 		const updates = {};
 
@@ -116,30 +116,29 @@ export default class ActiveEffect4e extends ActiveEffect {
 
 		if (Object.keys(updates).length) {
 			this.updateSource(updates);
-		}    
+		}
 	}
-  
+
 	async _onCreate(data, options, userId) {
 		await super._onCreate(data, options, userId);
-    // Manage mutually exclusive effects
-    if (game.settings.get("dnd4e", "dynamicAutomation") && game.user.id == userId) this.managePeers("create");
-  }
-  
-	/** @inheritdoc */
-  async _onUpdate(changed, options, userId) {
-    await super._onUpdate(changed, options, userId);
-    if (game.settings.get("dnd4e", "dynamicAutomation") && game.user.id == userId && Object.hasOwn(changed,"disabled")) {
-      this.managePeers(changed.disabled ? "disable" : "enable");
-    }
-  }
-  
-	/** @inheritdoc */
-  async _onDelete(options, userId) {
-    await super._onDelete(options, userId);
-    if (game.settings.get("dnd4e", "dynamicAutomation") && game.user.id == userId) await this.managePeers("delete");
+		// Manage mutually exclusive effects
+		if (game.settings.get("dnd4e", "dynamicAutomation") && (game.user.id == userId)) this.managePeers("create");
 	}
-  
-  
+
+	/** @inheritdoc */
+	async _onUpdate(changed, options, userId) {
+		await super._onUpdate(changed, options, userId);
+		if (game.settings.get("dnd4e", "dynamicAutomation") && (game.user.id == userId) && Object.hasOwn(changed, "disabled")) {
+			this.managePeers(changed.disabled ? "disable" : "enable");
+		}
+	}
+
+	/** @inheritdoc */
+	async _onDelete(options, userId) {
+		await super._onDelete(options, userId);
+		if (game.settings.get("dnd4e", "dynamicAutomation") && (game.user.id == userId)) await this.managePeers("delete");
+	}
+
 	/* --------------------------------------------- */
 
 	/** @inheritdoc */
@@ -330,7 +329,7 @@ export default class ActiveEffect4e extends ActiveEffect {
 
 		return { system: systemKeywords, custom: customKeywords, string: keywordString };
 	}
-  
+
 	/* --------------------------------------------- */
 
 	/**
@@ -338,40 +337,40 @@ export default class ActiveEffect4e extends ActiveEffect {
 	 * @param {string} action   The action (expected create/enable/disable/delete) being performed on the current effect
 	 */
 	async managePeers(action = null) {
-    //console.debug(`Managing mutually exclusive effects in mode ${action}`);
-    if (!game.settings.get("dnd4e", "dynamicAutomation") || !this?.actor || action == null) return;    
-    if (["enable","create"].includes(action)) this.unsetFlag("dnd4e", "status.suspendedBy");
-    
-    try{
-      if (["enable","create"].includes(action)) {
-        if(!this?.actor?.appliedEffects) return;
-        // New stances delete old stances
-        if (this.system.allKeywords.has("stance")) {
-          for (let effect of this.actor.appliedEffects) {
-            if (effect.system.allKeywords.has("stance") && effect.uuid !== this.uuid) effect.delete();
-          }
-        }
-        // New polymorph suppresses existing polymorphs
-        if (this.system.allKeywords.has("polymorph")) {
-          for (let effect of this.actor.appliedEffects) {
-            if (effect.system.allKeywords.has("polymorph") && effect.uuid !== this.uuid) effect.suspend(this.uuid);
-          }
-        }
-      } 
-      else if (["disable","delete"].includes(action)) {
-        if (!this?.actor?.allApplicableEffects()) return;
-        // Restore suspended polymorph, if any
-        if (this.system.allKeywords.has("polymorph") && (this.getFlag("dnd4e","status.suspendedBy") === undefined)) {
-          for (let effect of this.actor.allApplicableEffects()) {
-            if (effect.system.allKeywords.has("polymorph") && effect.uuid !== this.uuid && effect.getFlag("dnd4e","status.suspendedBy") === this.uuid){
-              effect.update({ disabled: false });
-            }
-          }
-        }
-      }
-    } catch(e) {
-      console.error(`There was an error during automatic effect management | mode: ${action} | details: ${e}`);
-    }
+		//console.debug(`Managing mutually exclusive effects in mode ${action}`);
+		if (!game.settings.get("dnd4e", "dynamicAutomation") || !this?.actor || (action == null)) return;
+		if (["enable", "create"].includes(action)) this.unsetFlag("dnd4e", "status.suspendedBy");
+
+		try {
+			if (["enable", "create"].includes(action)) {
+				if (!this?.actor?.appliedEffects) return;
+				// New stances delete old stances
+				if (this.system.allKeywords.has("stance")) {
+					for (let effect of this.actor.appliedEffects) {
+						if (effect.system.allKeywords.has("stance") && (effect.uuid !== this.uuid)) effect.delete();
+					}
+				}
+				// New polymorph suppresses existing polymorphs
+				if (this.system.allKeywords.has("polymorph")) {
+					for (let effect of this.actor.appliedEffects) {
+						if (effect.system.allKeywords.has("polymorph") && (effect.uuid !== this.uuid)) effect.suspend(this.uuid);
+					}
+				}
+			}
+			else if (["disable", "delete"].includes(action)) {
+				if (!this?.actor?.allApplicableEffects()) return;
+				// Restore suspended polymorph, if any
+				if (this.system.allKeywords.has("polymorph") && (this.getFlag("dnd4e", "status.suspendedBy") === undefined)) {
+					for (let effect of this.actor.allApplicableEffects()) {
+						if (effect.system.allKeywords.has("polymorph") && (effect.uuid !== this.uuid) && (effect.getFlag("dnd4e", "status.suspendedBy") === this.uuid)) {
+							effect.update({ disabled: false });
+						}
+					}
+				}
+			}
+		} catch(e) {
+			console.error(`There was an error during automatic effect management | mode: ${action} | details: ${e}`);
+		}
 	}
 
 	/* --------------------------------------------- */
@@ -381,14 +380,13 @@ export default class ActiveEffect4e extends ActiveEffect {
 	 * @param {string} source   ID of effect causing suspension
 	 */
 	async suspend(source) {
-    //console.debug('Suspending effect');
-    try{
-      this.update({'disabled': true, "flags.dnd4e.status.suspendedBy": source});
-    } catch(e) {
-      console.error(`Error while suspending effect: ${e}`);
-    }
+		//console.debug('Suspending effect');
+		try {
+			this.update({ disabled: true, "flags.dnd4e.status.suspendedBy": source });
+		} catch(e) {
+			console.error(`Error while suspending effect: ${e}`);
+		}
 	}
-
 
 	/* -------------------------------------------- */
 	/*  Data Migration                              */

--- a/module/documents/token.mjs
+++ b/module/documents/token.mjs
@@ -62,12 +62,12 @@ export default class TokenDocument4e extends TokenDocument {
 		let maxSightRange = -Infinity;
 		let sightVisionMode = null;
 
-		if (senses.blind) detectionModes["lightPerception"] = 0;
+		if (senses.basic === "blind") detectionModes["lightPerception"] = 0;
 
 		for (const [key, config] of Object.entries(CONFIG.DND4E.senses)) {
-			if (!senses.special[key]?.value) continue;
+			if (!(senses.special[key]?.value || (senses.basic === key))) continue;
 			let range;
-			if (senses.blind && ["nv", "lv", "dv"].includes(key)) {
+			if ((senses.basic === "blind") && ["nv", "lv", "dv"].includes(key)) {
 				range = 0;
 			} else {
 				range = config.range ?? senses.special[key]?.range ?? Infinity;

--- a/templates/actors/tabs/details.hbs
+++ b/templates/actors/tabs/details.hbs
@@ -155,10 +155,10 @@
 
   {{!-- Senses --}}
   <div class="traits senses">
-    <h4 class="group-header">{{ localize 'DND4E.SpecialSenses' }}</h4>
+    <h4 class="group-header">{{ localize 'DND4E.Senses' }}</h4>
     <div class="traits-row">
-      <a class="trait-selector-senses" data-action="traitSelectorSenses" data-options="senses" data-target="system.senses.special" data-app-title="{{ localize 'DND4E.SpecialSenses' }}">
-        <span class="subgroup-header label">{{ localize 'DND4E.SpecialSenses' }}</span>
+      <a class="trait-selector-senses" data-action="traitSelectorSenses" data-options="senses" data-target="system.senses.special" data-app-title="{{ localize 'DND4E.Senses' }}">
+        <span class="subgroup-header label">{{ localize 'DND4E.Senses' }}</span>
         <i class="fas fa-edit"></i>
       </a>
       <ul class="traits-list senses">

--- a/templates/apps/trait-selector-values.hbs
+++ b/templates/apps/trait-selector-values.hbs
@@ -1,4 +1,19 @@
 <div class="dialogue-content">
+  {{#if dropdownTraits}}
+  <div class="form-group vertical">
+    <ol class="trait-list">
+      {{#each dropdownTraits as |trait key|}}
+      <li>
+        <h1 class="form-title">{{trait.label}}</h1>
+        <select name="{{key}}">
+          {{selectOptions trait.choices selected=trait.chosen labelAttr="label"}}
+        </select>
+      </li>
+      {{/each}}
+    </ol>
+  </div>
+  {{/if}}
+
   <h1 class="form-title">{{heading}}</h1>
 
   {{#if valuelessTraits}}


### PR DESCRIPTION
Normal Vision, Low-Light Vision, Darkvision, and Blind are now combined into a single field and selected via dropdown in the senses config.

Since these four vision modes are mutually exclusive, in cases where an actor possesses more than one of them, one must take precedence over any others for migration purposes. Blind is the highest priority option, followed by darkvision, then low-light vision, and finally normal vision.